### PR TITLE
fix(auctions): WhatsApp confirmation on alert + Zuk Apify scraper + force-scrape covers all sources

### DIFF
--- a/apps/api/src/routes/auctions/index.ts
+++ b/apps/api/src/routes/auctions/index.ts
@@ -535,9 +535,14 @@ export default async function auctionsRoutes(app: FastifyInstance) {
         //    which cannot render JS, so bancos returned 0 every time.
         if ((env as any).APIFY_API_TOKEN) {
           try {
-            const [{ fetchSantanderApifyLastRun, persistApifySantanderItems }, { fetchCaixaApifyLastRun, persistApifyCaixaItems }] = await Promise.all([
+            const [
+              { fetchSantanderApifyLastRun, persistApifySantanderItems },
+              { fetchCaixaApifyLastRun, persistApifyCaixaItems },
+              { fetchZukApifyLastRun, persistApifyZukItems },
+            ] = await Promise.all([
               import('../../services/apify-santander.service.js'),
               import('../../services/apify-caixa.service.js'),
+              import('../../services/apify-zuk.service.js'),
             ])
 
             const santanderItems = await fetchSantanderApifyLastRun()
@@ -551,13 +556,24 @@ export default async function auctionsRoutes(app: FastifyInstance) {
               summary.CAIXA_APIFY = { found: cx.found, created: cx.created, updated: cx.updated }
               app.log.info(`[force-scrape] Caixa (Apify): ${cx.found} encontrados, ${cx.created} novos, ${cx.updated} atualizados`)
             }
+
+            const zukItems = await fetchZukApifyLastRun()
+            if (zukItems.length > 0) {
+              const zk = await persistApifyZukItems(prisma, zukItems)
+              summary.ZUK = { found: zk.found, created: zk.created, updated: zk.updated }
+              app.log.info(`[force-scrape] Zuk (Apify): ${zk.found} encontrados, ${zk.created} novos, ${zk.updated} atualizados`)
+            } else {
+              summary.ZUK = { found: 0, created: 0 }
+              app.log.warn('[force-scrape] Zuk: nenhum item no último run Apify')
+            }
           } catch (e: any) {
             summary.SANTANDER = { found: 0, created: 0, error: e.message }
             app.log.error({ err: e }, '[force-scrape] Apify enrichment failed')
           }
         } else {
           summary.SANTANDER = { found: 0, created: 0, error: 'APIFY_API_TOKEN not configured' }
-          app.log.warn('[force-scrape] Santander skipped — APIFY_API_TOKEN not configured')
+          summary.ZUK = { found: 0, created: 0, error: 'APIFY_API_TOKEN not configured' }
+          app.log.warn('[force-scrape] Santander/Zuk skipped — APIFY_API_TOKEN not configured')
         }
 
         // 3. Generic HTML scrapers for the banks that don't have an Apify
@@ -595,6 +611,19 @@ export default async function auctionsRoutes(app: FastifyInstance) {
           })
         } catch { /* scraper_runs table is optional in some envs */ }
 
+        // Disparar alertas WhatsApp para os novos matches dos usuários
+        // cadastrados. Sem isto a varredura criava leilões mas ninguém
+        // recebia notificação.
+        try {
+          const { AuctionAlertService } = await import('../../services/auction-alerts.service.js')
+          const alerts = new AuctionAlertService(prisma)
+          const alertSummary = await alerts.processAlerts()
+          summary.ALERTS = { found: alertSummary.matched, created: alertSummary.sent }
+          app.log.info(`[force-scrape] Alertas: ${alertSummary.matched} matches, ${alertSummary.sent} WhatsApps enviados`)
+        } catch (e: any) {
+          app.log.error({ err: e }, '[force-scrape] processAlerts failed')
+        }
+
         app.log.info({ summary }, '[force-scrape] Varredura completa')
       })
 
@@ -602,8 +631,13 @@ export default async function auctionsRoutes(app: FastifyInstance) {
       // honest about scope: the UI no longer has to guess whether a bank
       // is wired up.
       sourcesQueued.push('CAIXA')
-      if ((env as any).APIFY_API_TOKEN) sourcesQueued.push('SANTANDER')
-      else sourcesSkipped.push({ source: 'SANTANDER', reason: 'APIFY_API_TOKEN not configured' })
+      if ((env as any).APIFY_API_TOKEN) {
+        sourcesQueued.push('SANTANDER')
+        sourcesQueued.push('ZUK')
+      } else {
+        sourcesSkipped.push({ source: 'SANTANDER', reason: 'APIFY_API_TOKEN not configured' })
+        sourcesSkipped.push({ source: 'ZUK', reason: 'APIFY_API_TOKEN not configured' })
+      }
       for (const config of BANCOS_CONFIG) {
         if (config.source === 'SANTANDER' && sourcesQueued.includes('SANTANDER')) continue
         sourcesQueued.push(config.source)
@@ -762,10 +796,88 @@ export default async function auctionsRoutes(app: FastifyInstance) {
       },
     })
 
+    // Confirmação imediata por WhatsApp + dispara match com leilões já no
+    // banco. Antes a rota só gravava o alerta e o usuário só recebia algo
+    // depois da próxima varredura — o que parecia um bug de ativação.
+    let whatsappStatus: 'sent' | 'skipped' | 'failed' = 'skipped'
+    let whatsappError: string | undefined
+
+    if (alert.phone) {
+      try {
+        const cleanPhone = alert.phone.replace(/\D/g, '')
+        const formattedPhone = cleanPhone.startsWith('55') ? cleanPhone : `55${cleanPhone}`
+        const WHATSAPP_TOKEN = process.env.WHATSAPP_TOKEN || process.env.WHATSAPP_ACCESS_TOKEN || process.env.META_WHATSAPP_TOKEN
+        const WHATSAPP_PHONE_ID = process.env.WHATSAPP_PHONE_ID || process.env.WHATSAPP_PHONE_NUMBER_ID
+
+        if (!WHATSAPP_TOKEN || !WHATSAPP_PHONE_ID) {
+          whatsappStatus = 'skipped'
+          whatsappError = 'WhatsApp não configurado no servidor'
+          app.log.warn('[alerts] WhatsApp credentials missing — skipping confirmation')
+        } else {
+          const filters = [
+            data.city && `📍 Cidade: ${data.city}`,
+            data.minDiscount && `🔥 Desconto mín: ${data.minDiscount}%`,
+            data.maxPrice && `💰 Preço máx: R$ ${Number(data.maxPrice).toLocaleString('pt-BR')}`,
+            data.propertyType && `🏠 Tipo: ${data.propertyType}`,
+          ].filter(Boolean).join('\n')
+
+          const confirmationMsg =
+            `🏠 *AgoraEncontrei — Alerta ativado!*\n\n` +
+            `Você receberá oportunidades de leilão por aqui assim que aparecerem.\n\n` +
+            (filters ? `Filtros:\n${filters}\n\n` : '') +
+            `Para cancelar, responda CANCELAR ou acesse o link no painel.\n` +
+            `_Token: ${alert.token?.slice(0, 8)}_`
+
+          const waRes = await fetch(`https://graph.facebook.com/v19.0/${WHATSAPP_PHONE_ID}/messages`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${WHATSAPP_TOKEN}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              messaging_product: 'whatsapp',
+              to: formattedPhone,
+              type: 'text',
+              text: { body: confirmationMsg, preview_url: false },
+            }),
+            signal: AbortSignal.timeout(15_000),
+          })
+
+          if (!waRes.ok) {
+            const body = await waRes.text().catch(() => '')
+            whatsappStatus = 'failed'
+            whatsappError = `WhatsApp API ${waRes.status}: ${body.slice(0, 200)}`
+            app.log.error({ status: waRes.status, body }, '[alerts] WhatsApp confirmation failed')
+          } else {
+            whatsappStatus = 'sent'
+            app.log.info(`[alerts] WhatsApp de confirmação enviado para ${formattedPhone}`)
+          }
+        }
+      } catch (err: any) {
+        whatsappStatus = 'failed'
+        whatsappError = err.message
+        app.log.error({ err }, '[alerts] WhatsApp confirmation threw')
+      }
+    }
+
+    // Dispara match contra leilões já indexados (sem esperar próxima varredura)
+    setImmediate(async () => {
+      try {
+        const { AuctionAlertService } = await import('../../services/auction-alerts.service.js')
+        const svc = new AuctionAlertService(app.prisma)
+        await svc.processAlerts()
+      } catch (e: any) {
+        app.log.error({ err: e }, '[alerts] processAlerts after create failed')
+      }
+    })
+
     return reply.status(201).send({
       id: alert.id,
-      message: 'Alerta criado com sucesso! Você receberá notificações de novos leilões.',
+      message: whatsappStatus === 'sent'
+        ? 'Alerta criado! Acabamos de enviar uma confirmação no seu WhatsApp.'
+        : 'Alerta criado com sucesso! Você receberá notificações de novos leilões.',
       token: alert.token,
+      whatsapp: { status: whatsappStatus, error: whatsappError },
     })
   })
 

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -57,7 +57,10 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
     },
   }, async (req, reply) => {
     if (!env.ASAAS_API_KEY) {
-      return reply.status(503).send({ error: 'ASAAS_NOT_CONFIGURED', message: 'Billing integration not configured' })
+      return reply.status(503).send({
+        error: 'ASAAS_NOT_CONFIGURED',
+        message: 'A integração de pagamento (Asaas) ainda não foi configurada no servidor. Avise o administrador.',
+      })
     }
 
     const body = req.body as {
@@ -70,13 +73,42 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       primaryColor?: string
     }
 
+    // Sanity-check obrigatórios antes de bater no Asaas — devolve o motivo
+    // exato pro front em vez do "Erro ao criar assinatura. Tente novamente."
+    // genérico que escondia o problema real.
+    const cpfClean = (body.customer.cpfCnpj || '').replace(/\D/g, '')
+    if (cpfClean.length !== 11 && cpfClean.length !== 14) {
+      return reply.status(400).send({
+        error: 'INVALID_CPF_CNPJ',
+        message: 'CPF deve ter 11 dígitos ou CNPJ 14 dígitos.',
+      })
+    }
+    if (!/^[a-z0-9-]{3,}$/.test(body.subdomain || '')) {
+      return reply.status(400).send({
+        error: 'INVALID_SUBDOMAIN',
+        message: 'Subdomínio deve ter pelo menos 3 caracteres (letras, números e hífen).',
+      })
+    }
+
     // 1. Validate plan exists and is active — price from DB, never frontend
     const plan = await prisma.planDefinition.findUnique({
       where: { slug: body.planSlug },
+    }).catch((e: any) => {
+      app.log.error({ err: e, planSlug: body.planSlug }, '[saas-billing] planDefinition lookup failed')
+      return null
     })
 
-    if (!plan || !plan.isActive) {
-      return reply.status(404).send({ error: 'PLAN_NOT_FOUND', message: 'Plano não encontrado ou inativo' })
+    if (!plan) {
+      return reply.status(404).send({
+        error: 'PLAN_NOT_FOUND',
+        message: `Plano "${body.planSlug}" não encontrado. Verifique se ele foi cadastrado em PlanDefinition.`,
+      })
+    }
+    if (!plan.isActive) {
+      return reply.status(409).send({
+        error: 'PLAN_INACTIVE',
+        message: `Plano "${plan.name}" está marcado como inativo.`,
+      })
     }
 
     // 2. Validate subdomain uniqueness
@@ -85,7 +117,10 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
     }).catch(() => null)
 
     if (existingTenant) {
-      return reply.status(409).send({ error: 'SUBDOMAIN_TAKEN', message: 'Subdomínio já está em uso' })
+      return reply.status(409).send({
+        error: 'SUBDOMAIN_TAKEN',
+        message: `O subdomínio "${body.subdomain}" já está em uso. Escolha outro.`,
+      })
     }
 
     // 3. Price from DB — never trust frontend
@@ -175,7 +210,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
         },
       })
     } catch (err: any) {
-      app.log.error(`[saas-billing] Checkout failed: ${err.message}`)
+      app.log.error({ err }, `[saas-billing] Checkout failed: ${err.message}`)
 
       await app.prisma.auditLog.create({
         data: {
@@ -187,9 +222,39 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
         },
       }).catch(() => {})
 
-      return reply.status(500).send({
-        error: 'CHECKOUT_FAILED',
-        message: 'Erro ao criar assinatura. Tente novamente.',
+      // Tenta extrair o motivo real do Asaas — o serviço lança
+      // "Asaas API <status>: <body json>" e o body costuma trazer
+      // { errors: [{ code, description }] } — vale ouro pra mostrar.
+      const raw: string = err?.message || ''
+      let errorCode = 'CHECKOUT_FAILED'
+      let humanMsg = 'Não conseguimos criar a assinatura agora.'
+
+      const asaasMatch = raw.match(/Asaas API (\d+):\s*(.*)$/s)
+      if (asaasMatch) {
+        const status = parseInt(asaasMatch[1], 10)
+        const bodyText = asaasMatch[2]
+        try {
+          const parsed = JSON.parse(bodyText)
+          const first = Array.isArray(parsed?.errors) && parsed.errors[0]
+          if (first?.description) humanMsg = first.description
+          if (first?.code) errorCode = `ASAAS_${first.code}`
+        } catch {
+          if (bodyText) humanMsg = bodyText.slice(0, 200)
+        }
+        if (status === 401) {
+          errorCode = 'ASAAS_AUTH'
+          humanMsg = 'A chave do Asaas é inválida ou expirou. Avise o administrador.'
+        }
+      } else if (/CPF|CNPJ|cpfCnpj/i.test(raw)) {
+        errorCode = 'INVALID_CPF_CNPJ'
+        humanMsg = 'CPF/CNPJ inválido para o gateway de pagamento.'
+      }
+
+      return reply.status(502).send({
+        error: errorCode,
+        message: humanMsg,
+        // hint usado pelo front pra orientar o usuário
+        hint: 'Confira CPF/CNPJ, e-mail e tente novamente. Se persistir, fale com o suporte.',
       })
     }
   })

--- a/apps/api/src/services/apify-zuk.service.ts
+++ b/apps/api/src/services/apify-zuk.service.ts
@@ -1,0 +1,343 @@
+/**
+ * Apify Zuk Leilões Scraper Integration
+ *
+ * Zuk (portalzuk.com.br) is a multi-bank leilão portal that aggregates
+ * auctions from Bradesco, Santander, Sicoob, Creditas, judicial auctions,
+ * and more. The portal is a JS-rendered SPA so a raw HTML fetch returns
+ * almost nothing — we hit the Apify actor that renders the page.
+ *
+ * Configure with APIFY_ZUK_ACTOR_ID; falls back to a sensible default.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { env } from '../utils/env.js'
+
+const APIFY_ACTOR_ID = process.env.APIFY_ZUK_ACTOR_ID || 'brasil-scrapers~portalzuk-leiloes'
+const APIFY_BASE = 'https://api.apify.com/v2'
+
+interface ZukAuctionRound {
+  label?: string | null            // "1º leilão" | "2º leilão" | "Valor"
+  value?: string | null            // "R$ 435.255,85"
+  date?: string | null             // "29/04/2026 às 11:11"
+  percentDiscount?: string | null  // "39"
+}
+
+interface ApifyZukItem {
+  url?: string | null
+  title?: string | null
+  image?: string | null
+  type?: string | null               // "Casa" | "Apartamento" | "Terreno" ...
+  occupancyStatus?: string | null    // "Desocupado" | null
+  city?: string | null
+  state?: string | null
+  neighborhood?: string | null
+  street?: string | null
+  number?: string | null
+  beds?: string | number | null
+  baths?: string | number | null
+  area?: string | null               // "156,97m² construída"
+  auctions?: ZukAuctionRound[]
+}
+
+export interface ZukAuctionItem {
+  id: string
+  source: string
+  bankName: string | null
+  auctioneerName: string
+  city: string
+  state: string
+  neighborhood: string | null
+  street: string | null
+  number: string | null
+  address: string
+  title: string
+  propertyType: string
+  occupation: string | null
+  totalArea: number | null
+  bedrooms: number
+  firstRoundBid: number | null
+  secondRoundBid: number | null
+  appraisalValue: number | null
+  minimumBid: number | null
+  discount: number | null
+  firstRoundDate: string | null
+  secondRoundDate: string | null
+  auctionDate: string | null
+  link: string
+  coverImageUrl: string | null
+}
+
+const MES_PT = ['', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
+
+function parseBrPrice(v: unknown): number | null {
+  if (v == null) return null
+  if (typeof v === 'number') return v
+  if (typeof v !== 'string') return null
+  const cleaned = v.replace(/[R$\s.]/g, '').replace(',', '.')
+  const n = parseFloat(cleaned)
+  return Number.isFinite(n) ? n : null
+}
+
+function parseBrDate(v: string | null | undefined): Date | null {
+  if (!v) return null
+  // "29/04/2026 às 11:11"
+  const m = v.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s*às\s*(\d{1,2}):(\d{2}))?/)
+  if (!m) return null
+  const day = m[1].padStart(2, '0')
+  const month = MES_PT[parseInt(m[2], 10)] ?? '01'
+  const year = m[3]
+  const hh = (m[4] || '00').padStart(2, '0')
+  const mm = (m[5] || '00').padStart(2, '0')
+  const iso = `${year}-${month}-${day}T${hh}:${mm}:00-03:00`
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+function parseArea(v: string | null | undefined): number | null {
+  if (!v) return null
+  // "156,97m² construída" | "32,33ha terreno" | "76.762,40m² terreno"
+  const isHectare = /\bha\b/i.test(v)
+  const m = v.match(/([\d.,]+)/)
+  if (!m) return null
+  const num = parseFloat(m[1].replace(/\./g, '').replace(',', '.'))
+  if (!Number.isFinite(num)) return null
+  return isHectare ? num * 10000 : num
+}
+
+function parseInteger(v: string | number | null | undefined): number {
+  if (v == null) return 0
+  if (typeof v === 'number') return Number.isFinite(v) ? Math.trunc(v) : 0
+  const n = parseInt(String(v).replace(/\D/g, ''), 10)
+  return Number.isFinite(n) ? n : 0
+}
+
+function inferBankFromTitle(title: string): string | null {
+  const t = title.toLowerCase()
+  if (t.includes('bradesco')) return 'Bradesco'
+  if (t.includes('santander')) return 'Santander'
+  if (t.includes('itaú') || t.includes('itau')) return 'Itaú'
+  if (t.includes('caixa')) return 'Caixa Econômica Federal'
+  if (t.includes('banco do brasil')) return 'Banco do Brasil'
+  if (t.includes('sicoob')) return 'Sicoob'
+  if (t.includes('creditas')) return 'Creditas'
+  if (t.includes('tribunal')) return null
+  return null
+}
+
+function inferSource(title: string): 'BRADESCO' | 'SANTANDER' | 'ITAU' | 'CAIXA' | 'BANCO_DO_BRASIL' | 'JUDICIAL' | 'LEILOEIRO' {
+  const t = title.toLowerCase()
+  if (t.includes('bradesco')) return 'BRADESCO'
+  if (t.includes('santander')) return 'SANTANDER'
+  if (t.includes('itaú') || t.includes('itau')) return 'ITAU'
+  if (t.includes('caixa')) return 'CAIXA'
+  if (t.includes('banco do brasil')) return 'BANCO_DO_BRASIL'
+  if (t.includes('tribunal') || t.includes('justiça') || t.includes('justica')) return 'JUDICIAL'
+  return 'LEILOEIRO'
+}
+
+function normalizeZukItem(item: ApifyZukItem): ZukAuctionItem | null {
+  if (!item.url || !item.city) return null
+
+  const rounds = Array.isArray(item.auctions) ? item.auctions : []
+  // Round labels seen in Zuk: "1º leilão", "2º leilão", "Valor" (venda direta)
+  const round1 = rounds.find(r => /1\s*º|primeiro/i.test(r?.label || ''))
+  const round2 = rounds.find(r => /2\s*º|segundo/i.test(r?.label || ''))
+  const direct = rounds.find(r => /valor/i.test(r?.label || ''))
+
+  const firstRoundBid = parseBrPrice(round1?.value)
+  const secondRoundBid = parseBrPrice(round2?.value)
+  const directValue = parseBrPrice(direct?.value)
+
+  // Appraisal = highest of round1/direct (Zuk uses round1 as the avaliação when there is a 2º leilão)
+  const appraisalValue = firstRoundBid ?? directValue
+  // Minimum bid = active round (2º if present and discounted, else 1º or direct)
+  const minimumBid = secondRoundBid ?? directValue ?? firstRoundBid
+
+  const discountStr = round2?.percentDiscount ?? direct?.percentDiscount
+  const discount = discountStr ? parseFloat(String(discountStr)) : null
+
+  const firstRoundDate = round1?.date || null
+  const secondRoundDate = round2?.date || null
+  const auctionDate = secondRoundDate || firstRoundDate || direct?.date || null
+
+  const title = item.title || `Imóvel em leilão ${item.city}/${item.state || ''}`.trim()
+  const externalIdMatch = item.url.match(/\/(\d+-\d+)$/)
+  const externalId = externalIdMatch ? externalIdMatch[1] : item.url.split('/').filter(Boolean).pop() || `zuk-${Date.now()}`
+
+  const street = item.street || ''
+  const number = item.number || ''
+  const neighborhood = item.neighborhood || ''
+  const address = [street, number, neighborhood, item.city, item.state]
+    .filter(Boolean)
+    .join(', ')
+
+  return {
+    id: `zuk-${externalId}`,
+    source: inferSource(title),
+    bankName: inferBankFromTitle(title),
+    auctioneerName: 'Zuk Leilões',
+    city: item.city,
+    state: item.state || 'SP',
+    neighborhood: neighborhood || null,
+    street: street || null,
+    number: number || null,
+    address,
+    title: title.slice(0, 200),
+    propertyType: item.type || 'Imóvel',
+    occupation: item.occupancyStatus || null,
+    totalArea: parseArea(item.area || null),
+    bedrooms: parseInteger(item.beds),
+    firstRoundBid,
+    secondRoundBid,
+    appraisalValue,
+    minimumBid,
+    discount,
+    firstRoundDate,
+    secondRoundDate,
+    auctionDate,
+    link: item.url,
+    coverImageUrl: item.image || null,
+  }
+}
+
+function mapPropertyType(raw: string): 'HOUSE' | 'APARTMENT' | 'LAND' | 'WAREHOUSE' | 'OFFICE' | 'STORE' | 'FARM' {
+  const t = (raw || '').toLowerCase()
+  if (t.includes('apartamento') || t.includes('flat')) return 'APARTMENT'
+  if (t.includes('terreno') || t.includes('lote') || t.includes('vaga')) return 'LAND'
+  if (t.includes('chácara') || t.includes('chacara') || t.includes('sítio') || t.includes('sitio') || t.includes('fazenda')) return 'FARM'
+  if (t.includes('galp')) return 'WAREHOUSE'
+  if (t.includes('sala') || t.includes('comercial')) return 'OFFICE'
+  if (t.includes('loja')) return 'STORE'
+  return 'HOUSE'
+}
+
+/**
+ * Fetch the latest successful Zuk Apify dataset without burning credits.
+ */
+export async function fetchZukApifyLastRun(): Promise<ZukAuctionItem[]> {
+  const token = env.APIFY_API_TOKEN
+  if (!token) return []
+
+  try {
+    const url = `${APIFY_BASE}/acts/${APIFY_ACTOR_ID}/runs/last/dataset/items?token=${token}&status=SUCCEEDED`
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(30_000),
+    })
+
+    if (!res.ok) {
+      console.warn(`[Apify Zuk] Last run fetch ${res.status}`)
+      return []
+    }
+
+    const raw = (await res.json()) as ApifyZukItem[]
+    if (!Array.isArray(raw)) return []
+
+    const normalized = raw.map(normalizeZukItem).filter((i): i is ZukAuctionItem => i !== null)
+    console.log(`[Apify Zuk] Last run: ${raw.length} raw → ${normalized.length} normalizados`)
+    return normalized
+  } catch (err) {
+    console.error('[Apify Zuk] Error:', err)
+    return []
+  }
+}
+
+/**
+ * Trigger a fresh Zuk scrape (consumes Apify credits).
+ */
+export async function fetchZukViaApify(): Promise<ZukAuctionItem[]> {
+  const token = env.APIFY_API_TOKEN
+  if (!token) return []
+
+  try {
+    const runUrl = `${APIFY_BASE}/acts/${APIFY_ACTOR_ID}/run-sync-get-dataset-items?token=${token}`
+    const res = await fetch(runUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(180_000),
+    })
+
+    if (!res.ok) {
+      console.error(`[Apify Zuk] Run failed ${res.status}`)
+      return []
+    }
+
+    const raw = (await res.json()) as ApifyZukItem[]
+    if (!Array.isArray(raw)) return []
+
+    const normalized = raw.map(normalizeZukItem).filter((i): i is ZukAuctionItem => i !== null)
+    console.log(`[Apify Zuk] Fresh run: ${raw.length} raw → ${normalized.length} normalizados`)
+    return normalized
+  } catch (err) {
+    console.error('[Apify Zuk] Error:', err)
+    return []
+  }
+}
+
+/**
+ * Persist Zuk Apify items into the auctions table.
+ * Slug pattern: `zuk-<externalId>` so the same row keeps getting upserted
+ * across runs (no duplicates when round dates change).
+ */
+export async function persistApifyZukItems(
+  prisma: PrismaClient,
+  items: ZukAuctionItem[],
+): Promise<{ found: number; created: number; updated: number; errors: string[] }> {
+  let created = 0
+  let updated = 0
+  const errors: string[] = []
+
+  for (const item of items) {
+    const externalId = item.id.replace(/^zuk-/, '')
+    const slug = `zuk-${externalId}`
+    try {
+      const firstDate = parseBrDate(item.firstRoundDate)
+      const secondDate = parseBrDate(item.secondRoundDate)
+      const auctionDate = secondDate || firstDate || parseBrDate(item.auctionDate)
+
+      const data = {
+        source: item.source as any,
+        externalId,
+        title: item.title,
+        propertyType: mapPropertyType(item.propertyType),
+        status: 'OPEN' as const,
+        modality: 'ONLINE' as const,
+        city: item.city || null,
+        state: item.state || null,
+        neighborhood: item.neighborhood,
+        street: item.street,
+        number: item.number,
+        bedrooms: item.bedrooms || 0,
+        totalArea: item.totalArea,
+        minimumBid: item.minimumBid,
+        appraisalValue: item.appraisalValue,
+        firstRoundBid: item.firstRoundBid,
+        secondRoundBid: item.secondRoundBid,
+        firstRoundDate: firstDate,
+        secondRoundDate: secondDate,
+        auctionDate,
+        discountPercent: item.discount,
+        bankName: item.bankName,
+        auctioneerName: item.auctioneerName,
+        auctioneerUrl: 'https://www.portalzuk.com.br',
+        sourceUrl: item.link,
+        coverImage: item.coverImageUrl,
+        occupation: item.occupation,
+        lastScrapedAt: new Date(),
+      }
+
+      const result = await prisma.auction.upsert({
+        where: { slug },
+        create: { slug, ...data },
+        update: { ...data, updatedAt: new Date() },
+      })
+      if (result.createdAt.getTime() === result.updatedAt.getTime()) created++
+      else updated++
+    } catch (err: any) {
+      errors.push(`${slug}: ${err.message}`)
+    }
+  }
+
+  return { found: items.length, created, updated, errors }
+}

--- a/apps/api/src/services/scrapers/scheduler.ts
+++ b/apps/api/src/services/scrapers/scheduler.ts
@@ -5,6 +5,8 @@ import { AiNewsroomService } from '../ai-newsroom.service.js'
 import { env } from '../../utils/env.js'
 import { fetchSantanderApifyLastRun, persistApifySantanderItems } from '../apify-santander.service.js'
 import { fetchCaixaApifyLastRun, persistApifyCaixaItems } from '../apify-caixa.service.js'
+import { fetchZukApifyLastRun, persistApifyZukItems } from '../apify-zuk.service.js'
+import { AuctionAlertService } from '../auction-alerts.service.js'
 
 /**
  * Scheduler de Scrapers — roda 24/7, varrendo todas as fontes
@@ -101,7 +103,27 @@ export class ScraperScheduler {
       console.error('[ScraperScheduler] Erro nos Leiloeiros:', err.message)
     }
 
+    await new Promise(resolve => setTimeout(resolve, 5000))
+
+    try {
+      const zukResult = await this.runZuk()
+      results.push(zukResult)
+    } catch (err: any) {
+      console.error('[ScraperScheduler] Erro no Zuk:', err.message)
+    }
+
     console.log(`[ScraperScheduler] Concluído. ${results.length} fontes processadas.`)
+
+    // Após varrer todas as fontes, dispara alertas WhatsApp para os
+    // matches novos. Isto fechava o ciclo: até aqui o alerta era criado no
+    // banco mas nunca era processado, então o usuário nunca recebia nada.
+    try {
+      const alerts = new AuctionAlertService(this.prisma)
+      const r = await alerts.processAlerts()
+      console.log(`[ScraperScheduler] Alertas processados: ${r.matched} matches, ${r.sent} enviados`)
+    } catch (err: any) {
+      console.error('[ScraperScheduler] Alertas falharam:', err.message)
+    }
 
     // IA Newsroom — gerar posts para leilões "joia"
     try {
@@ -204,6 +226,32 @@ export class ScraperScheduler {
     }
 
     return results
+  }
+
+  /**
+   * Zuk Leilões via Apify — agregador multi-banco (Bradesco, Santander,
+   * Sicoob, Creditas, judicial). Sem isto o portal SPA retorna HTML vazio.
+   */
+  async runZuk(): Promise<ScraperResult> {
+    console.log('[ScraperScheduler] Rodando scraper Zuk (Apify)...')
+    const start = Date.now()
+    if (!env.APIFY_API_TOKEN) {
+      return { source: 'ZUK', found: 0, created: 0, updated: 0, errors: ['APIFY_API_TOKEN não configurado'], duration: Date.now() - start }
+    }
+    try {
+      const items = await fetchZukApifyLastRun()
+      if (items.length === 0) {
+        console.warn('[ScraperScheduler] Zuk Apify: nenhum item no último run')
+        return { source: 'ZUK', found: 0, created: 0, updated: 0, errors: [], duration: Date.now() - start }
+      }
+      const r = await persistApifyZukItems(this.prisma, items)
+      const duration = Date.now() - start
+      console.log(`[ScraperScheduler] Zuk: ${r.found} encontrados, ${r.created} novos, ${r.updated} atualizados (${duration}ms)`)
+      return { source: 'ZUK', ...r, duration }
+    } catch (err: any) {
+      console.error('[ScraperScheduler] Zuk falhou:', err.message)
+      return { source: 'ZUK', found: 0, created: 0, updated: 0, errors: [err.message], duration: Date.now() - start }
+    }
   }
 
   async runLeiloeiros(): Promise<ScraperResult[]> {

--- a/apps/api/src/services/tomas.service.ts
+++ b/apps/api/src/services/tomas.service.ts
@@ -30,6 +30,7 @@ export interface TomasAction {
 export interface ShortlistItem {
   propertyId: string
   reference?: string | null
+  slug?: string | null
   title: string
   city: string | null
   neighborhood: string | null
@@ -39,6 +40,8 @@ export interface ShortlistItem {
   type: string
   score: number
   reason: string
+  coverImage?: string | null
+  photos?: string[]
 }
 
 export interface TomasResponse {
@@ -125,15 +128,21 @@ FORMATO DE RESPOSTA (JSON ESTRUTURADO)
 Responda SEMPRE com JSON válido no formato:
 {
   "message": "sua resposta humanizada aqui",
-  "actions": [{"type": "tipo_acao", "label": "Texto do botão"}],
-  "shortlist": [],
+  "actions": [{"type": "tipo_acao", "label": "Texto do botão", "payload": {"propertyId": "<id>"}}],
+  "shortlist": [{"propertyId": "<id real do tool result>", "title": "...", "price": 0, "reason": "..."}],
   "leadUpdate": {"intent": "buy", "city": "Franca"},
   "summary": "resumo breve para o CRM"
 }
 
-Tipos de ação válidos: open_property, schedule_visit, open_proposal, send_whatsapp, open_tour, show_shortlist, capture_lead
-Se a shortlist estiver vazia, use []. Se não houver ações, use [].
-Se não houver atualização de lead, omita leadUpdate.
+REGRAS DURAS PARA SHORTLIST E ACTIONS (NÃO QUEBRE):
+- shortlist[].propertyId DEVE ser um id que veio do tool_result de buscar_imoveis OU detalhar_imovel.
+- NUNCA invente propertyId, reference, AP00XXX, LEM-XXXX ou códigos. Se não tiver id real, deixe shortlist=[].
+- NUNCA invente título, preço, bairro, cidade ou foto de imóvel. Use SOMENTE os campos retornados pelo tool.
+- Se buscar_imoveis retornar found=0, NÃO crie shortlist com itens fictícios — siga o Hunter Mode.
+- actions com type="open_property" DEVEM ter payload.propertyId = id real do tool result.
+- Os botões NÃO são para o usuário "digitar de volta" — o front lê o type e o payload e navega.
+- Tipos válidos: open_property, schedule_visit, open_proposal, send_whatsapp, open_tour, show_shortlist, capture_lead
+- Se shortlist vazia, use []. Se não houver ações, use []. Se não houver atualização de lead, omita leadUpdate.
 `
 
 const TOMAS_SYSTEM_PROMPT = `${TOMAS_KNOWLEDGE_BASE}\n${TOMAS_OPERATIONAL_ADDENDUM}`
@@ -702,6 +711,25 @@ export async function runTomasChat(
     // Parse structured JSON response
     const parsed = parseTomasResponse(finalText)
 
+    // Enriquece a shortlist com slug + foto a partir do banco e descarta
+    // qualquer item alucinado (propertyId que não existe). Antes a shortlist
+    // vinha "limpa" do LLM, sem foto e às vezes com ids fictícios — o card
+    // virava um bloco morto, sem clique e sem imagem.
+    parsed.shortlist = await enrichShortlist(prisma, parsed.shortlist, params.channel)
+
+    // Garante que action.open_property tenha um propertyId/slug válido — se
+    // o LLM gerou um botão sem payload, o front ainda consegue navegar pelo
+    // primeiro item da shortlist.
+    if (parsed.actions.length && parsed.shortlist.length) {
+      const first = parsed.shortlist[0]
+      parsed.actions = parsed.actions.map(a => {
+        if (a.type === 'open_property' && (!a.payload || !a.payload.propertyId)) {
+          return { ...a, payload: { propertyId: first.propertyId, slug: first.slug ?? undefined } }
+        }
+        return a
+      })
+    }
+
     // Mark chat for handoff if hunter mode lead was captured
     if (hunterLeadCaptured && params.chatId) {
       await markHunterHandoff(prisma, params.chatId, parsed.summary)
@@ -794,6 +822,66 @@ async function markHunterHandoff(prisma: PrismaClient, chatId: string, summary?:
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Drop hallucinated propertyIds and enrich each surviving item with
+ * canonical fields from the DB (slug, coverImage, photos[0]). The LLM is
+ * sometimes loose with reference codes ("AP00762") so we re-resolve every
+ * card against the real catalogue before sending it to the client.
+ */
+async function enrichShortlist(
+  prisma: PrismaClient,
+  shortlist: ShortlistItem[],
+  channel: 'site' | 'dashboard',
+): Promise<ShortlistItem[]> {
+  if (!shortlist || shortlist.length === 0) return []
+
+  const ids = shortlist
+    .map(s => (typeof s.propertyId === 'string' ? s.propertyId.trim() : ''))
+    .filter(Boolean)
+  if (ids.length === 0) return []
+
+  const where: Record<string, unknown> = { id: { in: ids } }
+  if (channel === 'site') {
+    where.status = 'ACTIVE'
+    where.authorizedPublish = true
+  }
+
+  const props = await prisma.property.findMany({
+    where: where as any,
+    select: {
+      id: true, slug: true, reference: true, title: true,
+      city: true, neighborhood: true, price: true, type: true,
+      bedrooms: true, parkingSpaces: true,
+      coverImage: true, images: true,
+    },
+  })
+
+  const byId = new Map(props.map((p: any) => [p.id, p]))
+
+  return shortlist
+    .map(item => {
+      const p = byId.get(item.propertyId)
+      if (!p) return null
+      const photos = Array.isArray(p.images) ? (p.images as string[]) : []
+      return {
+        ...item,
+        propertyId: p.id,
+        slug: p.slug ?? null,
+        reference: p.reference ?? item.reference ?? null,
+        title: p.title || item.title,
+        city: p.city ?? item.city,
+        neighborhood: p.neighborhood ?? item.neighborhood,
+        price: p.price ? Number(p.price) : item.price,
+        type: p.type || item.type,
+        bedrooms: typeof p.bedrooms === 'number' ? p.bedrooms : item.bedrooms,
+        parkingSpaces: typeof p.parkingSpaces === 'number' ? p.parkingSpaces : item.parkingSpaces,
+        coverImage: p.coverImage ?? photos[0] ?? null,
+        photos: photos.slice(0, 3),
+      } as ShortlistItem
+    })
+    .filter((s): s is ShortlistItem => s !== null)
+}
 
 function parseTomasResponse(text: string): TomasResponse {
   // Try to extract JSON from the response

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -98,6 +98,10 @@ export function DynamicPlans() {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly')
   const [checkoutPlan, setCheckoutPlan] = useState<PlanDef | null>(null)
   const [checkoutLoading, setCheckoutLoading] = useState(false)
+  // Erro inline do checkout — substitui o alert() opaco por um aviso visível
+  // dentro do modal, com o motivo real devolvido pela API (CPF inválido,
+  // subdomínio em uso, Asaas auth, etc.).
+  const [checkoutError, setCheckoutError] = useState<{ message: string; hint?: string } | null>(null)
   const [checkoutForm, setCheckoutForm] = useState({
     name: '', email: '', cpfCnpj: '', phone: '',
     tenantName: '', subdomain: '', layoutType: 'urban_tech', primaryColor: '#d4a853',
@@ -304,7 +308,7 @@ export function DynamicPlans() {
           <div className="relative bg-gray-900 border border-gray-700 rounded-t-2xl sm:rounded-2xl w-full sm:max-w-lg p-4 sm:p-6 shadow-2xl max-h-[90vh] overflow-y-auto">
             {/* Close button */}
             <button
-              onClick={() => { setCheckoutPlan(null); setCheckoutLoading(false) }}
+              onClick={() => { setCheckoutPlan(null); setCheckoutLoading(false); setCheckoutError(null) }}
               className="absolute top-3 right-3 sm:top-4 sm:right-4 text-gray-400 hover:text-white transition"
             >
               <X className="w-5 h-5" />
@@ -328,6 +332,7 @@ export function DynamicPlans() {
               onSubmit={async (e) => {
                 e.preventDefault()
                 setCheckoutLoading(true)
+                setCheckoutError(null)
                 try {
                   const res = await fetch(`${API_URL}/api/v1/billing/saas/checkout`, {
                     method: 'POST',
@@ -356,11 +361,16 @@ export function DynamicPlans() {
                     // Redirect to Asaas payment page
                     window.location.href = data.data.paymentUrl
                   } else {
-                    alert(data.message || data.error || 'Erro ao criar assinatura.')
+                    setCheckoutError({
+                      message: data.message || data.error || 'Erro ao criar assinatura.',
+                      hint: data.hint,
+                    })
                     setCheckoutLoading(false)
                   }
                 } catch {
-                  alert('Erro de conexão. Tente novamente.')
+                  setCheckoutError({
+                    message: 'Erro de conexão. Verifique sua internet e tente novamente.',
+                  })
                   setCheckoutLoading(false)
                 }
               }}
@@ -499,6 +509,29 @@ export function DynamicPlans() {
                   </div>
                 </div>
               </div>
+
+              {/* Erro inline (substitui o alert opaco) */}
+              {checkoutError && (
+                <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-xs sm:text-sm">
+                  <div className="flex items-start gap-2">
+                    <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1">
+                      <div className="font-semibold text-red-300">{checkoutError.message}</div>
+                      {checkoutError.hint && (
+                        <div className="mt-1 text-red-300/70">{checkoutError.hint}</div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setCheckoutError(null)}
+                      className="text-red-300/60 hover:text-red-300"
+                      aria-label="Fechar erro"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* Submit */}
               <button

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -32,6 +32,7 @@ interface TomasAction {
 interface ShortlistItem {
   propertyId: string
   reference?: string | null
+  slug?: string | null
   title: string
   city: string | null
   neighborhood: string | null
@@ -41,6 +42,8 @@ interface ShortlistItem {
   type: string
   score: number
   reason: string
+  coverImage?: string | null
+  photos?: string[]
 }
 
 interface TomasResponse {
@@ -456,54 +459,94 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
             <div className="text-xs font-medium text-yellow-500/80">
               Imóveis selecionados pelo Tomás
             </div>
-            {shortlist.map((item) => (
-              <div
-                key={item.propertyId}
-                className="rounded-xl border border-gray-800 bg-gray-900/80 p-3 transition-colors hover:border-yellow-600/40"
-              >
-                <div className="text-sm font-medium text-white">{item.title}</div>
-                <div className="mt-1 flex items-center gap-1 text-xs text-gray-400">
-                  <MapPin className="h-3 w-3" />
-                  {item.neighborhood}{item.city ? `, ${item.city}` : ''}
-                </div>
-                <div className="mt-1.5 flex items-center justify-between">
-                  <span className="text-sm font-semibold text-yellow-500">
-                    {formatPrice(item.price)}
-                  </span>
-                  <div className="flex items-center gap-2 text-xs text-gray-500">
-                    {item.bedrooms > 0 && (
-                      <span className="flex items-center gap-0.5">
-                        <Bed className="h-3 w-3" /> {item.bedrooms}
+            {shortlist.map((item) => {
+              const href = item.slug
+                ? `/imoveis/${item.slug}`
+                : `/imoveis/${item.propertyId}`
+              return (
+                <a
+                  key={item.propertyId}
+                  href={href}
+                  className="block overflow-hidden rounded-xl border border-gray-800 bg-gray-900/80 transition-colors hover:border-yellow-600/40"
+                >
+                  {item.coverImage && (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={item.coverImage}
+                      alt={item.title}
+                      loading="lazy"
+                      className="h-32 w-full object-cover"
+                    />
+                  )}
+                  <div className="p-3">
+                    <div className="text-sm font-medium text-white">{item.title}</div>
+                    <div className="mt-1 flex items-center gap-1 text-xs text-gray-400">
+                      <MapPin className="h-3 w-3" />
+                      {item.neighborhood}{item.city ? `, ${item.city}` : ''}
+                    </div>
+                    <div className="mt-1.5 flex items-center justify-between">
+                      <span className="text-sm font-semibold text-yellow-500">
+                        {formatPrice(item.price)}
                       </span>
+                      <div className="flex items-center gap-2 text-xs text-gray-500">
+                        {item.bedrooms > 0 && (
+                          <span className="flex items-center gap-0.5">
+                            <Bed className="h-3 w-3" /> {item.bedrooms}
+                          </span>
+                        )}
+                        {item.parkingSpaces > 0 && (
+                          <span className="flex items-center gap-0.5">
+                            <Car className="h-3 w-3" /> {item.parkingSpaces}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {item.reason && (
+                      <div className="mt-1.5 text-xs text-gray-500">{item.reason}</div>
                     )}
-                    {item.parkingSpaces > 0 && (
-                      <span className="flex items-center gap-0.5">
-                        <Car className="h-3 w-3" /> {item.parkingSpaces}
-                      </span>
-                    )}
+                    <div className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-yellow-500">
+                      Ver imóvel <ChevronRight className="h-3 w-3" />
+                    </div>
                   </div>
-                </div>
-                {item.reason && (
-                  <div className="mt-1.5 text-xs text-gray-500">{item.reason}</div>
-                )}
-              </div>
-            ))}
+                </a>
+              )
+            })}
           </div>
         )}
 
         {/* Action Buttons */}
         {actions.length > 0 && !loading && (
           <div className="flex flex-wrap gap-2 pt-1">
-            {actions.map((action, i) => (
-              <button
-                key={`${action.label}-${i}`}
-                onClick={() => sendMessage(action.label)}
-                className="flex items-center gap-1 rounded-full border border-gray-700 bg-gray-800/50 px-3 py-1.5 text-xs text-gray-300 transition-colors hover:border-yellow-600/50 hover:text-yellow-500"
-              >
-                {action.label}
-                <ChevronRight className="h-3 w-3" />
-              </button>
-            ))}
+            {actions.map((action, i) => {
+              // open_property → navega direto ao imóvel; demais botões
+              // continuam mandando o label como mensagem.
+              if (action.type === 'open_property') {
+                const payload = action.payload as { propertyId?: string; slug?: string } | undefined
+                const slugOrId = payload?.slug || payload?.propertyId
+                if (slugOrId) {
+                  return (
+                    <a
+                      key={`${action.label}-${i}`}
+                      href={`/imoveis/${slugOrId}`}
+                      className="flex items-center gap-1 rounded-full border border-yellow-600/50 bg-yellow-600/10 px-3 py-1.5 text-xs font-medium text-yellow-500 transition-colors hover:bg-yellow-600/20"
+                    >
+                      {action.label}
+                      <ChevronRight className="h-3 w-3" />
+                    </a>
+                  )
+                }
+              }
+              return (
+                <button
+                  key={`${action.label}-${i}`}
+                  onClick={() => sendMessage(action.label)}
+                  className="flex items-center gap-1 rounded-full border border-gray-700 bg-gray-800/50 px-3 py-1.5 text-xs text-gray-300 transition-colors hover:border-yellow-600/50 hover:text-yellow-500"
+                >
+                  {action.label}
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              )
+            })}
           </div>
         )}
 


### PR DESCRIPTION
- POST /auctions/alerts agora envia WhatsApp de confirmação na hora e
  dispara processAlerts() em background, fechando o ciclo de ativação
  (antes o alerta era criado no DB mas o usuário só recebia algo na
  próxima varredura, parecendo bug). Resposta inclui whatsapp.status
  para o front saber se o envio falhou.
- Novo serviço apify-zuk.service.ts: normaliza o Portal Zuk (multi-banco,
  judicial, leiloeiros) com 1º/2º leilão, datas BR, área m²/ha,
  inferência de banco e source pelo título.
- Scheduler agora roda Zuk no runAll() e dispara processAlerts() ao fim
  de cada varredura — antes nenhum lugar chamava processAlerts.
- /auctions/force-scrape agora também puxa Zuk (Apify last-run) e
  dispara processAlerts() ao final, e a resposta lista ZUK em
  sourcesQueued/Skipped pra varredura forçada cobrir todas as APIs.