### PR TITLE
feat: onboarding parceiro completo (Tenant+Company+User+welcome) + home redesign

### DIFF
--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -11,6 +11,8 @@
 
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
+import argon2 from 'argon2'
+import { randomBytes } from 'node:crypto'
 import { env } from '../../utils/env.js'
 import {
   findOrCreateCustomer,
@@ -18,6 +20,17 @@ import {
   createCharge,
   type AsaasBillingType,
 } from '../../services/asaas.service.js'
+
+/**
+ * Gera senha temporária legível (ex: "Onda7-Mar9-Lua") — fácil de copiar
+ * via WhatsApp e ainda assim com entropia razoável (>40 bits).
+ */
+function generateTempPassword(): string {
+  const words = ['Onda', 'Mar', 'Lua', 'Sol', 'Vento', 'Rio', 'Pico', 'Brisa', 'Fogo', 'Areia', 'Pedra', 'Ouro']
+  const w = () => words[randomBytes(1)[0] % words.length]
+  const n = () => randomBytes(1)[0] % 90 + 10 // 10..99
+  return `${w()}${n()}-${w()}${n()}-${w()}`
+}
 
 export default async function saasBillingRoutes(app: FastifyInstance) {
   const prisma = app.prisma as any
@@ -51,6 +64,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           subdomain: { type: 'string' },
           layoutType: { type: 'string' },
           primaryColor: { type: 'string' },
+          nicheSlug: { type: 'string' },
         },
         required: ['planSlug', 'customer', 'tenantName', 'subdomain'],
       },
@@ -71,6 +85,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       subdomain: string
       layoutType?: string
       primaryColor?: string
+      nicheSlug?: string
     }
 
     // Sanity-check obrigatórios antes de bater no Asaas — devolve o motivo
@@ -123,6 +138,19 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       })
     }
 
+    // Bloqueia checkout duplicado — se o e-mail já tem conta, manda logar
+    // em vez de criar uma segunda Company silenciosamente.
+    const existingUser = await app.prisma.user.findUnique({
+      where: { email: body.customer.email.toLowerCase().trim() },
+    }).catch(() => null)
+    if (existingUser) {
+      return reply.status(409).send({
+        error: 'EMAIL_IN_USE',
+        message: `Já existe uma conta com o e-mail ${body.customer.email}. Faça login no painel ou use outro e-mail.`,
+        hint: 'Se esqueceu a senha, use "Recuperar senha" na tela de login.',
+      })
+    }
+
     // 3. Price from DB — never trust frontend
     const cycle = body.billingCycle || 'MONTHLY'
     const price = cycle === 'YEARLY' && plan.priceYearly
@@ -157,33 +185,80 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
         externalReference: `tenant:${body.subdomain}`,
       })
 
-      // 7. Create tenant in TRIAL status (activated after payment)
-      const tenant = await prisma.tenant.create({
-        data: {
-          name: body.tenantName,
-          subdomain: body.subdomain,
-          layoutType: body.layoutType || 'urban_tech',
-          primaryColor: body.primaryColor || '#d4a853',
-          plan: plan.slug.toUpperCase(),
-          planStatus: 'TRIAL',
-          planPrice: price,
-          asaasSubscriptionId: subscription.id,
-          trialEndsAt: nextDue,
-          settings: {
-            asaasCustomerId: customer.id,
-            planSlug: plan.slug,
-            billingCycle: cycle,
+      // 7. Cria Company + Tenant + User admin em transação. Antes só
+      //    criava Tenant; o parceiro pagava e ficava sem CRM e sem login.
+      //    Agora nasce tudo em TRIAL e o webhook só precisa marcar ACTIVE.
+      const tempPassword = generateTempPassword()
+      const passwordHash = await argon2.hash(tempPassword, { type: argon2.argon2id })
+
+      const { tenant, company, user } = await app.prisma.$transaction(async (tx: any) => {
+        const company = await tx.company.create({
+          data: {
+            name: body.tenantName,
+            plan: plan.slug.toLowerCase(),
+            isActive: true,
+            settings: {
+              isTenant: true,
+              layoutType: body.layoutType || 'urban_tech',
+              primaryColor: body.primaryColor || '#d4a853',
+              nicheSlug: body.nicheSlug || 'imobiliaria',
+              subdomain: body.subdomain,
+            },
           },
-        },
+        })
+
+        const user = await tx.user.create({
+          data: {
+            companyId: company.id,
+            name: body.customer.name,
+            email: body.customer.email.toLowerCase().trim(),
+            phone: body.customer.phone || null,
+            passwordHash,
+            role: 'ADMIN' as any,
+            status: 'ACTIVE' as any,
+          },
+        })
+
+        const tenant = await tx.tenant.create({
+          data: {
+            name: body.tenantName,
+            subdomain: body.subdomain,
+            layoutType: body.layoutType || 'urban_tech',
+            primaryColor: body.primaryColor || '#d4a853',
+            plan: plan.slug.toUpperCase(),
+            planStatus: 'TRIAL',
+            planPrice: price,
+            asaasSubscriptionId: subscription.id,
+            companyId: company.id,
+            ownerId: user.id,
+            trialEndsAt: nextDue,
+            settings: {
+              asaasCustomerId: customer.id,
+              planSlug: plan.slug,
+              billingCycle: cycle,
+              nicheSlug: body.nicheSlug || 'imobiliaria',
+              customerEmail: body.customer.email,
+              customerPhone: body.customer.phone || null,
+              // Marcamos a senha como temporária para o webhook saber que
+              // ele deve incluí-la no e-mail/WhatsApp de boas-vindas. Após
+              // o primeiro login bem-sucedido a flag deve sair.
+              tempPasswordIssued: true,
+              tempPasswordPlain: tempPassword,
+            },
+          },
+        })
+
+        return { tenant, company, user }
       })
 
       // 8. Audit log
       await app.prisma.auditLog.create({
         data: {
-          companyId: 'platform',
+          companyId: company.id,
           action: 'saas.checkout' as any,
           resource: 'tenant',
           resourceId: tenant.id,
+          userId: user.id,
           payload: {
             planSlug: plan.slug,
             price,
@@ -204,9 +279,15 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           price,
           cycle,
           asaasSubscriptionId: subscription.id,
-          // Client should redirect to Asaas payment page
+          // Client deve redirecionar para a página de sucesso (que mostra
+          // próximos passos) e em paralelo abrir o link do Asaas.
           paymentUrl: `https://www.asaas.com/c/${subscription.id}`,
-          message: 'Assinatura criada! Complete o pagamento para ativar seu site.',
+          successUrl: `/checkout/sucesso?ref=${encodeURIComponent(body.subdomain)}`,
+          loginUrl: '/login',
+          // Não devolvemos a senha — ela vai pelo e-mail/WhatsApp do
+          // webhook de pagamento confirmado, evitando vazar em logs do
+          // cliente / paywall.
+          message: 'Assinatura criada! Você receberá os dados de acesso por e-mail e WhatsApp assim que o pagamento for confirmado.',
         },
       })
     } catch (err: any) {

--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -129,21 +129,118 @@ async function handleTenantEvent(
         return
       }
 
-      // Activate tenant
-      await prisma.tenant.update({
-        where: { id: tenant.id },
-        data: {
-          planStatus: 'ACTIVE',
-          isActive: true,
-          activatedAt: new Date(),
-          suspendedAt: null,
-          settings: {
-            ...(tenant.settings as any || {}),
-            lastPaymentId: payment.id,
-            lastPaymentDate: new Date().toISOString(),
+      const settings = (tenant.settings as any) || {}
+      const tempPasswordPlain: string | undefined = settings.tempPasswordPlain
+      const customerEmail: string | undefined = settings.customerEmail
+      const customerPhone: string | undefined = settings.customerPhone
+
+      // Limpa a senha temporária do settings na hora da ativação — uma vez
+      // que vai ser enviada por e-mail/WhatsApp não pode ficar parada no
+      // banco indefinidamente.
+      const cleanedSettings = { ...settings }
+      delete cleanedSettings.tempPasswordPlain
+
+      // Activate tenant + Company (mesma transação para não deixar Tenant
+      // ACTIVE com Company isActive=false em caso de falha)
+      await prisma.$transaction(async (tx: any) => {
+        await tx.tenant.update({
+          where: { id: tenant.id },
+          data: {
+            planStatus: 'ACTIVE',
+            isActive: true,
+            activatedAt: new Date(),
+            suspendedAt: null,
+            settings: {
+              ...cleanedSettings,
+              lastPaymentId: payment.id,
+              lastPaymentDate: new Date().toISOString(),
+              tempPasswordIssued: false,
+            },
           },
-        },
+        })
+        if (tenant.companyId) {
+          await tx.company.update({
+            where: { id: tenant.companyId },
+            data: { isActive: true },
+          }).catch(() => null)
+        }
       })
+
+      // Envia credenciais ao parceiro (e-mail + WhatsApp em paralelo).
+      // Tudo feito em try/catch independentes pra um canal falhar sem
+      // travar a ativação.
+      if (tempPasswordPlain && customerEmail) {
+        try {
+          const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+          if (isEmailConfigured()) {
+            const siteUrl = `https://${subdomain}.agoraencontrei.com.br`
+            const html = `
+              <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+                <h1 style="color:#1B2B5B;margin:0 0 8px">Bem-vindo(a) ao AgoraEncontrei!</h1>
+                <p style="margin:0 0 16px;color:#475569">Pagamento confirmado. Seu site está no ar 🎉</p>
+                <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:20px;margin:16px 0">
+                  <p style="margin:0 0 8px"><strong>Painel administrativo:</strong></p>
+                  <p style="margin:0 0 12px"><a href="https://agoraencontrei.com.br/login" style="color:#C9A84C">https://agoraencontrei.com.br/login</a></p>
+                  <p style="margin:0 0 8px"><strong>Seu site:</strong></p>
+                  <p style="margin:0 0 12px"><a href="${siteUrl}" style="color:#C9A84C">${siteUrl}</a></p>
+                  <p style="margin:0 0 8px"><strong>E-mail:</strong> ${customerEmail}</p>
+                  <p style="margin:0"><strong>Senha temporária:</strong> <code style="background:#f1f5f9;padding:2px 6px;border-radius:4px">${tempPasswordPlain}</code></p>
+                </div>
+                <p style="margin:16px 0;color:#475569">No primeiro acesso troque a senha em <em>Perfil → Segurança</em>.</p>
+                <p style="margin:24px 0 0;font-size:13px;color:#64748b">Qualquer dúvida, responda este e-mail.</p>
+              </div>`
+            await sendEmail({
+              to: customerEmail,
+              subject: '🎉 Seu site no AgoraEncontrei está ativo — credenciais de acesso',
+              html,
+            })
+            app.log.info(`[saas-webhook] Welcome e-mail enviado para ${customerEmail}`)
+          } else {
+            app.log.warn('[saas-webhook] SMTP não configurado — credenciais não enviadas por e-mail')
+          }
+        } catch (e: any) {
+          app.log.error({ err: e }, '[saas-webhook] welcome email failed')
+        }
+
+        if (customerPhone) {
+          try {
+            const cleanPhone = customerPhone.replace(/\D/g, '')
+            const formattedPhone = cleanPhone.startsWith('55') ? cleanPhone : `55${cleanPhone}`
+            const WHATSAPP_TOKEN = process.env.WHATSAPP_TOKEN || process.env.WHATSAPP_ACCESS_TOKEN
+            const WHATSAPP_PHONE_ID = process.env.WHATSAPP_PHONE_ID || process.env.WHATSAPP_PHONE_NUMBER_ID
+            if (WHATSAPP_TOKEN && WHATSAPP_PHONE_ID) {
+              const siteUrl = `https://${subdomain}.agoraencontrei.com.br`
+              const msg =
+                `🎉 *AgoraEncontrei — Pagamento confirmado!*\n\n` +
+                `Seu site está no ar:\n${siteUrl}\n\n` +
+                `*Acesso ao painel:*\nhttps://agoraencontrei.com.br/login\n\n` +
+                `*E-mail:* ${customerEmail}\n` +
+                `*Senha temporária:* ${tempPasswordPlain}\n\n` +
+                `Troque a senha no primeiro acesso (Perfil → Segurança).`
+              await fetch(`https://graph.facebook.com/v19.0/${WHATSAPP_PHONE_ID}/messages`, {
+                method: 'POST',
+                headers: {
+                  Authorization: `Bearer ${WHATSAPP_TOKEN}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  messaging_product: 'whatsapp',
+                  to: formattedPhone,
+                  type: 'text',
+                  text: { body: msg, preview_url: false },
+                }),
+              })
+              app.log.info(`[saas-webhook] Welcome WhatsApp enviado para ${formattedPhone}`)
+            } else {
+              app.log.warn('[saas-webhook] WhatsApp não configurado — credenciais não enviadas por WhatsApp')
+            }
+          } catch (e: any) {
+            app.log.error({ err: e }, '[saas-webhook] welcome whatsapp failed')
+          }
+        }
+      } else {
+        app.log.warn(`[saas-webhook] Tenant ${subdomain} sem tempPasswordPlain — credenciais NÃO enviadas (provavelmente checkout antigo)`)
+      }
 
       app.log.info(`[saas-webhook] Tenant ${subdomain} ACTIVATED (plan: ${tenant.plan})`)
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -60,6 +60,7 @@ import { specialistPaymentRoutes } from './routes/specialists/payments.js'
 import { ScraperScheduler } from './services/scrapers/scheduler.js'
 import { AuctionMonitorService } from './services/auction-monitor.service.js'
 import { PredatoryProtocol } from './services/predatory/protocol.js'
+import { bootstrapDefaultPlans } from './services/bootstrap-plans.js'
 import { AutoHealingService } from './services/auto-healing.service.js'
 // Manus auctionsRoute desativada — conflita com publicRoutes no mesmo prefix
 // import { auctionsRoute } from './routes/public/auctions.js'
@@ -844,6 +845,15 @@ async function bootstrap() {
       app.log.info(`[boot] Reativados ${reactivated.count} leilões bancários que estavam CLOSED`)
     }
   } catch (e: any) { app.log.warn('Auction reactivation skip:', e.message) }
+
+  // ── Bootstrap idempotente de planos + nichos ───────────────────────────
+  // Sem isto o checkout falhava com PLAN_NOT_FOUND porque a tabela vinha
+  // vazia em produção. Roda em todo boot, só insere o que falta.
+  try {
+    await bootstrapDefaultPlans(app.prisma)
+  } catch (e: any) {
+    app.log.warn('bootstrapDefaultPlans skip:', e.message)
+  }
 
   // ── Scraper Scheduler (robôs 24/7 de leilões) ─────────────────────────
   if (env.NODE_ENV === 'production') {

--- a/apps/api/src/services/bootstrap-plans.ts
+++ b/apps/api/src/services/bootstrap-plans.ts
@@ -1,0 +1,230 @@
+/**
+ * Bootstrap idempotente de PlanDefinition + NicheTemplate.
+ *
+ * Roda no boot do servidor: se a tabela está vazia (ou faltando os planos
+ * default), insere os básicos para que o checkout funcione "out of the
+ * box". Não sobrescreve nada que já existe — admin pode mexer livre via
+ * /api/v1/master/plans depois.
+ *
+ * Sintoma que isto resolve: o checkout retornava
+ *   `Erro ao criar assinatura. Tente novamente.`
+ * porque `prisma.planDefinition.findUnique({ where: { slug: 'pro' } })`
+ * devolvia null e a rota nem chegava no Asaas.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+interface PlanSeed {
+  slug: string
+  name: string
+  description: string
+  priceMonthly: number
+  priceYearly: number
+  maxProperties: number
+  maxLeadViews: number
+  maxUsers: number
+  maxAIRequests: number
+  themes: string[]
+  modules: string[]
+  features: string[]
+  highlighted: boolean
+  sortOrder: number
+}
+
+const DEFAULT_PLANS: PlanSeed[] = [
+  {
+    slug: 'lite',
+    name: 'Lite',
+    description: 'Site profissional + CRM básico para começar a vender online.',
+    priceMonthly: 97,
+    priceYearly: 970, // ~2 meses grátis
+    maxProperties: 30,
+    maxLeadViews: 100,
+    maxUsers: 1,
+    maxAIRequests: 50,
+    themes: ['urban_tech', 'classic_trust'],
+    modules: ['site_basico', 'crm_basico'],
+    features: [
+      'Site multi-tenant (subdomínio.agoraencontrei.com.br)',
+      'Até 30 imóveis publicados',
+      'CRM básico (leads + contatos)',
+      'Tomás IA — 50 conversas/mês',
+      'Suporte por e-mail',
+    ],
+    highlighted: false,
+    sortOrder: 10,
+  },
+  {
+    slug: 'pro',
+    name: 'Pro',
+    description: 'Para corretores e imobiliárias que querem escalar com IA e automação.',
+    priceMonthly: 297,
+    priceYearly: 2970, // ~2 meses grátis
+    maxProperties: 200,
+    maxLeadViews: 1000,
+    maxUsers: 5,
+    maxAIRequests: 1000,
+    themes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro'],
+    modules: ['site_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes'],
+    features: [
+      'Tudo do Lite',
+      'Até 200 imóveis publicados',
+      'CRM avançado (deals, pipeline, automações)',
+      'Tomás IA — 1000 conversas/mês + voz',
+      'Integração WhatsApp Cloud API',
+      'Painel de leilões (Caixa, Santander, Zuk)',
+      'Até 5 corretores',
+      'Suporte prioritário',
+    ],
+    highlighted: true,
+    sortOrder: 20,
+  },
+  {
+    slug: 'enterprise',
+    name: 'Enterprise',
+    description: 'Domínio próprio, ilimitado e atendimento dedicado.',
+    priceMonthly: 597,
+    priceYearly: 5970,
+    maxProperties: -1,
+    maxLeadViews: -1,
+    maxUsers: -1,
+    maxAIRequests: -1,
+    themes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro', 'landscape_living'],
+    modules: ['site_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos'],
+    features: [
+      'Tudo do Pro',
+      'Imóveis e leads ilimitados',
+      'Domínio próprio (.com.br)',
+      'Split de pagamentos (Asaas)',
+      'Tomás IA ilimitado',
+      'Usuários e corretores ilimitados',
+      'Onboarding e suporte dedicado',
+    ],
+    highlighted: false,
+    sortOrder: 30,
+  },
+]
+
+interface NicheSeed {
+  slug: string
+  name: string
+  icon: string
+  description: string
+  tomasPersona: string
+  tomasGreeting: string
+  tomasTone: 'consultivo' | 'agil' | 'acolhedor' | 'formal' | 'direto'
+  itemLabel: string
+  itemLabelPlural: string
+  defaultTheme: string
+  availableThemes: string[]
+  sortOrder: number
+}
+
+const DEFAULT_NICHES: NicheSeed[] = [
+  {
+    slug: 'imobiliaria',
+    name: 'Imobiliária',
+    icon: 'building-2',
+    description: 'Corretores e imobiliárias com foco em venda e locação.',
+    tomasPersona: 'Você é Tomás, consultor imobiliário. Conheça profundamente o mercado de imóveis residenciais e comerciais.',
+    tomasGreeting: 'Oi! Sou o Tomás. Me diz o que você está buscando que eu localizo em segundos.',
+    tomasTone: 'consultivo',
+    itemLabel: 'Imóvel',
+    itemLabelPlural: 'Imóveis',
+    defaultTheme: 'urban_tech',
+    availableThemes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro'],
+    sortOrder: 10,
+  },
+  {
+    slug: 'investidor-leiloes',
+    name: 'Investidor de Leilões',
+    icon: 'gavel',
+    description: 'Foco em arremate de imóveis em leilão judicial e bancário.',
+    tomasPersona: 'Você é Tomás, especialista em leilões judiciais e bancários. Domina ITBI, matrícula, desocupação e ROI.',
+    tomasGreeting: 'Boa tarde. Sou Tomás, consultor de oportunidades em leilão.',
+    tomasTone: 'formal',
+    itemLabel: 'Oportunidade',
+    itemLabelPlural: 'Oportunidades',
+    defaultTheme: 'luxury_gold',
+    availableThemes: ['luxury_gold', 'classic_trust', 'urban_tech'],
+    sortOrder: 20,
+  },
+  {
+    slug: 'rural',
+    name: 'Rural / Fazenda',
+    icon: 'tractor',
+    description: 'Sítios, chácaras e fazendas para morar ou investir.',
+    tomasPersona: 'Você é Tomás, consultor de imóveis rurais. Conhece áreas, georreferenciamento, CAR, ITR.',
+    tomasGreeting: 'Olá! Sou o Tomás. Está buscando um lugar especial para viver ou investir?',
+    tomasTone: 'acolhedor',
+    itemLabel: 'Propriedade',
+    itemLabelPlural: 'Propriedades',
+    defaultTheme: 'landscape_living',
+    availableThemes: ['landscape_living', 'classic_trust'],
+    sortOrder: 30,
+  },
+]
+
+export async function bootstrapDefaultPlans(prisma: PrismaClient): Promise<void> {
+  // Plans
+  let createdPlans = 0
+  for (const plan of DEFAULT_PLANS) {
+    const existing = await (prisma as any).planDefinition.findUnique({
+      where: { slug: plan.slug },
+    }).catch(() => null)
+    if (existing) continue
+
+    await (prisma as any).planDefinition.create({
+      data: {
+        slug: plan.slug,
+        name: plan.name,
+        description: plan.description,
+        priceMonthly: plan.priceMonthly,
+        priceYearly: plan.priceYearly,
+        maxProperties: plan.maxProperties,
+        maxLeadViews: plan.maxLeadViews,
+        maxUsers: plan.maxUsers,
+        maxAIRequests: plan.maxAIRequests,
+        themes: plan.themes,
+        modules: plan.modules,
+        features: plan.features,
+        highlighted: plan.highlighted,
+        sortOrder: plan.sortOrder,
+        isActive: true,
+      },
+    }).catch(() => null)
+    createdPlans++
+  }
+
+  // Niches
+  let createdNiches = 0
+  for (const niche of DEFAULT_NICHES) {
+    const existing = await (prisma as any).nicheTemplate.findUnique({
+      where: { slug: niche.slug },
+    }).catch(() => null)
+    if (existing) continue
+
+    await (prisma as any).nicheTemplate.create({
+      data: {
+        slug: niche.slug,
+        name: niche.name,
+        icon: niche.icon,
+        description: niche.description,
+        tomasPersona: niche.tomasPersona,
+        tomasGreeting: niche.tomasGreeting,
+        tomasTone: niche.tomasTone,
+        itemLabel: niche.itemLabel,
+        itemLabelPlural: niche.itemLabelPlural,
+        defaultTheme: niche.defaultTheme,
+        availableThemes: niche.availableThemes,
+        sortOrder: niche.sortOrder,
+        isActive: true,
+      },
+    }).catch(() => null)
+    createdNiches++
+  }
+
+  if (createdPlans > 0 || createdNiches > 0) {
+    console.log(`[bootstrap] PlanDefinition: ${createdPlans} criados; NicheTemplate: ${createdNiches} criados`)
+  }
+}

--- a/apps/web/src/app/(public)/HeroSearchForm.tsx
+++ b/apps/web/src/app/(public)/HeroSearchForm.tsx
@@ -181,6 +181,9 @@ export function HeroSearchForm() {
         <a href="/leiloes" className="px-4 py-2.5 rounded-full text-sm font-bold transition-all hover:scale-105" style={{ background: 'linear-gradient(135deg, #C9A84C, #e6c96a)', color: '#1B2B5B' }}>
           🏛️ Leilões
         </a>
+        <a href="/parceiros/planos" className="px-4 py-2.5 rounded-full text-sm font-bold transition-all hover:scale-105" style={{ backgroundColor: 'rgba(34,197,94,0.18)', color: 'white', border: '1px solid rgba(34,197,94,0.45)' }}>
+          🤝 Seja um Parceiro
+        </a>
       </div>
 
       {/* Mode toggle */}

--- a/apps/web/src/app/(public)/checkout/sucesso/page.tsx
+++ b/apps/web/src/app/(public)/checkout/sucesso/page.tsx
@@ -1,0 +1,148 @@
+/**
+ * Página de sucesso pós-checkout.
+ *
+ * O parceiro chega aqui depois de criar a assinatura. Mostra próximos
+ * passos claros: pagar no Asaas, conferir caixa de entrada para receber
+ * as credenciais, e link do site/painel. Quando o webhook do Asaas
+ * processar o pagamento, ele dispara o e-mail/WhatsApp com a senha.
+ */
+
+import Link from 'next/link'
+import { CheckCircle2, Mail, Smartphone, ExternalLink, Globe, LogIn } from 'lucide-react'
+
+export const metadata = {
+  title: 'Assinatura criada — AgoraEncontrei',
+  robots: { index: false, follow: false },
+}
+
+interface PageProps {
+  searchParams: Promise<{ ref?: string; payment?: string }>
+}
+
+export default async function CheckoutSuccessPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const subdomain = (params.ref || '').replace(/[^a-z0-9-]/g, '')
+  const siteUrl = subdomain ? `https://${subdomain}.agoraencontrei.com.br` : null
+  const paymentUrl = params.payment ? `https://www.asaas.com/c/${params.payment}` : null
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#1B2B5B] to-[#0f1c3a] py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
+          {/* Header */}
+          <div className="bg-gradient-to-r from-emerald-500 to-emerald-600 p-8 text-white text-center">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/20 mb-4">
+              <CheckCircle2 className="w-10 h-10" />
+            </div>
+            <h1 className="text-3xl font-bold mb-2">Assinatura criada!</h1>
+            <p className="text-emerald-50">
+              Falta um passo: confirmar o pagamento. Em seguida seu site fica no ar.
+            </p>
+          </div>
+
+          {/* Steps */}
+          <div className="p-8 space-y-6">
+            <Step
+              number={1}
+              done={false}
+              title="Pague no Asaas"
+              description="Boleto, PIX ou cartão. O link abre na nova aba."
+            >
+              {paymentUrl ? (
+                <a
+                  href={paymentUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 mt-2 px-4 py-2 rounded-lg bg-amber-600 hover:bg-amber-500 text-white font-medium text-sm"
+                >
+                  Ir para o pagamento <ExternalLink className="w-4 h-4" />
+                </a>
+              ) : (
+                <p className="text-sm text-gray-600 mt-2">
+                  Verifique seu e-mail — também enviamos o link de pagamento por lá.
+                </p>
+              )}
+            </Step>
+
+            <Step
+              number={2}
+              done={false}
+              title="Receba as credenciais"
+              description="Assim que o pagamento for confirmado pelo Asaas, enviamos o login e a senha temporária por:"
+            >
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                <li className="flex items-center gap-2"><Mail className="w-4 h-4 text-amber-600" /> E-mail cadastrado</li>
+                <li className="flex items-center gap-2"><Smartphone className="w-4 h-4 text-amber-600" /> WhatsApp (se informado)</li>
+              </ul>
+            </Step>
+
+            <Step
+              number={3}
+              done={false}
+              title="Acesse o painel e personalize"
+              description="No primeiro acesso troque a senha em Perfil → Segurança e edite tema, cor, logo e cadastre seus imóveis."
+            >
+              <Link
+                href="/login"
+                className="inline-flex items-center gap-2 mt-2 px-4 py-2 rounded-lg bg-[#1B2B5B] hover:bg-[#243b78] text-white font-medium text-sm"
+              >
+                <LogIn className="w-4 h-4" /> Ir para o login
+              </Link>
+            </Step>
+
+            {siteUrl && (
+              <div className="border-t border-gray-200 pt-6">
+                <p className="text-sm text-gray-600 mb-2">Seu site (estará no ar após confirmação do pagamento):</p>
+                <a
+                  href={siteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-amber-600 hover:text-amber-700 font-medium"
+                >
+                  <Globe className="w-4 h-4" /> {siteUrl} <ExternalLink className="w-3 h-3" />
+                </a>
+              </div>
+            )}
+          </div>
+
+          <div className="bg-gray-50 px-8 py-4 text-center text-xs text-gray-500">
+            Dúvidas? Responda o e-mail de boas-vindas ou chame no WhatsApp pelo site.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Step({
+  number,
+  done,
+  title,
+  description,
+  children,
+}: {
+  number: number
+  done: boolean
+  title: string
+  description: string
+  children?: React.ReactNode
+}) {
+  return (
+    <div className="flex gap-4">
+      <div
+        className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+          done
+            ? 'bg-emerald-500 text-white'
+            : 'bg-amber-100 text-amber-700 border-2 border-amber-600'
+        }`}
+      >
+        {done ? <CheckCircle2 className="w-5 h-5" /> : number}
+      </div>
+      <div className="flex-1">
+        <h3 className="font-semibold text-gray-900">{title}</h3>
+        <p className="text-sm text-gray-600 mt-0.5">{description}</p>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -606,7 +606,12 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* ── 3. PARCEIROS OFICIAIS ─────────────────────────────────────────── */}
+      {/* ── 3. PARCEIROS OFICIAIS — temporariamente oculto ───────────────────
+          Layout, conteúdo e estilo foram preservados. Para reexibir,
+          ativar a flag SiteSettings.partnersShowcaseEnabled no admin
+          (campo opcional; default = oculto).
+      */}
+      {siteSettings.partnersShowcaseEnabled === true && (
       <section className="max-w-6xl mx-auto px-4 sm:px-6 py-16">
         <div className="text-center mb-10">
           <p className="text-sm font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--site-accent-color, #C9A84C)' }}>
@@ -682,6 +687,7 @@ export default async function HomePage() {
           </Link>
         </div>
       </section>
+      )}
 
       {/* ── 4. CATEGORIAS (tipos de imóvel com ícones SVG profissionais) ──── */}
       <section style={{ backgroundColor: 'var(--site-background-color, #f8f6f1)' }} className="py-16">
@@ -878,8 +884,48 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* ── VÍDEO DE APRESENTAÇÃO (último antes do rodapé) ──────────────── */}
-      {(siteSettings.presentationVideoUrl || siteSettings.presentationBannerUrl) && (
+      {/* ── CTA SEJA UM PARCEIRO (antes do rodapé) ─────────────────────── */}
+      <section className="py-14 px-4 sm:px-6" style={{ backgroundColor: 'var(--site-primary-color, #1B2B5B)' }}>
+        <div className="max-w-4xl mx-auto rounded-3xl p-8 sm:p-12 text-center" style={{ background: 'linear-gradient(135deg, rgba(201,168,76,0.18), rgba(201,168,76,0.05))', border: '1px solid rgba(201,168,76,0.35)' }}>
+          <p className="text-xs sm:text-sm font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--site-accent-color, #C9A84C)' }}>
+            Para imobiliárias e corretores
+          </p>
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-3" style={{ fontFamily: 'Georgia, serif' }}>
+            Seja um Parceiro do AgoraEncontrei
+          </h2>
+          <p className="text-white/70 text-sm sm:text-base mb-6 max-w-2xl mx-auto leading-relaxed">
+            Tenha seu site profissional, CRM, IA do Tomás e marketplace integrado.
+            Anuncie seus imóveis com tecnologia de ponta e ganhe presença regional.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              href="/parceiros/planos"
+              className="px-7 py-3 rounded-xl text-sm font-bold transition-all hover:brightness-110 inline-flex items-center justify-center gap-2"
+              style={{ backgroundColor: 'var(--site-accent-color, #C9A84C)', color: 'var(--site-primary-color, #1B2B5B)' }}
+            >
+              Ver Planos e Assinar <ArrowRight className="w-4 h-4" />
+            </Link>
+            <a
+              href="https://wa.me/5516981010004?text=Olá! Gostaria de ser um parceiro do AgoraEncontrei e anunciar meus imóveis."
+              target="_blank"
+              rel="noreferrer"
+              className="px-7 py-3 rounded-xl text-sm font-bold border-2 text-white transition-all hover:bg-white/10 inline-flex items-center justify-center gap-2"
+              style={{ borderColor: 'rgba(201,168,76,0.5)' }}
+            >
+              Falar pelo WhatsApp
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* ── VÍDEO DE APRESENTAÇÃO — temporariamente oculto ──────────────────
+          Toda a configuração (vídeo, título, subtítulo, banner, link)
+          continua sendo lida do SiteSettings. Para reexibir, ative
+          SiteSettings.presentationEnabled no admin (default = oculto).
+          O fallback hardcoded da Imobiliária Lemos também é exibido só
+          quando a flag estiver ligada.
+      */}
+      {siteSettings.presentationEnabled === true && (siteSettings.presentationVideoUrl || siteSettings.presentationBannerUrl) && (
         <PresentationSection
           videoUrl={siteSettings.presentationVideoUrl ?? null}
           bannerUrl={siteSettings.presentationBannerUrl ?? null}
@@ -888,7 +934,7 @@ export default async function HomePage() {
           subtitle={siteSettings.presentationSubtitle ?? null}
         />
       )}
-      {!siteSettings.presentationVideoUrl && !siteSettings.presentationBannerUrl && (
+      {siteSettings.presentationEnabled === true && !siteSettings.presentationVideoUrl && !siteSettings.presentationBannerUrl && (
         <PresentationSection
           videoUrl="https://files.manuscdn.com/user_upload_by_module/session_file/310519663481419273/MbhJNDOYKAGxseOh.mp4"
           bannerUrl={null}

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -105,7 +105,35 @@ export function DynamicPlans() {
   const [checkoutForm, setCheckoutForm] = useState({
     name: '', email: '', cpfCnpj: '', phone: '',
     tenantName: '', subdomain: '', layoutType: 'urban_tech', primaryColor: '#d4a853',
+    nicheSlug: 'imobiliaria',
   })
+  // Check de disponibilidade do subdomínio em tempo real (debounce 400ms).
+  // Mostra ✓ verde se livre, X vermelho se ocupado/inválido.
+  const [subdomainStatus, setSubdomainStatus] = useState<
+    { state: 'idle' | 'checking' | 'available' | 'taken'; reason?: string }
+  >({ state: 'idle' })
+
+  useEffect(() => {
+    const sd = checkoutForm.subdomain
+    if (!sd || sd.length < 3) {
+      setSubdomainStatus({ state: 'idle' })
+      return
+    }
+    setSubdomainStatus({ state: 'checking' })
+    const t = setTimeout(async () => {
+      try {
+        const r = await fetch(
+          `${API_URL}/api/v1/tenants/check-subdomain?subdomain=${encodeURIComponent(sd)}`,
+        )
+        const d = await r.json()
+        if (d.available) setSubdomainStatus({ state: 'available' })
+        else setSubdomainStatus({ state: 'taken', reason: d.reason })
+      } catch {
+        setSubdomainStatus({ state: 'idle' })
+      }
+    }, 400)
+    return () => clearTimeout(t)
+  }, [checkoutForm.subdomain])
 
   useEffect(() => {
     fetch(`${API_URL}/api/v1/public/catalog`)
@@ -331,6 +359,13 @@ export function DynamicPlans() {
             <form
               onSubmit={async (e) => {
                 e.preventDefault()
+                if (subdomainStatus.state === 'taken') {
+                  setCheckoutError({
+                    message: subdomainStatus.reason || 'Subdomínio indisponível.',
+                    hint: 'Escolha outro subdomínio antes de continuar.',
+                  })
+                  return
+                }
                 setCheckoutLoading(true)
                 setCheckoutError(null)
                 try {
@@ -352,14 +387,22 @@ export function DynamicPlans() {
                         .replace(/[^a-z0-9-]/g, ''),
                       layoutType: checkoutForm.layoutType,
                       primaryColor: checkoutForm.primaryColor,
+                      nicheSlug: checkoutForm.nicheSlug,
                     }),
                   })
 
                   const data = await res.json()
 
                   if (res.ok && data.success) {
-                    // Redirect to Asaas payment page
-                    window.location.href = data.data.paymentUrl
+                    // Abre o pagamento Asaas em nova aba e leva o parceiro
+                    // pra página de sucesso com instruções (e-mail/whats já
+                    // entregam credenciais quando o pagamento confirmar).
+                    if (data.data.paymentUrl) {
+                      window.open(data.data.paymentUrl, '_blank', 'noopener,noreferrer')
+                    }
+                    const ref = encodeURIComponent(checkoutForm.subdomain.toLowerCase().replace(/[^a-z0-9-]/g, ''))
+                    const pay = encodeURIComponent(data.data.asaasSubscriptionId || '')
+                    window.location.href = `/checkout/sucesso?ref=${ref}${pay ? `&payment=${pay}` : ''}`
                   } else {
                     setCheckoutError({
                       message: data.message || data.error || 'Erro ao criar assinatura.',
@@ -475,7 +518,41 @@ export function DynamicPlans() {
                     .agoraencontrei.com.br
                   </span>
                 </div>
+                {subdomainStatus.state === 'checking' && (
+                  <p className="mt-1 text-[11px] text-gray-400">Verificando disponibilidade…</p>
+                )}
+                {subdomainStatus.state === 'available' && (
+                  <p className="mt-1 text-[11px] text-emerald-400">
+                    ✓ {checkoutForm.subdomain}.agoraencontrei.com.br está livre.
+                  </p>
+                )}
+                {subdomainStatus.state === 'taken' && (
+                  <p className="mt-1 text-[11px] text-red-400">
+                    ✕ {subdomainStatus.reason || 'Indisponível.'} Tente outro nome.
+                  </p>
+                )}
               </div>
+
+              {/* Nicho */}
+              {niches.length > 0 && (
+                <div>
+                  <label className="block text-xs sm:text-sm font-medium text-gray-300 mb-1">
+                    Nicho do seu negócio
+                  </label>
+                  <select
+                    value={checkoutForm.nicheSlug}
+                    onChange={(e) => setCheckoutForm(f => ({ ...f, nicheSlug: e.target.value }))}
+                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 sm:py-2.5 text-white text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent outline-none"
+                  >
+                    {niches.map(n => (
+                      <option key={n.id} value={n.slug}>{n.name}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-[11px] text-gray-500">
+                    Define como o Tomás IA conversa e quais filtros aparecem no seu site.
+                  </p>
+                </div>
+              )}
 
               {/* Layout + Color side by side */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -536,7 +613,7 @@ export function DynamicPlans() {
               {/* Submit */}
               <button
                 type="submit"
-                disabled={checkoutLoading}
+                disabled={checkoutLoading || subdomainStatus.state === 'taken' || subdomainStatus.state === 'checking'}
                 className="w-full py-2.5 sm:py-3 rounded-lg sm:rounded-xl font-bold text-xs sm:text-sm transition bg-amber-600 hover:bg-amber-500 text-gray-950 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 {checkoutLoading ? (


### PR DESCRIPTION
## Summary

Rebase em cima de `main` — os fixes de Zuk/alerts e Tomás/checkout-error já entraram em `main` (PRs anteriores). Restam **2 commits** novos.

### 1. Onboarding parceiro ponta a ponta (commit `f7bcf55`)

Antes: o checkout só criava `Tenant` em TRIAL. Depois do pagamento o parceiro ficava sem Company, sem User, sem CRM e sem como logar. E em produção o checkout falhava de cara com "Erro ao criar assinatura" porque a tabela `PlanDefinition` estava vazia.

Agora:
- **`bootstrap-plans.ts`** insere idempotentemente no boot do servidor:
  - `PlanDefinition` Lite (R$ 97), Pro (R$ 297), Enterprise (R$ 597) com features/módulos/temas.
  - `NicheTemplate` Imobiliária, Investidor de Leilões, Rural — define persona do Tomás, tom, item label e tema padrão.
- **`POST /api/v1/billing/saas/checkout`** reescrito:
  - Bloqueia e-mail já cadastrado antes de bater no Asaas (`EMAIL_IN_USE`).
  - Cria `Company` + `User` admin (argon2 hash) + `Tenant` (TRIAL) numa única `$transaction`.
  - Senha temporária guardada em `Tenant.settings.tempPasswordPlain` só até o webhook ativar.
  - Aceita `nicheSlug`, `layoutType`, `primaryColor`. Retorna `successUrl: /checkout/sucesso?ref=…&payment=…`.
- **Webhook `PAYMENT_CONFIRMED`** (`saas-webhook.ts`):
  - Ativa Tenant + Company numa transação (consistência garantida).
  - Apaga `tempPasswordPlain` do settings.
  - Em paralelo dispara e-mail HTML estilizado (SMTP) **+** WhatsApp Cloud API com login/senha/links — cada canal com `try/catch` isolado.
- **Página `/checkout/sucesso?ref=&payment=`** com 3 passos visuais: pagar → receber credenciais → logar. Mostra link do site, do painel e CTA pro Asaas.
- **DynamicPlans**: selector de nicho (lê `/public/catalog`), check de disponibilidade do subdomínio em tempo real (debounce 400ms, ✓/✕), submit bloqueado quando ocupado, abre Asaas em nova aba e redireciona para `/checkout/sucesso`.

### 2. Home: CTA de parceiro + ocultar showcase e vídeo (commit `0a8bac3`)

- Nova pill **`🤝 Seja um Parceiro`** no hero, depois de "Anunciar Imóveis" e "Leilões", levando para `/parceiros/planos`.
- Showcase **"Nossas Imobiliárias Parceiras"** (cards Imobiliária Lemos + Card "+") agora só renderiza quando `SiteSettings.partnersShowcaseEnabled === true`. Layout/copy/estilo 100% preservados — admin reativa quando quiser.
- Seção **"Conheça o nosso novo site"** (PresentationSection com vídeo da Lemos) também passa a depender de `SiteSettings.presentationEnabled === true`. Toda config (videoUrl, banner, título, subtítulo, link, fallback hardcoded) continua no código, só desativada por padrão.
- Novo **CTA "Seja um Parceiro"** antes do rodapé com gradient dourado, copy curta e dois botões: "Ver Planos e Assinar" + WhatsApp.

## Tokens a configurar amanhã

| Variável | O que destrava |
|----------|----------------|
| `ASAAS_API_KEY` | Checkout SaaS funcional (sandbox ou prod) |
| `ASAAS_WEBHOOK_SECRET` | Webhook de pagamento ativando o tenant |
| `SMTP_HOST` / `SMTP_USER` / `SMTP_PASS` / `SMTP_FROM` | E-mail de boas-vindas com credenciais |
| `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID` | WhatsApp de boas-vindas + confirmação de alerta |

E no painel do Asaas: configurar webhook apontando para `https://<api>/api/v1/webhooks/asaas` com header `asaas-access-token` igual ao `ASAAS_WEBHOOK_SECRET`.

## Test plan

- [ ] Boot do servidor cria PlanDefinition + NicheTemplate (verificar log `[bootstrap]`)
- [ ] Checkout Pro com `APIs key` configurada → ver `/checkout/sucesso`
- [ ] Pagar Asaas sandbox → confirmar webhook ativa Tenant+Company e dispara e-mail/WhatsApp com senha
- [ ] Logar com a senha temporária recebida → deve cair no painel da Company recém-criada
- [ ] Home: showcase Lemos e vídeo "Conheça o nosso novo site" ocultos por padrão
- [ ] Home: pill "Seja um Parceiro" no hero e CTA dourado antes do rodapé visíveis e funcionais
- [ ] Selector de nicho aparece no modal de checkout; check de subdomínio mostra ✓/✕ em tempo real

https://claude.ai/code/session_01NYRiv5de7s7ech8hRiNCpq