### PR TITLE
fix + feat: suggest-title IA, hero upload, voice VAD, property picker, Lemos repasse dia por contrato

### DIFF
--- a/apps/web/src/components/dashboard/MediaEditorModal.tsx
+++ b/apps/web/src/components/dashboard/MediaEditorModal.tsx
@@ -147,6 +147,27 @@ interface LogoOverlayOptions {
   showBackdrop: boolean
 }
 
+/**
+ * Converte uma data URL em Blob manualmente via atob().
+ *
+ * Substitui o padrão `await fetch(dataUrl).then(r => r.blob())`, que
+ * é elegante mas quebra em alguns navegadores para data URLs grandes
+ * (>~2 MB) com um TypeError genérico — a foto de um imóvel a 1200 px
+ * JPEG já estoura esse limite com frequência. A implementação manual
+ * não tem o mesmo limite e deixa claro *por que* falhou.
+ */
+function dataUrlToBlob(dataUrl: string): Blob {
+  const match = /^data:([^;]+);base64,(.*)$/.exec(dataUrl)
+  if (!match) throw new Error('data URL inválida')
+  const mime = match[1]
+  const b64 = match[2]
+  const binary = atob(b64)
+  const len = binary.length
+  const bytes = new Uint8Array(len)
+  for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i)
+  return new Blob([bytes], { type: mime })
+}
+
 async function applyPhotoEffects(
   imageUrl: string,
   filterId: string,
@@ -349,14 +370,20 @@ export function MediaEditorModal({
   // contra a API como último recurso — diagnóstico claro para o usuário.
   const uploadProcessed = useCallback(async (dataUrl: string, filename: string): Promise<string> => {
     // Convert dataUrl (produced by canvas.toDataURL) to a Blob.
-    // Using fetch() on a data URL is supported by all modern browsers but can
-    // throw a TypeError ("Failed to fetch") in rare cases. Surface a clearer
-    // message for the user.
+    // We used to do `fetch(dataUrl).then(r => r.blob())`, which is
+    // elegant but fails with a cryptic TypeError on large data URLs
+    // (>~2 MB) on Chrome/Safari — the user saw "Não foi possível
+    // preparar a imagem processada" for a perfectly normal 2560x1920
+    // photo. The manual atob path below is slower but has no size
+    // limit and surfaces a real reason when it does fail.
     let blob: Blob
     try {
-      blob = await fetch(dataUrl).then(r => r.blob())
+      blob = dataUrlToBlob(dataUrl)
     } catch (e: any) {
-      throw new Error('Não foi possível preparar a imagem processada. Tente novamente.')
+      throw new Error(
+        `Não foi possível preparar a imagem processada: ${e?.message ?? 'formato inválido'}. ` +
+        `Tente reduzir o tamanho da foto ou gravar uma nova.`,
+      )
     }
 
     const buildFormData = () => {


### PR DESCRIPTION
Pacote consolidado com todos os pedidos das últimas horas + fixes.

## Commits incluídos

| Hash | O que faz |
|---|---|
| `688ee2c` | **fix(editor):** conversão manual de data URL → Blob (acaba com o bug "Não foi possível preparar a imagem processada" em fotos grandes) |
| `388c290` | **fix(voice):** Voice Activity Detection + auto-stop ao parar de falar + erros persistentes com texto + timeout 60s |
| `eb25050` | **feat(properties):** título/descrição/hashtags sugeridos por IA no meio do cadastro (lê o form completo e devolve copy pronto para site e redes sociais) |
| `db9a976` | **feat(settings):** upload direto de foto/vídeo no Hero e na Apresentação (arraste ou clique, sem precisar colar URL) |
| `9d1b11d` | **feat(ai-visual):** seletor de imóvel por código/endereço + grid de fotos já publicadas (sem mais cuid + URL manual) |
| `971582a` | **feat(finance):** endpoint admin `POST /finance/batch-settle` para consolidação pré-migração Uniloc (dry-run obrigatório, confirm token, aba "Revisar" para exceções) + nome do logo no preview do editor |
| `dafb19e` | **fix(dashboard):** SEO Programático envia Authorization + Controle Master renova JWT automaticamente (ambos retornavam HTTP 401) |
| `ccbf5da` | **fix(repasse):** usa `Contract.landlordDueDay` por contrato (regra Imobiliária Lemos: dias 2, 12, 17, 22, 27) + fix do bug "mesmo dia ia pro mês seguinte" |
| `73f624f` | **fix(settings):** sub-nav responsivo no mobile (tabs horizontais) + header da biblioteca de logos empilhado |
| `089ec53` | **chore:** Dockerfile dedicado para o image-processor (Python 3.12-slim + deps nativas do Pillow/PyMuPDF) |
| `112260a` | **fix(logos):** mensagens de erro humanas quando o microserviço de imagens não está configurado (em vez de JSON cru) |

## O que o operador passa a poder fazer depois do merge

- **Forçar varredura de leilões** sem o erro "Body cannot be empty".
- **Outras leiloeiras** (Santander via Apify) passam a ser varridas, não só Caixa.
- **Login** deixa de mostrar "Erro de conexão" genérico — diferencia rede, timeout, senha errada, sessão expirada.
- **Biblioteca de múltiplos logos** no Settings (PDF/PNG/JPG/WEBP/AVIF/BMP/TIFF/GIF), cada um com tamanho e opacidade configuráveis por foto.
- **Editor de mídia** com seletor de logo + sliders de tamanho/opacidade + nome do logo visível no preview.
- **Cadastro de imóvel** com botão "Sugerir título + descrição com IA" no meio do form.
- **Hero e Apresentação** aceitando upload direto (todo formato de foto/vídeo).
- **Busca por voz** que para sozinha quando você termina de falar.
- **AI Visual** com busca humana por imóvel em vez de colar cuid.
- **Repasse Asaas** usando a data correta de cada contrato (regra Lemos).
- **Batch settlement** para consolidar o balanço antes de ligar o sistema em produção.

## Env vars que ficam pendentes no Railway

- `api` → `IMAGE_PROCESSOR_URL=http://image-processor.railway.internal:3200`
- `api` → `BATCH_SETTLE_CONFIRM=<string ≥16 chars>` (só se quiser usar o batch de consolidação)
- `api` → `APIFY_API_TOKEN` (para Santander via Apify na varredura de leilões)

## Validação

- `pnpm --filter web typecheck` → **0 erros**
- `pnpm --filter @agoraencontrei/api typecheck` → **48 erros pré-existentes** (documentados em `CLAUDE.md`, inalterados — nenhuma regressão introduzida)
- `pnpm --filter web build` → **sucesso**, todas as rotas geradas

https://claude.ai/code/session_01HCaMeQC2ER6kRAYi3rJMVc