### PR TITLE
fix + feat: unblock web deploy + logo library backend + force-scrape bugs

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -25,9 +25,15 @@ COPY apps/web ./apps/web
 # Generate Prisma client (needed by some web imports)
 RUN pnpm --filter @agoraencontrei/database generate
 
-# Build Next.js (standalone output). tomas-knowledge is transpiled from
-# source via next.config.mjs `transpilePackages`, so no explicit dist build
-# is needed here.
+# Build the shared knowledge package first. Even though next.config.mjs
+# lists it in `transpilePackages`, Next's module resolver still uses the
+# package's `main` / `exports` (./dist/index.js) to locate it, so the
+# build fails with "Can't resolve '@agoraencontrei/tomas-knowledge'"
+# when dist/ is missing. Building it here is cheap (pure tsc) and keeps
+# the resolver happy.
+RUN pnpm --filter @agoraencontrei/tomas-knowledge build
+
+# Build Next.js (standalone output).
 RUN pnpm --filter @agoraencontrei/web build
 
 # ── Production stage (smaller image) ──────────────────────────────────────────

--- a/apps/api/src/routes/auctions/index.ts
+++ b/apps/api/src/routes/auctions/index.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { z } from 'zod'
+import { env } from '../../utils/env.js'
 import { calculateAcquisitionCosts, getStateCosts, validateDocument } from '../../utils/brazil-costs.js'
 import { CaixaScraper } from '../../services/scrapers/caixa-scraper.js'
 import { GenericLeiloeiroScraper, BANCOS_CONFIG } from '../../services/scrapers/generic-scraper.js'
@@ -477,7 +478,21 @@ export default async function auctionsRoutes(app: FastifyInstance) {
   })
 
   // ── POST /auctions/force-scrape — Forçar varredura (admin) ────────────────
-  app.post('/force-scrape', async (_req: FastifyRequest, reply: FastifyReply) => {
+  //
+  // Accepts an empty JSON body (`{}`) — the route used to fail with
+  // "Body cannot be empty when content-type is set to 'application/json'"
+  // because the frontend sent the content-type header without a payload
+  // and Fastify's AJV in strict mode refused to parse. The schema below
+  // declares the body as an empty object so an empty `{}` succeeds.
+  app.post('/force-scrape', {
+    schema: {
+      body: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {},
+      },
+    },
+  }, async (_req: FastifyRequest, reply: FastifyReply) => {
     try {
       // Re-activate bank auctions that were incorrectly closed by aggressive cleanup
       const reactivated = await app.prisma.auction.updateMany({
@@ -489,40 +504,137 @@ export default async function auctionsRoutes(app: FastifyInstance) {
         data: { status: 'OPEN' },
       })
       if (reactivated.count > 0) {
-        console.log(`[force-scrape] Reativados ${reactivated.count} leilões bancários que estavam CLOSED`)
+        app.log.info(`[force-scrape] Reativados ${reactivated.count} leilões bancários que estavam CLOSED`)
       }
 
-      // Run Caixa scraper in background (don't block the response)
+      // Run scrapers in the background so the HTTP request returns fast.
+      // The response also tells the operator which sources are wired up
+      // so "nada chegou" stops looking like a silent failure.
       const prisma = app.prisma
+      const sourcesQueued: string[] = []
+      const sourcesSkipped: Array<{ source: string; reason: string }> = []
+
       setImmediate(async () => {
+        const summary: Record<string, { found: number; created: number; updated?: number; error?: string }> = {}
+
+        // 1. Caixa (CSV official — most reliable)
         try {
-          console.log('[force-scrape] Iniciando varredura forçada...')
+          app.log.info('[force-scrape] Caixa scraper starting')
           const caixa = new CaixaScraper(prisma)
           const result = await caixa.run()
-          console.log(`[force-scrape] Caixa: ${result.found} encontrados, ${result.created} novos, ${result.updated} atualizados`)
-
-          // Also run bank scrapers
-          for (const config of BANCOS_CONFIG) {
-            try {
-              const scraper = new GenericLeiloeiroScraper(prisma, config)
-              const r = await scraper.run()
-              console.log(`[force-scrape] ${config.name}: ${r.found} encontrados, ${r.created} novos`)
-            } catch (e: any) {
-              console.error(`[force-scrape] ${config.name} erro:`, e.message)
-            }
-            await new Promise(resolve => setTimeout(resolve, 2000))
-          }
-          console.log('[force-scrape] Varredura completa!')
+          summary.CAIXA = { found: result.found, created: result.created, updated: (result as any).updated ?? 0 }
+          app.log.info(`[force-scrape] Caixa: ${result.found} encontrados, ${result.created} novos`)
         } catch (e: any) {
-          console.error('[force-scrape] Erro:', e.message)
+          summary.CAIXA = { found: 0, created: 0, error: e.message }
+          app.log.error({ err: e }, '[force-scrape] Caixa failed')
         }
+
+        // 2. Apify-backed scrapers (Santander, Caixa-enriched). These
+        //    actually work against SPAs where the raw HTML fetch does not —
+        //    previously the force-scrape only called GenericLeiloeiroScraper
+        //    which cannot render JS, so bancos returned 0 every time.
+        if ((env as any).APIFY_API_TOKEN) {
+          try {
+            const { fetchSantanderApifyLastRun } = await import('../../services/apify-santander.service.js')
+            const santanderItems = await fetchSantanderApifyLastRun()
+            let saved = 0
+            for (const item of santanderItems) {
+              try {
+                await (prisma as any).auction.upsert({
+                  where: { slug: `santander-${(item as any).externalId ?? (item as any).id ?? saved}` },
+                  update: { updatedAt: new Date() },
+                  create: {
+                    slug: `santander-${(item as any).externalId ?? (item as any).id ?? `apify-${Date.now()}-${saved}`}`,
+                    source: 'SANTANDER',
+                    title: (item as any).title || 'Imóvel Santander',
+                    propertyType: (item as any).propertyType || 'HOUSE',
+                    status: 'OPEN',
+                    modality: 'ONLINE',
+                    city: (item as any).city || null,
+                    state: (item as any).state || null,
+                    neighborhood: (item as any).neighborhood || null,
+                    minimumBid: (item as any).price || null,
+                    appraisalValue: (item as any).appraisalValue || null,
+                    discountPercent: (item as any).discount || null,
+                    bankName: 'Santander',
+                    auctioneerName: 'Santander Imóveis',
+                    sourceUrl: (item as any).url || null,
+                  },
+                })
+                saved++
+              } catch {
+                /* one bad row shouldn't stop the rest */
+              }
+            }
+            summary.SANTANDER = { found: santanderItems.length, created: saved }
+            app.log.info(`[force-scrape] Santander (Apify): ${santanderItems.length} encontrados, ${saved} novos`)
+          } catch (e: any) {
+            summary.SANTANDER = { found: 0, created: 0, error: e.message }
+            app.log.error({ err: e }, '[force-scrape] Santander Apify failed')
+          }
+        } else {
+          summary.SANTANDER = { found: 0, created: 0, error: 'APIFY_API_TOKEN not configured' }
+          app.log.warn('[force-scrape] Santander skipped — APIFY_API_TOKEN not configured')
+        }
+
+        // 3. Generic HTML scrapers for the banks that don't have an Apify
+        //    actor. These only work when the target site returns server-
+        //    rendered listings — if a bank turns into a SPA the scraper
+        //    records 0 and logs the reason, but never throws past this
+        //    point so one bad bank doesn't stop the rest.
+        for (const config of BANCOS_CONFIG) {
+          // Skip Santander here when Apify already handled it.
+          if (config.source === 'SANTANDER' && summary.SANTANDER && summary.SANTANDER.found > 0) continue
+          try {
+            const scraper = new GenericLeiloeiroScraper(prisma, config)
+            const r = await scraper.run()
+            summary[config.source] = { found: r.found, created: r.created }
+            app.log.info(`[force-scrape] ${config.name}: ${r.found} encontrados, ${r.created} novos`)
+          } catch (e: any) {
+            summary[config.source] = { found: 0, created: 0, error: e.message }
+            app.log.error({ err: e, source: config.source }, '[force-scrape] generic scraper failed')
+          }
+          await new Promise(resolve => setTimeout(resolve, 2000))
+        }
+
+        // Persist summary on the scraper_runs table so /stats and admins
+        // can see what actually happened on the last force-scrape.
+        try {
+          await (prisma as any).scraperRun.create({
+            data: {
+              source: 'FORCE_SCRAPE',
+              status: 'SUCCESS',
+              finishedAt: new Date(),
+              itemsFound: Object.values(summary).reduce((a, b) => a + (b.found || 0), 0),
+              itemsCreated: Object.values(summary).reduce((a, b) => a + (b.created || 0), 0),
+              metadata: summary as any,
+            },
+          })
+        } catch { /* scraper_runs table is optional in some envs */ }
+
+        app.log.info({ summary }, '[force-scrape] Varredura completa')
       })
+
+      // Figure out which sources were actually queued so the response is
+      // honest about scope: the UI no longer has to guess whether a bank
+      // is wired up.
+      sourcesQueued.push('CAIXA')
+      if ((env as any).APIFY_API_TOKEN) sourcesQueued.push('SANTANDER')
+      else sourcesSkipped.push({ source: 'SANTANDER', reason: 'APIFY_API_TOKEN not configured' })
+      for (const config of BANCOS_CONFIG) {
+        if (config.source === 'SANTANDER' && sourcesQueued.includes('SANTANDER')) continue
+        sourcesQueued.push(config.source)
+      }
 
       return reply.send({
-        message: 'Varredura iniciada! Os robôs estão buscando novos imóveis. Atualize em 30-60 segundos para ver resultados.',
+        message: `Varredura iniciada — ${sourcesQueued.length} fonte(s) em execução. Atualize em 30-60 segundos para ver os resultados.`,
+        reactivated: reactivated.count,
+        sourcesQueued,
+        sourcesSkipped,
       })
     } catch (err: any) {
-      return reply.status(500).send({ error: err.message })
+      app.log.error({ err }, '[force-scrape] failed to enqueue')
+      return reply.status(500).send({ error: 'FORCE_SCRAPE_FAILED', message: err.message })
     }
   })
 

--- a/apps/api/src/routes/photo-editor/index.ts
+++ b/apps/api/src/routes/photo-editor/index.ts
@@ -8,9 +8,19 @@ import fetch from 'node-fetch'
 import FormData from 'form-data'
 
 const IMAGE_PROCESSOR_URL = process.env.IMAGE_PROCESSOR_URL ?? 'http://localhost:3200'
+const IMAGE_PROCESSOR_TOKEN = process.env.IMAGE_PROCESSOR_TOKEN
 
 async function proxyToProcessor(path: string, options: RequestInit = {}) {
-  const res = await fetch(`${IMAGE_PROCESSOR_URL}${path}`, options as any)
+  // Injects the shared-secret header automatically so every call from this
+  // route goes through the microservice's `verify_token` dependency. In
+  // production the processor is fail-closed, so without this the requests
+  // would come back as 401.
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
+  }
+  if (IMAGE_PROCESSOR_TOKEN) headers['x-image-processor-token'] = IMAGE_PROCESSOR_TOKEN
+
+  const res = await fetch(`${IMAGE_PROCESSOR_URL}${path}`, { ...options, headers } as any)
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`Image processor error ${res.status}: ${text}`)
@@ -31,14 +41,23 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
     }
   })
 
+  // Shared schema — preview/process inherit the same logo controls so the
+  // UI can pass logo_id + size + opacity consistently from everywhere.
+  const logoControls = {
+    apply_logo: z.boolean().default(true),
+    logo_id: z.string().optional(),                                    // undefined => default logo
+    logo_position: z.enum(['bottom-right', 'bottom-left', 'top-right', 'top-left', 'center']).default('bottom-right'),
+    logo_size_percent: z.number().min(2).max(25).default(8),
+    logo_opacity: z.number().min(0).max(1).default(0.85),
+  }
+
   // POST /api/v1/photo-editor/preview — gera preview com filtro (por URL)
   app.post('/preview', async (req, reply) => {
     try {
       const body = z.object({
         image_url: z.string(), // accepts URLs, data URLs, relative paths
         filter_id: z.string(),
-        apply_logo: z.boolean().default(true),
-        logo_position: z.enum(['bottom-right', 'bottom-left', 'top-right', 'top-left', 'center']).default('bottom-right'),
+        ...logoControls,
         preview_width: z.number().int().min(400).max(1600).default(800),
       }).parse(req.body)
       const data = await proxyToProcessor('/preview', {
@@ -61,7 +80,10 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
       const body = req.body as any
       const filterId = body?.filter_id ?? 'efeito-1'
       const applyLogo = body?.apply_logo !== 'false'
+      const logoId = typeof body?.logo_id === 'string' ? body.logo_id : ''
       const logoPosition = body?.logo_position ?? 'bottom-right'
+      const logoSizePercent = parseFloat(body?.logo_size_percent ?? '8')
+      const logoOpacity = parseFloat(body?.logo_opacity ?? '0.85')
       const previewWidth = parseInt(body?.preview_width ?? '800')
 
       const chunks: Buffer[] = []
@@ -73,7 +95,10 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
       form.append('file', buffer, { filename: data.filename, contentType: data.mimetype })
       form.append('filter_id', filterId)
       form.append('apply_logo', applyLogo ? 'true' : 'false')
+      if (logoId) form.append('logo_id', logoId)
       form.append('logo_position', logoPosition)
+      form.append('logo_size_percent', String(logoSizePercent))
+      form.append('logo_opacity', String(logoOpacity))
       form.append('preview_width', String(previewWidth))
 
       const res = await fetch(`${IMAGE_PROCESSOR_URL}/preview/upload`, {
@@ -100,8 +125,7 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
       const body = z.object({
         image_url: z.string(), // accepts URLs, data URLs, relative paths
         filter_id: z.string(),
-        apply_logo: z.boolean().default(true),
-        logo_position: z.enum(['bottom-right', 'bottom-left', 'top-right', 'top-left', 'center']).default('bottom-right'),
+        ...logoControls,
         output_quality: z.number().int().min(60).max(100).default(92),
       }).parse(req.body)
       const data = await proxyToProcessor('/process', {
@@ -121,8 +145,7 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
       const body = z.object({
         image_urls: z.array(z.string()).min(1).max(50), // accepts URLs, data URLs, relative paths
         filter_id: z.string(),
-        apply_logo: z.boolean().default(true),
-        logo_position: z.enum(['bottom-right', 'bottom-left', 'top-right', 'top-left', 'center']).default('bottom-right'),
+        ...logoControls,
         output_quality: z.number().int().min(60).max(100).default(92),
       }).parse(req.body)
       const data = await proxyToProcessor('/process/batch', {
@@ -130,6 +153,112 @@ export default async function photoEditorRoutes(app: FastifyInstance) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       })
+      return reply.send(data)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  // ── Logo library proxy ─────────────────────────────────────────────────
+  // GET    /api/v1/photo-editor/logos                list
+  // POST   /api/v1/photo-editor/logos                upload (multipart: file, name?)
+  // GET    /api/v1/photo-editor/logos/:id            metadata
+  // GET    /api/v1/photo-editor/logos/:id/file       raw PNG bytes (thumbnail src)
+  // PATCH  /api/v1/photo-editor/logos/:id            rename / set default
+  // DELETE /api/v1/photo-editor/logos/:id            remove
+  const processorToken = process.env.IMAGE_PROCESSOR_TOKEN
+  const withToken = (): Record<string, string> => (
+    processorToken ? { 'x-image-processor-token': processorToken } : {}
+  )
+
+  app.get('/logos', async (_req, reply) => {
+    try {
+      const data = await proxyToProcessor('/logos')
+      return reply.send(data)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  app.post('/logos', async (req, reply) => {
+    try {
+      const data = await req.file()
+      if (!data) return reply.status(400).send({ error: 'NO_FILE' })
+
+      // Name arrives as a sibling form field; defensive default.
+      const body = req.body as any
+      const name = typeof body?.name === 'string' ? body.name : ''
+
+      const chunks: Buffer[] = []
+      for await (const chunk of data.file) chunks.push(chunk)
+      const buffer = Buffer.concat(chunks)
+
+      const form = new FormData()
+      form.append('file', buffer, { filename: data.filename, contentType: data.mimetype })
+      if (name) form.append('name', name)
+
+      const res = await fetch(`${IMAGE_PROCESSOR_URL}/logos`, {
+        method: 'POST',
+        body: form as any,
+        headers: { ...form.getHeaders(), ...withToken() },
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        return reply.status(res.status).send({ error: 'IMAGE_PROCESSOR_ERROR', detail: text })
+      }
+      const result = await res.json()
+      return reply.send(result)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  app.get('/logos/:id', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    try {
+      const data = await proxyToProcessor(`/logos/${encodeURIComponent(id)}`)
+      return reply.send(data)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  app.get('/logos/:id/file', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    try {
+      const res = await fetch(`${IMAGE_PROCESSOR_URL}/logos/${encodeURIComponent(id)}/file`, {
+        headers: { ...withToken() },
+      })
+      if (!res.ok) return reply.status(res.status).send({ error: 'LOGO_NOT_FOUND' })
+      const buf = Buffer.from(await res.arrayBuffer())
+      return reply.type('image/png').send(buf)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  app.patch('/logos/:id', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    try {
+      const body = z.object({
+        name: z.string().min(1).max(120).optional(),
+        is_default: z.boolean().optional(),
+      }).parse(req.body ?? {})
+      const data = await proxyToProcessor(`/logos/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      return reply.send(data)
+    } catch (e: any) {
+      return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })
+    }
+  })
+
+  app.delete('/logos/:id', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    try {
+      const data = await proxyToProcessor(`/logos/${encodeURIComponent(id)}`, { method: 'DELETE' })
       return reply.send(data)
     } catch (e: any) {
       return reply.status(503).send({ error: 'IMAGE_PROCESSOR_UNAVAILABLE', detail: e.message })

--- a/apps/image-processor/filters.py
+++ b/apps/image-processor/filters.py
@@ -675,45 +675,58 @@ def apply_filter(img: Image.Image, filter_id: str, custom_params: dict = None) -
 
 # ── Marca d'água (Logo) ───────────────────────────────────────────────────────
 
-def apply_watermark(img: Image.Image, logo_path: str, position: str = 'bottom-right', opacity: float = 0.85) -> Image.Image:
+def apply_watermark(
+    img: Image.Image,
+    logo_path: str,
+    position: str = 'bottom-right',
+    opacity: float = 0.85,
+    size_percent: float = 8.0,
+    margin_percent: float = 2.0,
+) -> Image.Image:
     """
-    Aplica logo como marca d'água na foto do imóvel.
-    
-    O logo é redimensionado para ~6% da menor dimensão da foto (nunca muito grande/pequeno).
-    Posição padrão: canto inferior direito com margem.
+    Aplica logo como marca d'agua na foto do imovel.
+
+    Parametros configuraveis (controlados pelo caller, nao mais hardcoded):
+      - position: bottom-right | bottom-left | top-right | top-left | center
+      - opacity:  0.0-1.0 (default 0.85)
+      - size_percent:   largura alvo do logo como % da menor dimensao
+                         da foto. Default 8.0 (= 8%). Range seguro 2-25.
+      - margin_percent: margem ate a borda em % da menor dimensao.
+                         Default 2.0. Range seguro 0.5-10.
     """
     if not os.path.exists(logo_path):
         return img
-    
+
     # Carregar logo
     logo = Image.open(logo_path).convert('RGBA')
-    
-    # Calcular tamanho ideal do logo
-    # Regra: logo ocupa ~8% da menor dimensão da foto (padrão profissional imobiliário)
+
+    # Clamp parametros para evitar extremos absurdos
+    size_percent = max(2.0, min(25.0, float(size_percent)))
+    margin_percent = max(0.5, min(10.0, float(margin_percent)))
+    opacity = max(0.0, min(1.0, float(opacity)))
+
     img_w, img_h = img.size
     min_dim = min(img_w, img_h)
-    target_size = int(min_dim * 0.08)  # 8% da menor dimensão
+    target_size = int(min_dim * (size_percent / 100.0))
+    # Floor minimo absoluto para logos muito pequenos ficarem visiveis
+    target_size = max(20, target_size)
 
-    # Limitar: mínimo 50px, máximo 160px (proporcional mas nunca excessivo)
-    target_size = max(50, min(160, target_size))
-    
-    # Redimensionar logo mantendo proporção
+    # Redimensionar logo mantendo proporcao
     logo_w, logo_h = logo.size
     ratio = min(target_size / logo_w, target_size / logo_h)
-    new_w = int(logo_w * ratio)
-    new_h = int(logo_h * ratio)
+    new_w = max(1, int(logo_w * ratio))
+    new_h = max(1, int(logo_h * ratio))
     logo = logo.resize((new_w, new_h), Image.LANCZOS)
-    
+
     # Aplicar opacidade
     if opacity < 1.0:
         logo_arr = np.array(logo).astype(np.float32)
         logo_arr[:, :, 3] = logo_arr[:, :, 3] * opacity
         logo = Image.fromarray(logo_arr.astype(np.uint8))
-    
-    # Calcular posição
-    margin = int(min_dim * 0.02)  # 2% de margem
-    margin = max(10, min(30, margin))
-    
+
+    # Margem configuravel
+    margin = max(4, int(min_dim * (margin_percent / 100.0)))
+
     positions = {
         'bottom-right': (img_w - new_w - margin, img_h - new_h - margin),
         'bottom-left':  (margin, img_h - new_h - margin),
@@ -722,37 +735,41 @@ def apply_watermark(img: Image.Image, logo_path: str, position: str = 'bottom-ri
         'center':       ((img_w - new_w) // 2, (img_h - new_h) // 2),
     }
     pos = positions.get(position, positions['bottom-right'])
-    
+
     # Compor imagem
     result = img.convert('RGBA')
     result.paste(logo, pos, logo)
     return result.convert('RGB')
 
 
-# ── Funções de preview e processamento ───────────────────────────────────────
+# ── Funcoes de preview e processamento ───────────────────────────────────────
 
 def generate_preview(image_bytes: bytes, filter_id: str, custom_params: dict = None,
                      logo_path: str = None, logo_position: str = 'bottom-right',
+                     logo_opacity: float = 0.85, logo_size_percent: float = 8.0,
                      preview_width: int = 800) -> bytes:
     """
     Gera um preview da imagem com o filtro aplicado.
     Retorna bytes JPEG do resultado.
     """
     img = Image.open(io.BytesIO(image_bytes)).convert('RGB')
-    
-    # Redimensionar para preview (mais rápido)
+
+    # Redimensionar para preview (mais rapido)
     w, h = img.size
     if w > preview_width:
         ratio = preview_width / w
         img = img.resize((preview_width, int(h * ratio)), Image.LANCZOS)
-    
+
     # Aplicar filtro
     img = apply_filter(img, filter_id, custom_params)
-    
+
     # Aplicar logo se fornecido
     if logo_path:
-        img = apply_watermark(img, logo_path, logo_position)
-    
+        img = apply_watermark(
+            img, logo_path, logo_position,
+            opacity=logo_opacity, size_percent=logo_size_percent,
+        )
+
     # Salvar como JPEG
     output = io.BytesIO()
     img.save(output, format='JPEG', quality=85, optimize=True)
@@ -761,20 +778,24 @@ def generate_preview(image_bytes: bytes, filter_id: str, custom_params: dict = N
 
 def process_image(image_bytes: bytes, filter_id: str, custom_params: dict = None,
                   logo_path: str = None, logo_position: str = 'bottom-right',
+                  logo_opacity: float = 0.85, logo_size_percent: float = 8.0,
                   output_quality: int = 92) -> bytes:
     """
     Processa uma imagem em qualidade completa com o filtro e logo.
     Retorna bytes JPEG do resultado.
     """
     img = Image.open(io.BytesIO(image_bytes)).convert('RGB')
-    
+
     # Aplicar filtro
     img = apply_filter(img, filter_id, custom_params)
-    
+
     # Aplicar logo se fornecido
     if logo_path:
-        img = apply_watermark(img, logo_path, logo_position)
-    
+        img = apply_watermark(
+            img, logo_path, logo_position,
+            opacity=logo_opacity, size_percent=logo_size_percent,
+        )
+
     # Salvar como JPEG de alta qualidade
     output = io.BytesIO()
     img.save(output, format='JPEG', quality=output_quality, optimize=True)

--- a/apps/image-processor/logos.py
+++ b/apps/image-processor/logos.py
@@ -1,0 +1,212 @@
+"""
+Logo library — storage e manipulacao de multiplos logos.
+
+Cada logo tem um id (uuid) + nome amigavel + o arquivo binario (normalizado
+para PNG transparente) + metadados em JSON.
+
+Formatos aceitos no upload (qualquer coisa que o Pillow abrir + PDF):
+  - PNG, JPG/JPEG, WEBP, AVIF, BMP, GIF, TIFF
+  - PDF (primeira pagina, convertida via PyMuPDF quando disponivel)
+
+O logo e sempre armazenado internamente como `logo.png` (RGBA). Isso:
+  * da suporte a transparencia
+  * evita problemas de formato ao aplicar watermark
+  * permite converter formatos na entrada sem tocar no filters.py
+"""
+from __future__ import annotations
+import io
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from PIL import Image
+
+
+LOGOS_DIR = Path(__file__).parent / "logos_store"
+LOGOS_DIR.mkdir(exist_ok=True)
+INDEX_PATH = LOGOS_DIR / "index.json"
+
+
+# ── Index helpers ────────────────────────────────────────────────────────
+
+def _load_index() -> Dict[str, dict]:
+    if not INDEX_PATH.exists():
+        return {}
+    try:
+        return json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_index(idx: Dict[str, dict]) -> None:
+    INDEX_PATH.write_text(json.dumps(idx, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+def list_logos() -> List[dict]:
+    """Returns the list of all registered logos, newest first."""
+    idx = _load_index()
+    logos = list(idx.values())
+    logos.sort(key=lambda l: l.get("created_at", ""), reverse=True)
+    return logos
+
+
+def get_logo(logo_id: str) -> Optional[dict]:
+    """Returns a single logo record, or None if not found."""
+    return _load_index().get(logo_id)
+
+
+def get_logo_path(logo_id: str) -> Optional[str]:
+    """Returns the filesystem path to the PNG file of the given logo."""
+    rec = get_logo(logo_id)
+    if not rec:
+        return None
+    path = LOGOS_DIR / rec["filename"]
+    return str(path) if path.exists() else None
+
+
+def get_default_logo() -> Optional[dict]:
+    """Returns the logo marked as default, or the newest if none is marked,
+    or None if the store is empty. Kept for backwards compatibility with
+    callers that expect a single implicit logo."""
+    idx = _load_index()
+    if not idx:
+        return None
+    for rec in idx.values():
+        if rec.get("is_default"):
+            return rec
+    logos = list(idx.values())
+    logos.sort(key=lambda l: l.get("created_at", ""), reverse=True)
+    return logos[0] if logos else None
+
+
+def save_logo(name: str, image_bytes: bytes, original_mime: str) -> dict:
+    """
+    Persists a new logo. Converts the input to PNG-RGBA so the watermark
+    pipeline stays uniform regardless of the uploaded format.
+
+    Raises ValueError when the bytes cannot be interpreted as an image.
+    """
+    png_bytes = _normalize_to_png(image_bytes, original_mime)
+
+    logo_id = uuid.uuid4().hex
+    filename = f"{logo_id}.png"
+    (LOGOS_DIR / filename).write_bytes(png_bytes)
+
+    # Record the image dimensions so the UI can pick a sensible default size.
+    with Image.open(io.BytesIO(png_bytes)) as probe:
+        width, height = probe.size
+
+    idx = _load_index()
+    is_first = len(idx) == 0
+    record = {
+        "id": logo_id,
+        "name": (name or "Logo sem nome").strip()[:120] or "Logo sem nome",
+        "filename": filename,
+        "mime": "image/png",
+        "original_mime": original_mime,
+        "width": width,
+        "height": height,
+        "bytes": len(png_bytes),
+        "is_default": is_first,  # first one becomes default automatically
+        "created_at": datetime.utcnow().isoformat() + "Z",
+    }
+    idx[logo_id] = record
+    _save_index(idx)
+    return record
+
+
+def delete_logo(logo_id: str) -> bool:
+    """Removes the logo's file and its index entry. Returns True when
+    something was actually removed."""
+    idx = _load_index()
+    rec = idx.pop(logo_id, None)
+    if rec is None:
+        return False
+    file_path = LOGOS_DIR / rec["filename"]
+    try:
+        file_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    # If we just deleted the default, promote the most recent one.
+    if rec.get("is_default") and idx:
+        newest_id = max(idx.keys(), key=lambda k: idx[k].get("created_at", ""))
+        idx[newest_id]["is_default"] = True
+    _save_index(idx)
+    return True
+
+
+def set_default_logo(logo_id: str) -> Optional[dict]:
+    """Marks `logo_id` as the default, clearing the flag on every other
+    record. Returns the new default record or None when the id is unknown."""
+    idx = _load_index()
+    if logo_id not in idx:
+        return None
+    for k, rec in idx.items():
+        rec["is_default"] = (k == logo_id)
+    _save_index(idx)
+    return idx[logo_id]
+
+
+def rename_logo(logo_id: str, new_name: str) -> Optional[dict]:
+    """Updates the display name of a logo. Returns the updated record or
+    None when the id is unknown."""
+    idx = _load_index()
+    if logo_id not in idx:
+        return None
+    idx[logo_id]["name"] = (new_name or "").strip()[:120] or idx[logo_id]["name"]
+    _save_index(idx)
+    return idx[logo_id]
+
+
+# ── Format normalization ────────────────────────────────────────────────
+
+def _normalize_to_png(image_bytes: bytes, original_mime: str) -> bytes:
+    """
+    Converts an arbitrary uploaded file into PNG bytes preserving alpha.
+
+    PDF: extracts the first page at 300 DPI via PyMuPDF when installed.
+         Without PyMuPDF, raises a clear error so the API layer can surface
+         a useful message instead of a 500.
+    """
+    mime = (original_mime or "").lower()
+
+    if mime == "application/pdf" or image_bytes[:4] == b"%PDF":
+        return _pdf_first_page_to_png(image_bytes)
+
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            img = img.convert("RGBA")
+            out = io.BytesIO()
+            img.save(out, format="PNG", optimize=True)
+            return out.getvalue()
+    except Exception as exc:
+        raise ValueError(f"Arquivo nao reconhecido como imagem: {exc}")
+
+
+def _pdf_first_page_to_png(pdf_bytes: bytes) -> bytes:
+    """Renders the first page of the PDF into a transparent PNG. Uses
+    PyMuPDF (fitz) which ships as a pre-built wheel and doesn't require
+    poppler on the system."""
+    try:
+        import fitz  # type: ignore  # PyMuPDF
+    except ImportError:
+        raise ValueError(
+            "Upload de PDF requer o pacote PyMuPDF. "
+            "Instale com `pip install PyMuPDF` ou adicione no requirements.txt."
+        )
+
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    try:
+        if doc.page_count == 0:
+            raise ValueError("PDF vazio")
+        page = doc.load_page(0)
+        # 300 DPI — Logo-quality without being massive.
+        matrix = fitz.Matrix(300 / 72, 300 / 72)
+        pix = page.get_pixmap(matrix=matrix, alpha=True)
+        return pix.tobytes("png")
+    finally:
+        doc.close()

--- a/apps/image-processor/main.py
+++ b/apps/image-processor/main.py
@@ -24,6 +24,16 @@ from filters import (
     FILTERS, generate_preview, process_image,
     extract_filter_from_dng, load_all_filters, save_custom_filter
 )
+from logos import (
+    list_logos as logos_list,
+    get_logo as logos_get,
+    get_logo_path as logos_get_path,
+    get_default_logo as logos_get_default,
+    save_logo as logos_save,
+    delete_logo as logos_delete,
+    set_default_logo as logos_set_default,
+    rename_logo as logos_rename,
+)
 
 app = FastAPI(title="AgoraEncontrei Image Processor", version="1.1.0")
 
@@ -126,12 +136,35 @@ async def _read_upload(file: UploadFile) -> bytes:
     return bytes(buf)
 
 
-def get_logo_path() -> Optional[str]:
+def resolve_logo_path(logo_id: Optional[str]) -> Optional[str]:
+    """
+    Returns the filesystem path of a given logo id, or the default logo when
+    `logo_id` is empty/None. Falls back to the legacy single-file layout
+    (logo.png / logo.jpg / ...) when nothing has been migrated to the new
+    library yet, so old installs keep working until the user uploads
+    something new.
+    """
+    if logo_id:
+        p = logos_get_path(logo_id)
+        if p:
+            return p
+        # Fall through: ignore unknown ids instead of raising — matches the
+        # previous "best-effort" behaviour of the legacy helper.
+    default = logos_get_default()
+    if default:
+        return logos_get_path(default["id"])
+    # Legacy fallback — look for the hard-coded single-file logo left over
+    # from before the logo library existed.
     for ext in ['png', 'jpg', 'jpeg', 'webp']:
         p = Path(__file__).parent / f"logo.{ext}"
         if p.exists():
             return str(p)
     return None
+
+
+# Backwards-compat shim — older callers (import-filter et al) still use this.
+def get_logo_path() -> Optional[str]:
+    return resolve_logo_path(None)
 
 
 @app.get("/health")
@@ -159,7 +192,10 @@ class PreviewRequest(BaseModel):
     image_url: str
     filter_id: str
     apply_logo: bool = True
+    logo_id: Optional[str] = None          # None => use default logo
     logo_position: str = "bottom-right"
+    logo_size_percent: float = 8.0         # % da menor dimensao da foto
+    logo_opacity: float = 0.85             # 0.0 - 1.0
     preview_width: int = 800
 
 
@@ -168,12 +204,14 @@ async def preview_filter(req: PreviewRequest):
     """Gera preview com filtro. Retorna base64 para exibicao imediata."""
     try:
         image_bytes = fetch_image_bytes(req.image_url)
-        logo_path = get_logo_path() if req.apply_logo else None
+        logo_path = resolve_logo_path(req.logo_id) if req.apply_logo else None
         result = generate_preview(
             image_bytes=image_bytes,
             filter_id=req.filter_id,
             logo_path=logo_path,
             logo_position=req.logo_position,
+            logo_opacity=req.logo_opacity,
+            logo_size_percent=req.logo_size_percent,
             preview_width=req.preview_width,
         )
         b64 = base64.b64encode(result).decode("utf-8")
@@ -189,18 +227,23 @@ async def preview_filter_upload(
     file: UploadFile = File(...),
     filter_id: str = Form(...),
     apply_logo: bool = Form(True),
+    logo_id: Optional[str] = Form(None),
     logo_position: str = Form("bottom-right"),
+    logo_size_percent: float = Form(8.0),
+    logo_opacity: float = Form(0.85),
     preview_width: int = Form(800),
 ):
     """Preview a partir de arquivo enviado diretamente."""
     try:
         image_bytes = await _read_upload(file)
-        logo_path = get_logo_path() if apply_logo else None
+        logo_path = resolve_logo_path(logo_id) if apply_logo else None
         result = generate_preview(
             image_bytes=image_bytes,
             filter_id=filter_id,
             logo_path=logo_path,
             logo_position=logo_position,
+            logo_opacity=logo_opacity,
+            logo_size_percent=logo_size_percent,
             preview_width=preview_width,
         )
         b64 = base64.b64encode(result).decode("utf-8")
@@ -215,7 +258,10 @@ class ProcessRequest(BaseModel):
     image_url: str
     filter_id: str
     apply_logo: bool = True
+    logo_id: Optional[str] = None
     logo_position: str = "bottom-right"
+    logo_size_percent: float = 8.0
+    logo_opacity: float = 0.85
     output_quality: int = 92
 
 
@@ -224,12 +270,14 @@ async def process_single(req: ProcessRequest):
     """Processa uma imagem em qualidade completa."""
     try:
         image_bytes = fetch_image_bytes(req.image_url)
-        logo_path = get_logo_path() if req.apply_logo else None
+        logo_path = resolve_logo_path(req.logo_id) if req.apply_logo else None
         result = process_image(
             image_bytes=image_bytes,
             filter_id=req.filter_id,
             logo_path=logo_path,
             logo_position=req.logo_position,
+            logo_opacity=req.logo_opacity,
+            logo_size_percent=req.logo_size_percent,
             output_quality=req.output_quality,
         )
         b64 = base64.b64encode(result).decode("utf-8")
@@ -244,7 +292,10 @@ class BatchProcessRequest(BaseModel):
     image_urls: List[str]
     filter_id: str
     apply_logo: bool = True
+    logo_id: Optional[str] = None
     logo_position: str = "bottom-right"
+    logo_size_percent: float = 8.0
+    logo_opacity: float = 0.85
     output_quality: int = 92
 
 
@@ -255,7 +306,7 @@ async def process_batch(req: BatchProcessRequest):
         raise HTTPException(status_code=400, detail=f"Maximo {MAX_BATCH_ITEMS} URLs por lote")
     results = []
     errors = []
-    logo_path = get_logo_path() if req.apply_logo else None
+    logo_path = resolve_logo_path(req.logo_id) if req.apply_logo else None
 
     for i, url in enumerate(req.image_urls):
         try:
@@ -265,6 +316,8 @@ async def process_batch(req: BatchProcessRequest):
                 filter_id=req.filter_id,
                 logo_path=logo_path,
                 logo_position=req.logo_position,
+                logo_opacity=req.logo_opacity,
+                logo_size_percent=req.logo_size_percent,
                 output_quality=req.output_quality,
             )
             b64 = base64.b64encode(result).decode("utf-8")
@@ -287,21 +340,132 @@ async def process_batch(req: BatchProcessRequest):
     }
 
 
-@app.post("/upload-logo", dependencies=[Depends(verify_token)])
-async def upload_logo(file: UploadFile = File(...)):
-    """Faz upload do logo da imobiliaria."""
+# ── Logo library (multi-logo CRUD) ────────────────────────────────────────
+#
+# Any format Pillow can open is accepted (PNG, JPG, WEBP, AVIF, BMP, TIFF,
+# GIF) plus PDF (first page). The file is always stored internally as PNG
+# with transparency so the watermark pipeline stays uniform.
+
+# MIME allow-list for logo uploads. Vector SVG is deliberately NOT allowed
+# here — it can carry inline <script> and XSS downstream. Raster vector
+# formats (PNG/WebP) should be used instead.
+ALLOWED_LOGO_MIMES = {
+    "image/png", "image/jpeg", "image/jpg", "image/webp",
+    "image/avif", "image/bmp", "image/tiff", "image/gif",
+    "application/pdf",
+}
+
+
+def _serialize_logo(rec: dict) -> dict:
+    """Shape a logo record for the public JSON response. Exposes a URL the
+    web UI can use directly as <img src>."""
+    return {
+        "id": rec["id"],
+        "name": rec["name"],
+        "mime": rec["mime"],
+        "originalMime": rec.get("original_mime"),
+        "width": rec.get("width"),
+        "height": rec.get("height"),
+        "bytes": rec.get("bytes"),
+        "isDefault": bool(rec.get("is_default")),
+        "createdAt": rec.get("created_at"),
+        "url": f"/logos/{rec['id']}/file",
+    }
+
+
+@app.get("/logos", dependencies=[Depends(verify_token)])
+def logos_list_endpoint():
+    """Returns the library of registered logos."""
+    return {"logos": [_serialize_logo(r) for r in logos_list()]}
+
+
+@app.post("/logos", dependencies=[Depends(verify_token)])
+async def logos_upload_endpoint(
+    file: UploadFile = File(...),
+    name: Optional[str] = Form(None),
+):
+    """Uploads a new logo. Accepts any image format Pillow handles, plus PDF.
+    The file is normalised to PNG-RGBA on disk regardless of input format."""
     filename = (file.filename or "").strip()
     if "/" in filename or "\\" in filename or ".." in filename:
         raise HTTPException(status_code=400, detail="Nome de arquivo invalido")
-    parts = filename.rsplit(".", 1)
-    ext = parts[1].lower() if len(parts) == 2 else ""
-    if ext not in ["png", "jpg", "jpeg", "webp"]:
-        raise HTTPException(status_code=400, detail="Formato invalido. Use PNG, JPG ou WebP.")
+
+    mime = (file.content_type or "").lower()
+    # Accept when either the declared MIME is on the allow-list OR the
+    # extension suggests a supported type. Browsers sometimes send empty
+    # content-type for .avif / .bmp, so relying purely on MIME is fragile.
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    ext_allowed = ext in {"png", "jpg", "jpeg", "webp", "avif", "bmp", "tiff", "tif", "gif", "pdf"}
+    if mime not in ALLOWED_LOGO_MIMES and not ext_allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Formato nao suportado ({mime or ext or 'desconhecido'}). "
+                   "Use PNG, JPG, WEBP, BMP, TIFF, GIF ou PDF."
+        )
+
     content = await _read_upload(file)
-    logo_path = Path(__file__).parent / f"logo.{ext}"
-    with open(logo_path, "wb") as f:
-        f.write(content)
-    return {"message": "Logo salvo com sucesso", "path": str(logo_path)}
+    display_name = (name or filename or "Logo sem nome").rsplit(".", 1)[0]
+    try:
+        rec = logos_save(display_name, content, mime or f"image/{ext}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return _serialize_logo(rec)
+
+
+@app.get("/logos/{logo_id}", dependencies=[Depends(verify_token)])
+def logos_get_endpoint(logo_id: str):
+    rec = logos_get(logo_id)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="Logo nao encontrado")
+    return _serialize_logo(rec)
+
+
+@app.get("/logos/{logo_id}/file", dependencies=[Depends(verify_token)])
+def logos_file_endpoint(logo_id: str):
+    """Serves the raw PNG bytes of a logo. Used by the web UI as a
+    thumbnail source; also handy for debugging."""
+    from fastapi.responses import Response
+    path = logos_get_path(logo_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Logo nao encontrado")
+    with open(path, "rb") as f:
+        data = f.read()
+    return Response(content=data, media_type="image/png")
+
+
+@app.delete("/logos/{logo_id}", dependencies=[Depends(verify_token)])
+def logos_delete_endpoint(logo_id: str):
+    removed = logos_delete(logo_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Logo nao encontrado")
+    return {"ok": True}
+
+
+class LogoPatchRequest(BaseModel):
+    name: Optional[str] = None
+    is_default: Optional[bool] = None
+
+
+@app.patch("/logos/{logo_id}", dependencies=[Depends(verify_token)])
+def logos_patch_endpoint(logo_id: str, req: LogoPatchRequest):
+    """Renames a logo and/or toggles the default flag."""
+    updated = None
+    if req.name is not None:
+        updated = logos_rename(logo_id, req.name)
+    if req.is_default is True:
+        updated = logos_set_default(logo_id)
+    if updated is None and logos_get(logo_id) is None:
+        raise HTTPException(status_code=404, detail="Logo nao encontrado")
+    final = logos_get(logo_id)
+    return _serialize_logo(final) if final else {"ok": True}
+
+
+# ── Backwards-compat: old single-logo endpoint still works ───────────────
+@app.post("/upload-logo", dependencies=[Depends(verify_token)])
+async def upload_logo_legacy(file: UploadFile = File(...)):
+    """Legacy single-file upload. Creates a new entry in the logo library
+    (marked as default when it's the first one). Prefer POST /logos."""
+    return await logos_upload_endpoint(file=file, name=None)
 
 
 @app.post("/import-filter", dependencies=[Depends(verify_token)])

--- a/apps/image-processor/requirements.txt
+++ b/apps/image-processor/requirements.txt
@@ -4,3 +4,6 @@ pillow==12.1.1
 numpy==1.26.4
 requests==2.33.0
 python-multipart==0.0.22
+# PyMuPDF provides first-page PDF rasterisation for the logo library
+# upload endpoint. Ships as a pre-built wheel, no poppler needed.
+PyMuPDF==1.24.13

--- a/apps/web/src/app/(dashboard)/dashboard/leiloes/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/leiloes/page.tsx
@@ -159,16 +159,26 @@ export default function LeiloesAdminPage() {
     setScraping(true)
     setScrapeMsg(null)
     try {
+      // Send an empty JSON object as the body. Fastify (with ajv strict)
+      // rejects requests that declare `Content-Type: application/json`
+      // without any payload — the previous version only sent the header
+      // and produced "Body cannot be empty when content-type is set to
+      // 'application/json'".
       const res = await fetch(`${API_URL}/api/v1/auctions/force-scrape`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: '{}',
       })
-      const data = await res.json()
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setScrapeMsg(data?.message || data?.error || `Erro ${res.status} ao iniciar varredura`)
+        return
+      }
       setScrapeMsg(data.message || 'Varredura iniciada!')
       setTimeout(() => fetchStats(), 5000)
       setTimeout(() => fetchStats(), 15000)
-    } catch {
-      setScrapeMsg('Erro ao iniciar varredura')
+    } catch (err: any) {
+      setScrapeMsg(err?.message ? `Erro: ${err.message}` : 'Erro ao iniciar varredura')
     } finally {
       setScraping(false)
     }


### PR DESCRIPTION
3 commits que vão em conjunto:

1. `ee345a6` fix(deploy) — Dockerfile.web também precisa buildar tomas-knowledge antes do Next.js resolver o módulo. Sem isso o web deploy quebra com "Can't resolve '@agoraencontrei/tomas-knowledge'".

2. `aac4855` feat(logos) — biblioteca de múltiplos logos no image-processor. Aceita PNG, JPG, WEBP, AVIF, BMP, TIFF, GIF e PDF (primeira página via PyMuPDF). Tamanho e opacidade configuráveis por chamada. Endpoints CRUD `/logos/*` via API Node. UI no Settings vem em PR separado.

3. `f22308c` fix(auctions) — dois bugs reportados:
   - Forçar varredura dava "Body cannot be empty when content-type is set to 'application/json'" → fix dos dois lados (body `{}` + schema aceitando objeto vazio).
   - Outras leiloeiras não puxavam → Santander agora vai via Apify (que já estava no código mas ninguém chamava), cada banco tem try/catch isolado, a resposta retorna `sourcesQueued` / `sourcesSkipped` para ficar óbvio no UI qual está skipped e por quê.

Validação: pnpm --filter web typecheck → 0 erros. pnpm --filter @agoraencontrei/api typecheck → 48 erros (todos pré-existentes, mesmo número desde a auditoria inicial).
