### PR TITLE
Agenda inteligente de visitas — gestão e feedback

### DIFF
--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -58,6 +58,21 @@ export default async function visitRoutes(app: FastifyInstance) {
       },
     })
 
+    // Structured visit record so the dashboard agenda can manage status,
+    // confirmation and post-visit feedback (separate from the free-form Activity).
+    await app.prisma.propertyVisit.create({
+      data: {
+        companyId,
+        propertyId: body.propertyId,
+        visitorName: body.name,
+        visitorEmail: body.email ?? null,
+        visitorPhone: body.phone,
+        scheduledAt: visitDateTime,
+        mode: 'in_person',
+        notes: body.notes ?? null,
+      },
+    }).catch(() => {})
+
     // 3. Create a Deal (lead pipeline) if not exists
     const existingDeal = await app.prisma.deal.findFirst({
       where: {

--- a/apps/api/src/routes/visits/index.ts
+++ b/apps/api/src/routes/visits/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Property Visits — agenda de visitas no dashboard.
+ *
+ * GET   /api/v1/visits          — lista visitas da empresa (filtros)
+ * PATCH /api/v1/visits/:id      — atualiza status/responsável/feedback
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+
+export default async function visitsRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+
+  app.get('/', { schema: { tags: ['visits'] } }, async (req, reply) => {
+    const q = req.query as { status?: string; from?: string; limit?: string }
+    const take = Math.min(Number(q.limit) || 100, 500)
+
+    const visits = await app.prisma.propertyVisit.findMany({
+      where: {
+        companyId: req.user.cid,
+        ...(q.status && { status: q.status }),
+        ...(q.from && { scheduledAt: { gte: new Date(q.from) } }),
+      },
+      orderBy: { scheduledAt: 'asc' },
+      take,
+    })
+
+    // Anexa o título/slug do imóvel e o nome do corretor responsável (se houver).
+    const propertyIds = [...new Set(visits.map(v => v.propertyId))]
+    const brokerIds = [...new Set(visits.map(v => v.brokerId).filter((b): b is string => !!b))]
+
+    const [properties, brokers] = await Promise.all([
+      app.prisma.property.findMany({
+        where: { id: { in: propertyIds } },
+        select: { id: true, title: true, slug: true, coverImage: true, neighborhood: true, city: true },
+      }).catch(() => []),
+      brokerIds.length
+        ? app.prisma.user.findMany({
+            where: { id: { in: brokerIds } },
+            select: { id: true, name: true, avatarUrl: true },
+          }).catch(() => [])
+        : Promise.resolve([]),
+    ])
+
+    const pById = new Map(properties.map(p => [p.id, p]))
+    const bById = new Map(brokers.map(b => [b.id, b]))
+
+    return reply.send({
+      data: visits.map(v => ({
+        ...v,
+        property: pById.get(v.propertyId) ?? null,
+        broker: v.brokerId ? bById.get(v.brokerId) ?? null : null,
+      })),
+    })
+  })
+
+  app.patch('/:id', { schema: { tags: ['visits'] } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const body = z.object({
+      status:      z.enum(['pending', 'confirmed', 'done', 'cancelled', 'no_show']).optional(),
+      brokerId:    z.string().optional().nullable(),
+      scheduledAt: z.string().optional(),
+      mode:        z.enum(['in_person', 'video']).optional(),
+      notes:       z.string().max(2000).optional(),
+      rating:      z.number().int().min(1).max(5).optional(),
+      feedback:    z.string().max(2000).optional(),
+    }).parse(req.body)
+
+    const visit = await app.prisma.propertyVisit.findFirst({
+      where: { id, companyId: req.user.cid },
+    })
+    if (!visit) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const updated = await app.prisma.propertyVisit.update({
+      where: { id },
+      data: {
+        ...(body.status !== undefined && { status: body.status }),
+        ...(body.brokerId !== undefined && { brokerId: body.brokerId }),
+        ...(body.scheduledAt !== undefined && { scheduledAt: new Date(body.scheduledAt) }),
+        ...(body.mode !== undefined && { mode: body.mode }),
+        ...(body.notes !== undefined && { notes: body.notes }),
+        ...(body.rating !== undefined && { rating: body.rating }),
+        ...(body.feedback !== undefined && { feedback: body.feedback }),
+      },
+    })
+    return reply.send({ data: updated })
+  })
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -100,6 +100,7 @@ import publicApiRoutes from './routes/public-api/index.js'
 import outgoingWebhooksRoutes from './routes/outgoing-webhooks/index.js'
 import marketRoutes from './routes/market/index.js'
 import systemEventsRoutes from './routes/system-events/index.js'
+import visitsRoutes from './routes/visits/index.js'
 import hunterRoutes from './routes/hunter/index.js'
 import affiliateRoutes from './routes/affiliates/index.js'
 import saasFinanceRoutes from './routes/saas-finance/index.js'
@@ -842,6 +843,7 @@ async function bootstrap() {
   await app.register(outgoingWebhooksRoutes, { prefix: '/api/v1/webhooks' })
   await app.register(marketRoutes,           { prefix: '/api/v1/market' })
   await app.register(systemEventsRoutes,     { prefix: '/api/v1/system-events' })
+  await app.register(visitsRoutes,           { prefix: '/api/v1/visits' })
   await app.register(publicApiRoutes,        { prefix: '/public-api' })
   await app.register(hunterRoutes,           { prefix: '/api/v1/hunter' })
   await app.register(affiliateRoutes,        { prefix: '/api/v1/affiliates' })

--- a/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { Calendar, Loader2, RefreshCw, Check, X, Phone, MessageCircle, Star } from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface Visit {
+  id: string
+  visitorName: string; visitorEmail: string | null; visitorPhone: string
+  scheduledAt: string; mode: string; status: string
+  notes: string | null; rating: number | null; feedback: string | null
+  property: { id: string; title: string; slug: string | null; neighborhood: string | null; city: string | null } | null
+  broker: { id: string; name: string; avatarUrl: string | null } | null
+}
+
+const STATUS: Record<string, { label: string; cls: string }> = {
+  pending:   { label: 'Pendente',   cls: 'bg-yellow-500/15 text-yellow-300' },
+  confirmed: { label: 'Confirmada', cls: 'bg-blue-500/15 text-blue-300' },
+  done:      { label: 'Realizada',  cls: 'bg-emerald-500/15 text-emerald-300' },
+  cancelled: { label: 'Cancelada',  cls: 'bg-gray-500/15 text-gray-400' },
+  no_show:   { label: 'Não compareceu', cls: 'bg-red-500/15 text-red-300' },
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit', hour: '2-digit', minute: '2-digit' })
+}
+
+export default function AgendaPage() {
+  const { getValidToken } = useAuth()
+  const [visits, setVisits] = useState<Visit[]>([])
+  const [loading, setLoading] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [busy, setBusy] = useState<string | null>(null)
+  const [feedbackFor, setFeedbackFor] = useState<string | null>(null)
+  const [rating, setRating] = useState(5)
+  const [fbText, setFbText] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const token = await getValidToken()
+      const q = new URLSearchParams()
+      if (filter) q.set('status', filter)
+      const res = await fetch(`${API_URL}/api/v1/visits?${q}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      setVisits(j.data ?? [])
+    } catch { setVisits([]) }
+    finally { setLoading(false) }
+  }, [filter, getValidToken])
+
+  useEffect(() => { load() }, [load])
+
+  async function patch(id: string, data: Record<string, unknown>) {
+    setBusy(id)
+    try {
+      const token = await getValidToken()
+      await fetch(`${API_URL}/api/v1/visits/${id}`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      await load()
+    } finally { setBusy(null) }
+  }
+
+  async function submitFeedback() {
+    if (!feedbackFor) return
+    await patch(feedbackFor, { status: 'done', rating, feedback: fbText })
+    setFeedbackFor(null); setRating(5); setFbText('')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <div className="border-b border-gray-800">
+        <div className="mx-auto max-w-6xl px-4 py-4 sm:py-6 sm:px-6 flex items-center gap-3">
+          <Calendar size={24} className="text-amber-400" />
+          <div className="flex-1 min-w-0">
+            <h1 className="text-lg sm:text-2xl font-bold">Agenda de visitas</h1>
+            <p className="mt-0.5 text-xs sm:text-sm text-gray-400">
+              Confirme, acompanhe e colete feedback das visitas agendadas pelo site
+            </p>
+          </div>
+          <button onClick={load}
+            className="flex items-center gap-1.5 rounded-lg border border-gray-700 px-3 py-2 text-xs text-gray-300 hover:bg-gray-800">
+            <RefreshCw size={13} />
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-6xl px-4 py-5 sm:px-6 space-y-4">
+        {/* Filters */}
+        <div className="flex flex-wrap gap-1">
+          {[['', 'Todas'], ['pending', 'Pendentes'], ['confirmed', 'Confirmadas'], ['done', 'Realizadas'], ['cancelled', 'Canceladas']]
+            .map(([v, l]) => (
+            <button key={v} onClick={() => setFilter(v)}
+              className={`rounded-full px-3 py-1 text-xs ${filter === v ? 'bg-amber-600 text-white' : 'bg-gray-900 text-gray-400 hover:text-white'}`}>
+              {l}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-10"><Loader2 className="animate-spin text-amber-400" /></div>
+        ) : visits.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-600">Nenhuma visita.</p>
+        ) : (
+          <div className="space-y-2">
+            {visits.map(v => {
+              const s = STATUS[v.status] ?? STATUS.pending
+              const busyThis = busy === v.id
+              const phoneClean = v.visitorPhone.replace(/\D/g, '')
+              return (
+                <div key={v.id} className="rounded-xl border border-gray-800 bg-gray-900/40 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold text-white">{v.visitorName}</span>
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${s.cls}`}>{s.label}</span>
+                        <span className="text-[10px] text-gray-500">{v.mode === 'video' ? 'Por vídeo' : 'Presencial'}</span>
+                      </div>
+                      <p className="text-xs text-gray-400 mt-0.5">
+                        {fmtDate(v.scheduledAt)} ·{' '}
+                        {v.property ? (
+                          <Link href={`/imoveis/${v.property.slug ?? v.property.id}`} className="hover:text-amber-400">
+                            {v.property.title}
+                          </Link>
+                        ) : 'Imóvel removido'}
+                        {v.property?.neighborhood && <span className="text-gray-600"> · {v.property.neighborhood}</span>}
+                      </p>
+                      {v.notes && <p className="mt-1 text-xs text-gray-500 italic">"{v.notes}"</p>}
+                      {v.feedback && (
+                        <div className="mt-1 text-xs text-emerald-300">
+                          <span className="font-semibold">Feedback: </span>
+                          {v.rating && <span>{'★'.repeat(v.rating)}{'☆'.repeat(5 - v.rating)} </span>}
+                          {v.feedback}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <a href={`https://wa.me/55${phoneClean}`} target="_blank" rel="noopener noreferrer"
+                        className="text-emerald-400 hover:text-emerald-300" title="WhatsApp">
+                        <MessageCircle size={16} />
+                      </a>
+                      <a href={`tel:${phoneClean}`} className="text-gray-400 hover:text-white" title="Ligar">
+                        <Phone size={16} />
+                      </a>
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  {v.status === 'pending' || v.status === 'confirmed' ? (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {v.status === 'pending' && (
+                        <button onClick={() => patch(v.id, { status: 'confirmed' })} disabled={busyThis}
+                          className="flex items-center gap-1 rounded-md border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs text-blue-300 hover:bg-blue-500/20 disabled:opacity-50">
+                          <Check size={12} /> Confirmar
+                        </button>
+                      )}
+                      <button onClick={() => { setFeedbackFor(v.id); setRating(5); setFbText('') }}
+                        disabled={busyThis}
+                        className="flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-50">
+                        <Star size={12} /> Marcar realizada
+                      </button>
+                      <button onClick={() => patch(v.id, { status: 'cancelled' })} disabled={busyThis}
+                        className="flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-400 hover:bg-gray-800 disabled:opacity-50">
+                        <X size={12} /> Cancelar
+                      </button>
+                    </div>
+                  ) : null}
+
+                  {/* Feedback form */}
+                  {feedbackFor === v.id && (
+                    <div className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-3 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-emerald-200">Avaliação:</span>
+                        {[1, 2, 3, 4, 5].map(n => (
+                          <button key={n} onClick={() => setRating(n)}
+                            className={`text-lg ${n <= rating ? 'text-yellow-400' : 'text-gray-600'}`}>
+                            ★
+                          </button>
+                        ))}
+                      </div>
+                      <textarea value={fbText} onChange={(e) => setFbText(e.target.value)}
+                        placeholder="Feedback do cliente (gostou? fez proposta? quer ver opções parecidas?)"
+                        rows={2}
+                        className="w-full rounded-md border border-gray-700 bg-gray-950 px-2 py-1.5 text-xs text-white" />
+                      <div className="flex gap-2">
+                        <button onClick={submitFeedback}
+                          className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-500">
+                          Salvar
+                        </button>
+                        <button onClick={() => setFeedbackFor(null)}
+                          className="rounded-md border border-gray-700 px-3 py-1 text-xs text-gray-400 hover:bg-gray-800">
+                          Cancelar
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -55,6 +55,7 @@ import {
   LandPlot,
   Brain,
   Clapperboard,
+  Calendar,
 } from 'lucide-react'
 import { useNotifications } from '@/stores/notifications.store'
 import { UserAvatar } from '@/components/ui/UserAvatar'
@@ -71,6 +72,7 @@ const midNavItems = [
   { href: '/dashboard/leads',               icon: UserCheck,        label: 'Leads',         highlight: false },
   { href: '/dashboard/contacts',            icon: Users,            label: 'Contatos',      highlight: false },
   { href: '/dashboard/deals',               icon: TrendingUp,       label: 'Negócios',      highlight: false },
+  { href: '/dashboard/agenda',              icon: Calendar,         label: 'Agenda de Visitas', highlight: false },
   { href: '/dashboard/inbox',               icon: MessageCircle,    label: 'Lemos.chat',    highlight: false },
   { href: '/dashboard/financiamentos',      icon: Landmark,         label: 'Financiamentos',highlight: false },
   { href: '/dashboard/portals',             icon: Globe,            label: 'Portais',       highlight: false },

--- a/packages/database/prisma/migrations/20260519000012_property_visits/migration.sql
+++ b/packages/database/prisma/migrations/20260519000012_property_visits/migration.sql
@@ -1,0 +1,24 @@
+-- Agenda de visitas a imóveis (PropertyVisit)
+CREATE TABLE "property_visits" (
+    "id"           TEXT NOT NULL,
+    "companyId"    TEXT NOT NULL,
+    "propertyId"   TEXT NOT NULL,
+    "brokerId"     TEXT,
+    "visitorName"  TEXT NOT NULL,
+    "visitorEmail" TEXT,
+    "visitorPhone" TEXT NOT NULL,
+    "scheduledAt"  TIMESTAMP(3) NOT NULL,
+    "mode"         TEXT NOT NULL DEFAULT 'in_person',
+    "status"       TEXT NOT NULL DEFAULT 'pending',
+    "notes"        TEXT,
+    "rating"       INTEGER,
+    "feedback"     TEXT,
+    "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"    TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "property_visits_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "property_visits_companyId_scheduledAt_idx" ON "property_visits"("companyId", "scheduledAt");
+CREATE INDEX "property_visits_propertyId_idx" ON "property_visits"("propertyId");
+CREATE INDEX "property_visits_status_idx" ON "property_visits"("status");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3487,3 +3487,36 @@ model SystemEvent {
   @@index([processed])
   @@map("system_events")
 }
+
+// =============================================================================
+// PROPERTY VISITS — agenda inteligente de visitas
+// =============================================================================
+
+/// Visita agendada a um imóvel pelo site público. Distinto do PropertyTour
+/// (que é tour virtual). Aqui ficam visitas presenciais ou por vídeo, com
+/// status workflow e feedback pós-visita.
+model PropertyVisit {
+  id           String   @id @default(cuid())
+  companyId    String
+  propertyId   String
+  brokerId     String?
+  visitorName  String
+  visitorEmail String?
+  visitorPhone String
+  scheduledAt  DateTime
+  /// in_person | video
+  mode         String   @default("in_person")
+  /// pending | confirmed | done | cancelled | no_show
+  status       String   @default("pending")
+  notes        String?
+  /// 1-5 — coletado após a visita
+  rating       Int?
+  feedback     String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([companyId, scheduledAt])
+  @@index([propertyId])
+  @@index([status])
+  @@map("property_visits")
+}


### PR DESCRIPTION
## Summary

A página pública de imóvel já agendava visita via `POST /api/v1/public/visits` (criando um Contact + Activity), mas o corretor não tinha **onde gerenciar** essas visitas no dashboard — só apareciam misturadas na timeline livre.

Este PR fecha o ciclo com uma agenda estruturada:

- **Modelo `PropertyVisit`** com status (`pending → confirmed → done / cancelled / no_show`), modo (presencial / vídeo), responsável (`brokerId`), avaliação 1-5 e feedback textual pós-visita
- **Rota pública `POST /public/visits` aprimorada** — agora grava o `PropertyVisit` ao lado da `Activity` (sem quebrar nada existente)
- **Novo CRUD `/api/v1/visits`** (auth-protegido, escopado por `companyId`):
  - `GET` com filtros `status` / `from` / `limit` e enrich com `property` (título, slug, bairro) + `broker` (nome, avatar)
  - `PATCH /:id` para mudar status, atribuir responsável, reagendar, adicionar notas, rating e feedback
- **Página `/dashboard/agenda`** (Next.js, dark theme, mobile-friendly):
  - Chips de filtro (Todas / Pendentes / Confirmadas / Realizadas / Canceladas)
  - Cards de visita com status badge, link para o imóvel, observação do cliente, modo (presencial / vídeo)
  - Botões de ação rápida: **Confirmar**, **Marcar realizada**, **Cancelar**
  - Atalhos rápidos **WhatsApp** e **telefone** do visitante
  - Formulário inline de feedback: 1-5 estrelas + textarea, salva como `{ status: 'done', rating, feedback }`
- **Sidebar**: nova entrada "Agenda de Visitas" (ícone Calendar) entre Negócios e Lemos.chat

## Test plan

- [ ] Agendar visita no site público (modal `ScheduleVisitModal`) e verificar que aparece em `/dashboard/agenda` com status `pending`
- [ ] Confirmar a visita pelo dashboard → status muda para `confirmed`
- [ ] Marcar como realizada com 5 estrelas + feedback → status `done`, dados de avaliação persistem e aparecem no card
- [ ] Cancelar visita → status `cancelled`
- [ ] Filtros por status filtram corretamente
- [ ] Atalho WhatsApp abre `wa.me/55<phone>` em nova aba
- [ ] Visita de outra empresa NÃO aparece (isolamento por `companyId`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_