### PR TITLE
fix: schema sync — colunas existentes no banco + novos campos frontend

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1063,6 +1063,12 @@ model Contract {
   contractHtml      String?        @db.Text   // HTML do contrato gerado por IA
   guaranteeType     String?        // fiador | caucao | seguro
 
+  // Encargos inclusos no aluguel (dados migrados do Uniloc)
+  condoIncluded     Boolean        @default(false)
+  waterIncluded     Boolean        @default(false)
+  electricIncluded  Boolean        @default(false)
+  iptuIncluded      Boolean        @default(false)
+
   // Rescisão detalhada
   rescissionReason  String?        // motivo da rescisão
   rescissionFine    Decimal?       @db.Decimal(12, 2) // multa rescisória
@@ -1124,6 +1130,7 @@ model Rental {
   repassePaidAt   DateTime?                         // data em que o repasse foi pago ao proprietário
   status          RentalStatus @default(PENDING)
   createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @default(now()) @updatedAt
 
   @@index([companyId])
   @@index([contractId])
@@ -1284,6 +1291,7 @@ model Invoice {
   asaasStatus     String?       // PENDING | RECEIVED | CONFIRMED | OVERDUE | REFUNDED
   asaasBankSlipUrl String?      // URL do boleto gerado pelo Asaas
   asaasPixCode    String?       // Código PIX Copia e Cola
+  status          String?       @default("PENDING")  // PENDING | PAID | CANCELLED
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
 


### PR DESCRIPTION
Corrige db push que tentava dropar colunas existentes no banco (criadas pelo Manus):
- Contract: condoIncluded, waterIncluded, electricIncluded, iptuIncluded (982 registros)
- Invoice: status (19.434 registros)
- Rental: updatedAt (27.997 registros)

Também inclui: wizard contratos, dar baixa modal, portal boletos com breakdown.

https://claude.ai/code/session_013aaKHyvj5zeCRNxzx1g6SD