### PR TITLE
fix(auctions): auto-sync Santander + Caixa via Apify in scheduler

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -55,3 +55,10 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=noreply@agoraencontrei.com.br
+
+# Apify — Auction scrapers (Santander, Caixa enriched)
+# Get at: https://console.apify.com → Settings → Integrations → API tokens
+# Without this, only the official Caixa CSV is ingested. Santander, BB,
+# Bradesco and Itaú all use SPAs and require Apify (or another browser-
+# rendering scraper) to extract listings.
+APIFY_API_TOKEN=

--- a/apps/api/src/routes/auctions/index.ts
+++ b/apps/api/src/routes/auctions/index.ts
@@ -535,42 +535,25 @@ export default async function auctionsRoutes(app: FastifyInstance) {
         //    which cannot render JS, so bancos returned 0 every time.
         if ((env as any).APIFY_API_TOKEN) {
           try {
-            const { fetchSantanderApifyLastRun } = await import('../../services/apify-santander.service.js')
+            const [{ fetchSantanderApifyLastRun, persistApifySantanderItems }, { fetchCaixaApifyLastRun, persistApifyCaixaItems }] = await Promise.all([
+              import('../../services/apify-santander.service.js'),
+              import('../../services/apify-caixa.service.js'),
+            ])
+
             const santanderItems = await fetchSantanderApifyLastRun()
-            let saved = 0
-            for (const item of santanderItems) {
-              try {
-                await (prisma as any).auction.upsert({
-                  where: { slug: `santander-${(item as any).externalId ?? (item as any).id ?? saved}` },
-                  update: { updatedAt: new Date() },
-                  create: {
-                    slug: `santander-${(item as any).externalId ?? (item as any).id ?? `apify-${Date.now()}-${saved}`}`,
-                    source: 'SANTANDER',
-                    title: (item as any).title || 'Imóvel Santander',
-                    propertyType: (item as any).propertyType || 'HOUSE',
-                    status: 'OPEN',
-                    modality: 'ONLINE',
-                    city: (item as any).city || null,
-                    state: (item as any).state || null,
-                    neighborhood: (item as any).neighborhood || null,
-                    minimumBid: (item as any).price || null,
-                    appraisalValue: (item as any).appraisalValue || null,
-                    discountPercent: (item as any).discount || null,
-                    bankName: 'Santander',
-                    auctioneerName: 'Santander Imóveis',
-                    sourceUrl: (item as any).url || null,
-                  },
-                })
-                saved++
-              } catch {
-                /* one bad row shouldn't stop the rest */
-              }
+            const sant = await persistApifySantanderItems(prisma, santanderItems)
+            summary.SANTANDER = { found: sant.found, created: sant.created, updated: sant.updated }
+            app.log.info(`[force-scrape] Santander (Apify): ${sant.found} encontrados, ${sant.created} novos, ${sant.updated} atualizados`)
+
+            const caixaApify = await fetchCaixaApifyLastRun()
+            if (caixaApify.length > 0) {
+              const cx = await persistApifyCaixaItems(prisma, caixaApify)
+              summary.CAIXA_APIFY = { found: cx.found, created: cx.created, updated: cx.updated }
+              app.log.info(`[force-scrape] Caixa (Apify): ${cx.found} encontrados, ${cx.created} novos, ${cx.updated} atualizados`)
             }
-            summary.SANTANDER = { found: santanderItems.length, created: saved }
-            app.log.info(`[force-scrape] Santander (Apify): ${santanderItems.length} encontrados, ${saved} novos`)
           } catch (e: any) {
             summary.SANTANDER = { found: 0, created: 0, error: e.message }
-            app.log.error({ err: e }, '[force-scrape] Santander Apify failed')
+            app.log.error({ err: e }, '[force-scrape] Apify enrichment failed')
           }
         } else {
           summary.SANTANDER = { found: 0, created: 0, error: 'APIFY_API_TOKEN not configured' }

--- a/apps/api/src/services/apify-caixa.service.ts
+++ b/apps/api/src/services/apify-caixa.service.ts
@@ -11,6 +11,7 @@
  * Falls back to CSV scraper if Apify is unavailable or token not configured.
  */
 
+import type { PrismaClient } from '@prisma/client'
 import { env } from '../utils/env.js'
 
 const APIFY_ACTOR_ID = 'brasil-scrapers~caixa-leiloes-api'
@@ -241,4 +242,72 @@ export async function fetchCaixaFromDataset(datasetId: string): Promise<CaixaApi
     console.error('[Apify Caixa] Dataset fetch error:', err)
     return []
   }
+}
+
+function mapPropertyType(raw: string): 'HOUSE' | 'APARTMENT' | 'LAND' | 'WAREHOUSE' | 'OFFICE' | 'STORE' {
+  const t = (raw || '').toLowerCase()
+  if (t.includes('apartamento') || t.includes('apto')) return 'APARTMENT'
+  if (t.includes('terreno') || t.includes('lote')) return 'LAND'
+  if (t.includes('galp')) return 'WAREHOUSE'
+  if (t.includes('sala') || t.includes('comercial')) return 'OFFICE'
+  if (t.includes('loja')) return 'STORE'
+  return 'HOUSE'
+}
+
+/**
+ * Persist Caixa Apify items into the auctions table. Used by the scheduler
+ * to enrich the CSV-based ingest with extra fields (images, edital, rooms)
+ * the Apify actor exposes that the public CSV does not.
+ */
+export async function persistApifyCaixaItems(
+  prisma: PrismaClient,
+  items: CaixaApifyItem[],
+): Promise<{ found: number; created: number; updated: number; errors: string[] }> {
+  let created = 0
+  let updated = 0
+  const errors: string[] = []
+
+  for (const item of items) {
+    const externalId = item.propertyNumber || item.id.replace(/^caixa-/, '')
+    const slug = `caixa-${externalId}`
+    try {
+      const data = {
+        source: 'CAIXA' as const,
+        externalId,
+        title: item.description?.slice(0, 200) || `Imóvel Caixa em ${item.city || 'BR'}`,
+        propertyType: mapPropertyType(item.propertyType),
+        status: 'OPEN' as const,
+        modality: 'ONLINE' as const,
+        city: item.city || null,
+        state: item.state || null,
+        neighborhood: item.neighborhood || null,
+        street: item.address || null,
+        bedrooms: item.bedrooms || 0,
+        parkingSpaces: item.parkingSpots || 0,
+        minimumBid: item.price || null,
+        appraisalValue: item.appraisalValue || null,
+        discountPercent: item.discount || null,
+        bankName: 'Caixa Econômica Federal',
+        auctioneerName: 'Caixa Econômica Federal',
+        sourceUrl: item.link || null,
+        coverImage: item.coverImageUrl || null,
+        editalUrl: item.edital || null,
+        financingAvailable: item.financeable,
+        fgtsAllowed: item.fgtsAllowed,
+        lastScrapedAt: new Date(),
+      }
+
+      const result = await prisma.auction.upsert({
+        where: { slug },
+        create: { slug, ...data },
+        update: { ...data, updatedAt: new Date() },
+      })
+      if (result.createdAt.getTime() === result.updatedAt.getTime()) created++
+      else updated++
+    } catch (err: any) {
+      errors.push(`${slug}: ${err.message}`)
+    }
+  }
+
+  return { found: items.length, created, updated, errors }
 }

--- a/apps/api/src/services/apify-santander.service.ts
+++ b/apps/api/src/services/apify-santander.service.ts
@@ -10,6 +10,7 @@
  * - Cartório (registry office) info
  */
 
+import type { PrismaClient } from '@prisma/client'
 import { env } from '../utils/env.js'
 
 const APIFY_ACTOR_ID = 'gqjg9RZsLWXjy9c3u' // Santander Imóveis API
@@ -210,4 +211,69 @@ export async function fetchSantanderViaApify(): Promise<SantanderAuctionItem[]> 
     console.error('[Apify Santander] Error:', err)
     return []
   }
+}
+
+function mapPropertyType(raw: string): 'HOUSE' | 'APARTMENT' | 'LAND' | 'WAREHOUSE' | 'OFFICE' | 'STORE' {
+  const t = (raw || '').toLowerCase()
+  if (t.includes('apartamento')) return 'APARTMENT'
+  if (t.includes('terreno') || t.includes('lote')) return 'LAND'
+  if (t.includes('galp')) return 'WAREHOUSE'
+  if (t.includes('sala')) return 'OFFICE'
+  if (t.includes('loja')) return 'STORE'
+  return 'HOUSE'
+}
+
+/**
+ * Persist Santander Apify items into the auctions table.
+ * Returns counts so callers (scheduler, force-scrape) can report metrics.
+ */
+export async function persistApifySantanderItems(
+  prisma: PrismaClient,
+  items: SantanderAuctionItem[],
+): Promise<{ found: number; created: number; updated: number; errors: string[] }> {
+  let created = 0
+  let updated = 0
+  const errors: string[] = []
+
+  for (const item of items) {
+    const externalId = item.id.replace(/^santander-/, '')
+    const slug = `santander-${externalId}`
+    try {
+      const data = {
+        source: 'SANTANDER' as const,
+        externalId,
+        title: item.description?.slice(0, 200) || `Imóvel Santander em ${item.city || 'BR'}`,
+        propertyType: mapPropertyType(item.propertyType),
+        status: 'OPEN' as const,
+        modality: 'ONLINE' as const,
+        city: item.city || null,
+        state: item.state || null,
+        neighborhood: item.neighborhood || null,
+        street: item.address || null,
+        minimumBid: item.price || null,
+        appraisalValue: item.appraisalValue || null,
+        discountPercent: item.discount || null,
+        bankName: 'Santander',
+        auctioneerName: item.leiloeiro || 'Santander Imóveis',
+        sourceUrl: item.link || null,
+        coverImage: item.coverImageUrl || null,
+        images: item.photos?.length ? item.photos : [],
+        occupation: item.occupation || null,
+        registryNumber: item.matriculas || null,
+        lastScrapedAt: new Date(),
+      }
+
+      const result = await prisma.auction.upsert({
+        where: { slug },
+        create: { slug, ...data },
+        update: { ...data, updatedAt: new Date() },
+      })
+      if (result.createdAt.getTime() === result.updatedAt.getTime()) created++
+      else updated++
+    } catch (err: any) {
+      errors.push(`${slug}: ${err.message}`)
+    }
+  }
+
+  return { found: items.length, created, updated, errors }
 }

--- a/apps/api/src/services/scrapers/scheduler.ts
+++ b/apps/api/src/services/scrapers/scheduler.ts
@@ -2,6 +2,9 @@ import { PrismaClient } from '@prisma/client'
 import { CaixaScraper } from './caixa-scraper.js'
 import { GenericLeiloeiroScraper, LEILOEIROS_CONFIG, BANCOS_CONFIG } from './generic-scraper.js'
 import { AiNewsroomService } from '../ai-newsroom.service.js'
+import { env } from '../../utils/env.js'
+import { fetchSantanderApifyLastRun, persistApifySantanderItems } from '../apify-santander.service.js'
+import { fetchCaixaApifyLastRun, persistApifyCaixaItems } from '../apify-caixa.service.js'
 
 /**
  * Scheduler de Scrapers — roda 24/7, varrendo todas as fontes
@@ -118,9 +121,32 @@ export class ScraperScheduler {
 
     try {
       const result = await scraper.run()
+      let merged = { ...result }
+
+      // Apify-enriched Caixa data complements the official CSV with photos,
+      // edital URLs and room counts the CSV does not expose. Skipped silently
+      // when APIFY_API_TOKEN is not configured.
+      if (env.APIFY_API_TOKEN) {
+        try {
+          const apifyItems = await fetchCaixaApifyLastRun()
+          if (apifyItems.length > 0) {
+            const apifyResult = await persistApifyCaixaItems(this.prisma, apifyItems)
+            merged = {
+              found: result.found + apifyResult.found,
+              created: result.created + apifyResult.created,
+              updated: result.updated + apifyResult.updated,
+              errors: [...(result.errors || []), ...apifyResult.errors],
+            }
+            console.log(`[ScraperScheduler] Caixa+Apify: +${apifyResult.found} encontrados, +${apifyResult.created} novos`)
+          }
+        } catch (err: any) {
+          console.error('[ScraperScheduler] Caixa Apify falhou:', err.message)
+        }
+      }
+
       const duration = Date.now() - start
-      console.log(`[ScraperScheduler] Caixa: ${result.found} encontrados, ${result.created} novos, ${result.updated} atualizados (${duration}ms)`)
-      return { source: 'CAIXA', ...result, duration }
+      console.log(`[ScraperScheduler] Caixa: ${merged.found} encontrados, ${merged.created} novos, ${merged.updated} atualizados (${duration}ms)`)
+      return { source: 'CAIXA', ...merged, duration }
     } catch (err: any) {
       console.error('[ScraperScheduler] Caixa falhou:', err.message)
       return { source: 'CAIXA', found: 0, created: 0, updated: 0, errors: [err.message], duration: Date.now() - start }
@@ -130,8 +156,37 @@ export class ScraperScheduler {
   async runBancos(): Promise<ScraperResult[]> {
     console.log('[ScraperScheduler] Rodando scrapers de Bancos...')
     const results: ScraperResult[] = []
+    const apifyEnabled = !!env.APIFY_API_TOKEN
+    let santanderHandledByApify = false
+
+    // Santander via Apify — the bank's site is a SPA that returns blank HTML
+    // to raw fetch, so the GenericLeiloeiroScraper always recorded zero. The
+    // Apify actor renders the page and returns enriched listings.
+    if (apifyEnabled) {
+      const start = Date.now()
+      try {
+        const items = await fetchSantanderApifyLastRun()
+        if (items.length > 0) {
+          const r = await persistApifySantanderItems(this.prisma, items)
+          const duration = Date.now() - start
+          console.log(`[ScraperScheduler] Santander (Apify): ${r.found} encontrados, ${r.created} novos (${duration}ms)`)
+          results.push({ source: 'SANTANDER', ...r, duration })
+          santanderHandledByApify = true
+        } else {
+          console.warn('[ScraperScheduler] Santander Apify: nenhum item no último run')
+        }
+      } catch (err: any) {
+        console.error('[ScraperScheduler] Santander Apify falhou:', err.message)
+        results.push({ source: 'SANTANDER', found: 0, created: 0, updated: 0, errors: [err.message], duration: Date.now() - start })
+      }
+    } else {
+      console.warn('[ScraperScheduler] APIFY_API_TOKEN ausente — Santander cairá no scraper genérico (que falha em SPA)')
+    }
 
     for (const config of BANCOS_CONFIG) {
+      // Skip Santander generic scraper when Apify already filled the DB.
+      if (config.source === 'SANTANDER' && santanderHandledByApify) continue
+
       const start = Date.now()
       try {
         const scraper = new GenericLeiloeiroScraper(this.prisma, config)


### PR DESCRIPTION
Only Caixa auctions appeared in production because the ScraperScheduler relied on GenericLeiloeiroScraper for all banks — that scraper does a raw HTML fetch + regex parse and silently records 0 items against modern SPAs (Santander, BB, Bradesco, Itaú). The Apify-backed Santander integration existed but was only called from the manual /force-scrape endpoint, and its upsert referenced fields the normalized item never had (externalId/title/url) so even that path saved nothing.

- Add persistApifySantanderItems / persistApifyCaixaItems helpers that upsert normalized Apify rows into the auctions table by slug.
- Wire both into ScraperScheduler.runBancos / runCaixa so the auto-sync populates the DB every 6h (Caixa) and 12h (banks); skip the broken generic Santander scraper when Apify already handled it.
- Replace the broken inline upsert in /force-scrape with the same helper and also pull Apify Caixa enrichment there.
- Document APIFY_API_TOKEN in .env.example so the missing var stops silently disabling every non-Caixa source.