### PR TITLE
Visitas: pedido de feedback pós-visita automatizado

### DIFF
--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -169,4 +169,72 @@ export default async function visitRoutes(app: FastifyInstance) {
 
     return reply.send({ success: true, activityId: activity.id, contactId: contact.id })
   })
+
+  // GET /api/v1/public/visits/:id/feedback — fetch visit info for the public
+  // feedback page (only returns the bare minimum needed to render the form).
+  app.get('/:id/feedback', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const visit = await app.prisma.propertyVisit.findUnique({
+      where: { id },
+      select: {
+        id: true, visitorName: true, scheduledAt: true,
+        status: true, rating: true, propertyId: true,
+      },
+    }).catch(() => null)
+    if (!visit) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const prop = await app.prisma.property.findUnique({
+      where: { id: visit.propertyId },
+      select: { title: true, slug: true, neighborhood: true, city: true },
+    }).catch(() => null)
+
+    return reply.send({
+      id: visit.id,
+      visitorName: visit.visitorName,
+      scheduledAt: visit.scheduledAt,
+      status: visit.status,
+      alreadyRated: visit.rating != null,
+      property: prop,
+    })
+  })
+
+  // POST /api/v1/public/visits/:id/feedback — visitor submits rating + comment.
+  // Only accepted when the visit is marked done and has no rating yet, so the
+  // link can be safely shared (no auth) without risk of overwrite or spam.
+  app.post('/:id/feedback', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const body = req.body as { rating?: number; feedback?: string }
+    const rating = Math.max(1, Math.min(5, Number(body.rating) || 0))
+    const feedback = (body.feedback ?? '').toString().slice(0, 2000)
+    if (!rating) return reply.status(400).send({ error: 'INVALID_RATING' })
+
+    const visit = await app.prisma.propertyVisit.findUnique({
+      where: { id },
+      select: { id: true, status: true, rating: true, companyId: true, visitorName: true },
+    }).catch(() => null)
+    if (!visit) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (visit.status !== 'done') return reply.status(409).send({ error: 'VISIT_NOT_COMPLETED' })
+    if (visit.rating != null) return reply.status(409).send({ error: 'ALREADY_RATED' })
+
+    await app.prisma.propertyVisit.update({
+      where: { id },
+      data: { rating, feedback: feedback || null },
+    })
+
+    // Notifica o corretor que o feedback chegou — sinal forte para reabrir o
+    // diálogo com o cliente (proposta, novas opções, etc.).
+    try {
+      const { notify } = await import('../../services/notification.service.js')
+      await notify({
+        prisma: app.prisma,
+        companyId: visit.companyId,
+        type: 'system',
+        title: 'Feedback de visita recebido',
+        body: `${visit.visitorName} avaliou a visita ${rating}/5.${feedback ? `\n"${feedback.slice(0, 200)}"` : ''}`,
+        payload: { visitId: id, rating },
+      })
+    } catch { /* non-fatal */ }
+
+    return reply.send({ success: true })
+  })
 }

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -595,6 +595,108 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] visit-reminder-24h failed')
   }
 
+  // ── 7c. Pedido de feedback pós-visita ─────────────────────────────────
+  // Visitas marcadas como done sem rating há 2h-7d → manda link para o
+  // visitante avaliar. WhatsApp se configurado, e-mail como fallback.
+  try {
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+    const donesWaiting = await app.prisma.propertyVisit.findMany({
+      where: {
+        status: 'done',
+        rating: null,
+        updatedAt: { lt: twoHoursAgo, gte: sevenDaysAgo },
+      },
+      take: 200,
+    })
+
+    if (donesWaiting.length > 0) {
+      const baseUrl = (env.WEB_URL ?? 'https://agoraencontrei.com.br').replace(/\/$/, '')
+      let asked = 0
+      for (const visit of donesWaiting) {
+        const already = await app.prisma.auditLog.findFirst({
+          where: {
+            resource: 'property_visit',
+            resourceId: visit.id,
+            action: 'visit.feedback_request.sent' as any,
+          },
+        }).catch(() => null)
+        if (already) continue
+
+        const link = `${baseUrl}/visita/${visit.id}/feedback`
+        const propTitle = visit.propertyId
+          ? (await app.prisma.property.findUnique({
+              where: { id: visit.propertyId },
+              select: { title: true },
+            }).catch(() => null))?.title ?? 'o imóvel'
+          : 'o imóvel'
+        const message = `Olá ${visit.visitorName.split(' ')[0]}! Como foi sua visita em ${propTitle}? Avalie em 30 segundos: ${link}`
+
+        // WhatsApp se configurado.
+        if (env.WHATSAPP_TOKEN && env.WHATSAPP_PHONE_ID && visit.visitorPhone) {
+          const phone = visit.visitorPhone.replace(/\D/g, '')
+          const dest = phone.startsWith('55') ? phone : `55${phone}`
+          try {
+            const { whatsappService } = await import('./whatsapp.service.js')
+            await whatsappService.sendText(dest, message)
+          } catch (err) {
+            app.log.warn({ err }, '[scheduled] feedback whatsapp failed')
+          }
+        }
+
+        // E-mail fallback se houver endereço.
+        if (visit.visitorEmail) {
+          try {
+            const { sendEmail, isEmailConfigured } = await import('./email.service.js')
+            if (isEmailConfigured()) {
+              await sendEmail({
+                to: visit.visitorEmail,
+                subject: 'Como foi sua visita?',
+                html: `<p>Olá ${visit.visitorName.split(' ')[0]},</p>
+<p>Como foi sua visita em ${propTitle}?</p>
+<p><a href="${link}" style="background:#1B2B5B;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;display:inline-block">Avaliar em 30 segundos</a></p>
+<p style="color:#888;font-size:12px">AgoraEncontrei — Imobiliária Lemos</p>`,
+              })
+            }
+          } catch { /* non-fatal */ }
+        }
+
+        // Permite que regras do automation engine reajam ao evento também.
+        emitAutomation({
+          companyId: visit.companyId,
+          event: 'visita_pedido_feedback' as any,
+          data: {
+            visitId: visit.id,
+            visitorName: visit.visitorName,
+            visitorPhone: visit.visitorPhone,
+            visitorEmail: visit.visitorEmail ?? '',
+            propertyId: visit.propertyId,
+            feedbackUrl: link,
+          },
+        })
+
+        await app.prisma.auditLog.create({
+          data: {
+            companyId: visit.companyId,
+            action: 'visit.feedback_request.sent' as any,
+            resource: 'property_visit',
+            resourceId: visit.id,
+            payload: { sentAt: now.toISOString(), channel: visit.visitorPhone ? 'whatsapp' : 'email' },
+          },
+        }).catch(() => {})
+
+        asked++
+      }
+
+      if (asked > 0) {
+        app.log.info(`[scheduled] visit-feedback-request: sent ${asked} requests`)
+      }
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] visit-feedback-request failed')
+  }
+
   // ── 8. Follow-up automático: processa follow-ups agendados (D+1, D+3, D+7) ───
   try {
     const followUpResult = await processDueFollowUps(app.prisma, app.outboundQueue)

--- a/apps/web/src/app/(public)/visita/[id]/feedback/page.tsx
+++ b/apps/web/src/app/(public)/visita/[id]/feedback/page.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface VisitInfo {
+  id: string
+  visitorName: string
+  scheduledAt: string
+  status: string
+  alreadyRated: boolean
+  property: { title: string; slug: string | null; neighborhood: string | null; city: string | null } | null
+}
+
+export default function PublicVisitFeedbackPage() {
+  const { id } = useParams<{ id: string }>()
+  const [visit, setVisit] = useState<VisitInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [rating, setRating] = useState(0)
+  const [feedback, setFeedback] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`${API_URL}/api/v1/public/visits/${id}/feedback`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error('not_found')))
+      .then(j => { if (!cancelled) setVisit(j) })
+      .catch(() => { if (!cancelled) setError('Visita não encontrada.') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [id])
+
+  async function submit() {
+    if (!rating) { setError('Escolha uma nota de 1 a 5.'); return }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/v1/public/visits/${id}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating, feedback }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        if (j.error === 'ALREADY_RATED') setError('Você já avaliou esta visita. Obrigado!')
+        else if (j.error === 'VISIT_NOT_COMPLETED') setError('Essa visita ainda não foi finalizada.')
+        else setError('Não foi possível enviar. Tente novamente.')
+        return
+      }
+      setDone(true)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] text-[#1B2B5B]">Carregando…</main>
+  }
+
+  if (error && !visit) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] px-4">
+        <div className="max-w-md rounded-2xl bg-white p-8 text-center shadow">
+          <h1 className="text-xl font-bold text-[#1B2B5B]">Visita não encontrada</h1>
+          <p className="mt-2 text-sm text-gray-600">O link expirou ou está incorreto.</p>
+          <Link href="/" className="mt-6 inline-block rounded-lg bg-[#1B2B5B] px-5 py-2.5 text-sm font-medium text-white">Voltar ao site</Link>
+        </div>
+      </main>
+    )
+  }
+
+  if (done || visit?.alreadyRated) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] px-4">
+        <div className="max-w-md rounded-2xl bg-white p-8 text-center shadow">
+          <div className="mx-auto h-12 w-12 rounded-full bg-emerald-100 flex items-center justify-center text-2xl">✓</div>
+          <h1 className="mt-4 text-xl font-bold text-[#1B2B5B]">Obrigado pela avaliação!</h1>
+          <p className="mt-2 text-sm text-gray-600">Sua opinião nos ajuda a melhorar o atendimento.</p>
+          <Link href="/" className="mt-6 inline-block rounded-lg bg-[#C9A84C] px-5 py-2.5 text-sm font-medium text-[#1B2B5B]">Ver mais imóveis</Link>
+        </div>
+      </main>
+    )
+  }
+
+  const propLabel = visit?.property?.title ?? 'o imóvel'
+  const location = [visit?.property?.neighborhood, visit?.property?.city].filter(Boolean).join(' · ')
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] px-4 py-10">
+      <div className="w-full max-w-md rounded-2xl bg-white p-7 shadow">
+        <div className="text-center">
+          <p className="text-xs uppercase tracking-wider text-[#C9A84C] font-semibold">Imobiliária Lemos</p>
+          <h1 className="mt-2 text-2xl font-bold text-[#1B2B5B]">Como foi sua visita?</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Olá <strong>{visit?.visitorName?.split(' ')[0]}</strong>, conte pra gente como foi visitar <strong>{propLabel}</strong>{location ? ` (${location})` : ''}.
+          </p>
+        </div>
+
+        <div className="mt-6 flex justify-center gap-2">
+          {[1, 2, 3, 4, 5].map(n => (
+            <button
+              key={n}
+              type="button"
+              onClick={() => setRating(n)}
+              className={`text-4xl transition-transform ${n <= rating ? 'text-[#C9A84C] scale-110' : 'text-gray-300 hover:text-gray-400'}`}
+              aria-label={`${n} estrela${n > 1 ? 's' : ''}`}
+            >
+              ★
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          value={feedback}
+          onChange={e => setFeedback(e.target.value)}
+          rows={4}
+          maxLength={2000}
+          placeholder="Conte o que achou — o imóvel atendeu? Tem interesse? Quer ver opções parecidas?"
+          className="mt-4 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-[#1B2B5B] focus:outline-none focus:ring-1 focus:ring-[#1B2B5B]"
+          style={{ fontSize: '16px' }}
+        />
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <button
+          onClick={submit}
+          disabled={submitting || !rating}
+          className="mt-5 w-full rounded-lg bg-[#1B2B5B] px-5 py-3 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? 'Enviando…' : 'Enviar avaliação'}
+        </button>
+
+        <p className="mt-4 text-center text-[11px] text-gray-400">
+          Apenas o corretor responsável e a equipe Lemos verão seu feedback.
+        </p>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Fecha o ciclo da agenda de visitas: a partir de #115 (gestão) + #116 (notificações imediatas e lembrete 24h antes), agora o **visitante** também é trazido pra dentro do loop, automaticamente.

- **`POST /api/v1/public/visits/:id/feedback`** — endpoint público (sem auth) que aceita `rating` (1-5) + texto livre. Hardening anti-abuso:
  - Só aceita quando `status = 'done'`
  - Só aceita uma vez por visita (`rating IS NULL`)
  - `feedback` truncado em 2000 chars
- **`GET /api/v1/public/visits/:id/feedback`** — expõe nome, imóvel, status e flag `alreadyRated` para a página pública renderizar o formulário ou a tela de "obrigado".
- **Página pública `/visita/[id]/feedback`** — tema navy/gold do site, 5 estrelas, textarea com `font-size: 16px` (anti-zoom iOS Safari), estados de sucesso/erro/já-avaliado.
- **Job agendado**: visitas `done` há entre 2h e 7d sem rating recebem mensagem com o link:
  - WhatsApp se configurado (via `whatsappService.sendText`)
  - E-mail fallback se o visitante tem endereço
  - Emite automation event `visita_pedido_feedback` (para regras adicionais)
  - Dedup via `auditLog` com action `visit.feedback_request.sent` — 1 disparo único por visita
- Quando o feedback chega, o corretor recebe notificação in-app + e-mail (`type: 'system'`, payload com `visitId` e `rating`) — gatilho perfeito para retomar o diálogo (proposta, novas opções).

## Test plan

- [ ] Marcar uma visita como `done` no `/dashboard/agenda` sem feedback
- [ ] Aguardar 2h (ou rodar `runScheduledJobs` manualmente) → verificar WhatsApp/e-mail entregue
- [ ] Rodar `runScheduledJobs` novamente → log `sent 0` (dedup funcionando)
- [ ] Acessar `/visita/<id>/feedback` no celular → confirmar que o input não dá zoom no iOS Safari
- [ ] Enviar avaliação → corretor recebe notificação in-app + e-mail
- [ ] Tentar avaliar a mesma visita 2 vezes → 409 `ALREADY_RATED` + tela "Obrigado"
- [ ] Avaliar uma visita `pending` via API → 409 `VISIT_NOT_COMPLETED`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_