### PR TITLE
Pagamento de sinal por negociação via Asaas

### DIFF
--- a/apps/api/src/routes/deals/index.ts
+++ b/apps/api/src/routes/deals/index.ts
@@ -2,6 +2,9 @@ import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { emitAutomation } from '../../services/automation.emitter.js'
 import { createAuditLog } from '../../services/audit.service.js'
+import { env } from '../../utils/env.js'
+import { findOrCreateCustomer, createCharge, getPixQrCode, type AsaasBillingType } from '../../services/asaas.service.js'
+import { notify } from '../../services/notification.service.js'
 
 const toUpper = (v: unknown) => typeof v === 'string' ? v.toUpperCase() : v
 
@@ -333,5 +336,107 @@ export default async function dealsRoutes(app: FastifyInstance) {
     })
 
     return reply.send(updated)
+  })
+
+  // ── GET /:id/payments — pagamentos da negociação ───────────────────────
+  app.get('/:id/payments', { schema: { tags: ['deals'] } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const deal = await app.prisma.deal.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!deal) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const payments = await app.prisma.dealPayment.findMany({
+      where: { dealId: id },
+      orderBy: { createdAt: 'desc' },
+    })
+    return reply.send({ data: payments })
+  })
+
+  // ── POST /:id/payments/signal — gera cobrança de sinal via Asaas ───────
+  app.post('/:id/payments/signal', { schema: { tags: ['deals'] } }, async (req, reply) => {
+    if (!env.ASAAS_API_KEY) {
+      return reply.status(503).send({
+        error: 'ASAAS_NOT_CONFIGURED',
+        message: 'A integração de pagamento (Asaas) não está configurada.',
+      })
+    }
+    const { id } = req.params as { id: string }
+    const body = z.object({
+      amount:      z.number().positive(),
+      billingType: z.enum(['PIX', 'BOLETO', 'CREDIT_CARD', 'UNDEFINED']).default('PIX'),
+      dueDate:     z.string().optional(),
+      cpfCnpj:     z.string().optional(),
+      type:        z.enum(['signal', 'installment', 'balance', 'other']).default('signal'),
+    }).parse(req.body)
+
+    const deal = await app.prisma.deal.findFirst({
+      where: { id, companyId: req.user.cid },
+      include: { contact: true },
+    })
+    if (!deal) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (!deal.contact) {
+      return reply.status(400).send({ error: 'NO_CONTACT', message: 'A negociação precisa de um contato (comprador).' })
+    }
+
+    const cpfCnpj = (body.cpfCnpj || (deal.contact as any).cpf || '').replace(/\D/g, '')
+    if (cpfCnpj.length !== 11 && cpfCnpj.length !== 14) {
+      return reply.status(400).send({ error: 'INVALID_CPF', message: 'Informe um CPF/CNPJ válido do comprador.' })
+    }
+
+    const due = body.dueDate ? new Date(body.dueDate) : new Date(Date.now() + 3 * 86_400_000)
+    const dueDate = due.toISOString().split('T')[0]
+
+    try {
+      const customer = await findOrCreateCustomer({
+        name: deal.contact.name,
+        cpfCnpj,
+        email: deal.contact.email ?? undefined,
+        phone: deal.contact.phone ?? undefined,
+      })
+      const charge = await createCharge({
+        customer: customer.id,
+        billingType: body.billingType as AsaasBillingType,
+        value: body.amount,
+        dueDate,
+        description: `Sinal — negociação "${deal.title}"`,
+        externalReference: `deal:${deal.id}`,
+      })
+
+      let pixPayload: string | null = null
+      if (body.billingType === 'PIX') {
+        pixPayload = await getPixQrCode(charge.id).then(r => r.payload).catch(() => null)
+      }
+
+      const payment = await app.prisma.dealPayment.create({
+        data: {
+          dealId: deal.id,
+          companyId: req.user.cid,
+          type: body.type,
+          amount: body.amount,
+          billingType: body.billingType,
+          status: 'pending',
+          asaasChargeId: charge.id,
+          invoiceUrl: charge.invoiceUrl ?? charge.bankSlipUrl ?? null,
+          pixPayload,
+          dueDate: due,
+        },
+      })
+
+      return reply.status(201).send({
+        success: true,
+        data: {
+          paymentId: payment.id,
+          asaasChargeId: charge.id,
+          invoiceUrl: payment.invoiceUrl,
+          pixPayload,
+          amount: body.amount,
+          dueDate,
+        },
+      })
+    } catch (err: any) {
+      app.log.error({ err }, `[deals] signal payment failed: ${err?.message}`)
+      return reply.status(502).send({
+        error: 'CHARGE_FAILED',
+        message: 'Não foi possível gerar a cobrança. Confira os dados e tente novamente.',
+      })
+    }
   })
 }

--- a/apps/api/src/routes/finance/webhook.ts
+++ b/apps/api/src/routes/finance/webhook.ts
@@ -16,6 +16,7 @@ import { env } from '../../utils/env.js'
 import type { AsaasWebhookEvent } from '../../services/asaas.service.js'
 import { scheduleRepasse } from '../../services/repasse.service.js'
 import { safeStringEqual } from '../../utils/crypto-safe.js'
+import { notify } from '../../services/notification.service.js'
 
 function isUniqueConstraintError(err: any): boolean {
   return err?.code === 'P2002'
@@ -242,6 +243,47 @@ export default async function asaasWebhookRoutes(app: FastifyInstance) {
               }
 
               app.log.info(`[asaas-webhook] Rental ${rentalId} marked as PAID (${payment.billingType}, R$ ${payment.value})`)
+            }
+          }
+
+          // Deal sinal payment — mark received and advance the Transaction Hub.
+          {
+            const dealPayment = await app.prisma.dealPayment.findUnique({
+              where: { asaasChargeId: payment.id },
+            }).catch(() => null)
+            if (dealPayment && dealPayment.status !== 'received') {
+              await app.prisma.dealPayment.update({
+                where: { id: dealPayment.id },
+                data: {
+                  status: 'received',
+                  paidAt: payment.confirmedDate ? new Date(payment.confirmedDate) : new Date(),
+                },
+              }).catch(() => {})
+
+              const deal = await app.prisma.deal.findUnique({ where: { id: dealPayment.dealId } }).catch(() => null)
+              if (deal) {
+                // Advance the Transaction Hub to "sinal" once the signal is paid.
+                const meta = (deal.metadata as Record<string, unknown>) ?? {}
+                const tx = (meta.transaction as Record<string, unknown>) ?? {}
+                const ORDER = ['lead', 'proposta', 'kyc', 'sinal']
+                const cur = (tx.stage as string) ?? 'lead'
+                if (dealPayment.type === 'signal' && ORDER.includes(cur)) {
+                  await app.prisma.deal.update({
+                    where: { id: deal.id },
+                    data: { metadata: { ...meta, transaction: { ...tx, stage: 'sinal' } } },
+                  }).catch(() => {})
+                }
+                await notify({
+                  prisma: app.prisma,
+                  companyId: deal.companyId,
+                  type: 'proposal_received',
+                  title: `Sinal pago — negociação "${deal.title}"`,
+                  body: `Pagamento de R$ ${Number(payment.value ?? dealPayment.amount).toLocaleString('pt-BR')} confirmado.`,
+                  payload: { dealId: deal.id, dealPaymentId: dealPayment.id },
+                  email: false,
+                }).catch(() => {})
+              }
+              app.log.info(`[asaas-webhook] DealPayment ${dealPayment.id} marked received`)
             }
           }
           break

--- a/apps/web/src/app/(dashboard)/dashboard/deals/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/deals/[id]/page.tsx
@@ -16,6 +16,16 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+const PAYMENT_STATUS: Record<string, string> = {
+  pending:   'bg-yellow-500/20 text-yellow-400',
+  received:  'bg-emerald-500/20 text-emerald-400',
+  overdue:   'bg-red-500/20 text-red-400',
+  refunded:  'bg-white/10 text-white/50',
+  cancelled: 'bg-white/10 text-white/50',
+}
+
 const STATUS_MAP: Record<string, string> = {
   OPEN:        'bg-white/10 text-white/60',
   IN_PROGRESS: 'bg-blue-500/20 text-blue-400',
@@ -95,6 +105,8 @@ export default function DealDetailPage() {
   const [showCommForm, setShowCommForm] = useState(false)
   const [commRate, setCommRate] = useState('6')
   const [commSplit, setCommSplit] = useState('100')
+  const [signalAmount, setSignalAmount] = useState('')
+  const [signalType, setSignalType] = useState('PIX')
 
   const canManageComm = ['SUPER_ADMIN','ADMIN','MANAGER','FINANCIAL'].includes(user?.role ?? '')
 
@@ -130,6 +142,36 @@ export default function DealDetailPage() {
       })
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['deal', id] }),
+  })
+
+  const paymentsQuery = useQuery({
+    queryKey: ['deal-payments', id],
+    queryFn: async () => {
+      const token = await getValidToken()
+      const res = await fetch(`${API_URL}/api/v1/deals/${id}/payments`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) return { data: [] as any[] }
+      return res.json() as Promise<{ data: any[] }>
+    },
+  })
+
+  const signalMutation = useMutation({
+    mutationFn: async (vars: { amount: number; billingType: string }) => {
+      const token = await getValidToken()
+      const res = await fetch(`${API_URL}/api/v1/deals/${id}/payments/signal`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(vars),
+      })
+      const j = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(j.message || 'Falha ao gerar cobrança')
+      return j
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['deal-payments', id] })
+      setSignalAmount('')
+    },
   })
 
   const stageMutation = useMutation({
@@ -327,6 +369,66 @@ export default function DealDetailPage() {
                   : 'Conclua o checklist desta etapa para avançar.'}
               </p>
             )}
+          </div>
+
+          {/* Pagamentos / Sinal */}
+          <div className="bg-white/5 rounded-xl border border-white/10 p-4">
+            <h3 className="text-xs font-semibold text-white/40 uppercase tracking-wider mb-2">
+              Pagamentos
+            </h3>
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Label className="text-xs text-white/50">Valor do sinal (R$)</Label>
+                <Input
+                  value={signalAmount} onChange={(e) => setSignalAmount(e.target.value)}
+                  type="number" placeholder="Ex: 25000"
+                  className="bg-white/5 border-white/10 text-white text-sm h-8"
+                />
+              </div>
+              <Select value={signalType} onValueChange={setSignalType}>
+                <SelectTrigger className="w-24 bg-white/5 border-white/10 text-white text-xs h-8">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[['PIX', 'Pix'], ['BOLETO', 'Boleto'], ['CREDIT_CARD', 'Cartão']].map(([v, l]) => (
+                    <SelectItem key={v} value={v}>{l}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                size="sm" className="h-8 text-xs"
+                disabled={!signalAmount || Number(signalAmount) <= 0 || signalMutation.isPending}
+                onClick={() => signalMutation.mutate({ amount: Number(signalAmount), billingType: signalType })}
+              >
+                Gerar cobrança
+              </Button>
+            </div>
+            {signalMutation.isError && (
+              <p className="mt-1 text-xs text-red-400">{(signalMutation.error as Error).message}</p>
+            )}
+
+            <div className="mt-3 space-y-1.5">
+              {(paymentsQuery.data?.data ?? []).length === 0 && (
+                <p className="text-xs text-white/40">Nenhuma cobrança gerada.</p>
+              )}
+              {(paymentsQuery.data?.data ?? []).map((pay: any) => (
+                <div key={pay.id} className="flex items-center justify-between border-t border-white/5 pt-1.5">
+                  <div>
+                    <p className="text-sm text-white">{fmt(Number(pay.amount))}</p>
+                    <p className="text-[10px] text-white/40">{pay.billingType} · {pay.type}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {pay.invoiceUrl && (
+                      <a href={pay.invoiceUrl} target="_blank" rel="noopener noreferrer"
+                        className="text-[11px] text-yellow-400 hover:underline">cobrança</a>
+                    )}
+                    <Badge className={cn('border-0 text-xs', PAYMENT_STATUS[pay.status] ?? 'bg-white/10')}>
+                      {pay.status}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
 
           {/* Properties */}

--- a/packages/database/prisma/migrations/20260519000006_deal_payments/migration.sql
+++ b/packages/database/prisma/migrations/20260519000006_deal_payments/migration.sql
@@ -1,0 +1,23 @@
+-- Pagamentos da negociação (sinal/parcelas via Asaas)
+CREATE TABLE "deal_payments" (
+    "id"            TEXT NOT NULL,
+    "dealId"        TEXT NOT NULL,
+    "companyId"     TEXT NOT NULL,
+    "type"          TEXT NOT NULL DEFAULT 'signal',
+    "amount"        DECIMAL(14,2) NOT NULL,
+    "billingType"   TEXT NOT NULL DEFAULT 'UNDEFINED',
+    "status"        TEXT NOT NULL DEFAULT 'pending',
+    "asaasChargeId" TEXT,
+    "invoiceUrl"    TEXT,
+    "pixPayload"    TEXT,
+    "dueDate"       TIMESTAMP(3),
+    "paidAt"        TIMESTAMP(3),
+    "metadata"      JSONB NOT NULL DEFAULT '{}',
+    "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"     TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "deal_payments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "deal_payments_asaasChargeId_key" ON "deal_payments"("asaasChargeId");
+CREATE INDEX "deal_payments_dealId_idx" ON "deal_payments"("dealId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3321,3 +3321,33 @@ model LoteReserva {
   @@index([status, expiresAt])
   @@map("lote_reservas")
 }
+
+// =============================================================================
+// DEAL PAYMENTS — sinal e pagamentos da negociação (Asaas)
+// =============================================================================
+
+/// Cobrança vinculada a uma negociação (sinal, parcela, saldo). Criada via
+/// Asaas; o webhook atualiza o status e avança a etapa do Transaction Hub.
+model DealPayment {
+  id            String    @id @default(cuid())
+  dealId        String
+  companyId     String
+  /// signal | installment | balance | other
+  type          String    @default("signal")
+  amount        Decimal   @db.Decimal(14, 2)
+  /// PIX | BOLETO | CREDIT_CARD | UNDEFINED
+  billingType   String    @default("UNDEFINED")
+  /// pending | received | overdue | refunded | cancelled
+  status        String    @default("pending")
+  asaasChargeId String?   @unique
+  invoiceUrl    String?
+  pixPayload    String?
+  dueDate       DateTime?
+  paidAt        DateTime?
+  metadata      Json      @default("{}")
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([dealId])
+  @@map("deal_payments")
+}


### PR DESCRIPTION
## Resumo

Pagamento de sinal por negociação via Asaas (§3/§6 do plano do Transaction Hub).

- Modelo `DealPayment` (+ migration) — cobrança vinculada à negociação (sinal, parcela, saldo).
- `POST /api/v1/deals/:id/payments/signal` — gera cobrança Pix/boleto/cartão via Asaas para o comprador (contato da negociação), com `externalReference: deal:<id>`.
- `GET /api/v1/deals/:id/payments` — lista os pagamentos da negociação.
- O **webhook do Asaas** (`PAYMENT_RECEIVED`/`CONFIRMED`) agora marca o `DealPayment` como recebido, **avança o Transaction Hub para a etapa "Sinal"** e notifica a imobiliária.
- Página da negociação ganha o card **Pagamentos** — gerar a cobrança (valor + Pix/boleto/cartão) e acompanhar o status com link da fatura.

## ⚠️ Migration

Nova migration no deploy: `20260519000006_deal_payments`.

## Test plan

- [ ] `pnpm typecheck` (API + Web) passa
- [ ] `prisma migrate deploy` aplica `deal_payments`
- [ ] Numa negociação com contato (com CPF), gerar cobrança de sinal
- [ ] Conferir o `DealPayment` criado (status `pending`) e o link da fatura
- [ ] Simular `PAYMENT_RECEIVED` no webhook Asaas → pagamento vira `received`, Transaction Hub avança para "Sinal", notificação criada

https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_