### PR TITLE
Visitas: painel de métricas no topo da agenda

### DIFF
--- a/apps/api/src/routes/visits/index.ts
+++ b/apps/api/src/routes/visits/index.ts
@@ -11,6 +11,97 @@ import { z } from 'zod'
 export default async function visitsRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
 
+  // GET /stats — métricas agregadas da agenda no período (default 30d).
+  app.get('/stats', { schema: { tags: ['visits'] } }, async (req, reply) => {
+    const q = req.query as { days?: string }
+    const days = Math.min(Math.max(Number(q.days) || 30, 1), 365)
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+
+    const visits = await app.prisma.propertyVisit.findMany({
+      where: { companyId: req.user.cid, createdAt: { gte: since } },
+      select: {
+        id: true, status: true, propertyId: true, brokerId: true,
+        rating: true, scheduledAt: true, createdAt: true,
+      },
+    })
+
+    const byStatus: Record<string, number> = {
+      pending: 0, confirmed: 0, done: 0, cancelled: 0, no_show: 0,
+    }
+    const propertyCount = new Map<string, number>()
+    const brokerStats = new Map<string, { total: number; done: number; ratingSum: number; ratingCount: number }>()
+    let ratingSum = 0
+    let ratingCount = 0
+
+    for (const v of visits) {
+      byStatus[v.status] = (byStatus[v.status] ?? 0) + 1
+      propertyCount.set(v.propertyId, (propertyCount.get(v.propertyId) ?? 0) + 1)
+
+      if (v.brokerId) {
+        const b = brokerStats.get(v.brokerId) ?? { total: 0, done: 0, ratingSum: 0, ratingCount: 0 }
+        b.total += 1
+        if (v.status === 'done') b.done += 1
+        if (v.rating != null) { b.ratingSum += v.rating; b.ratingCount += 1 }
+        brokerStats.set(v.brokerId, b)
+      }
+
+      if (v.rating != null) { ratingSum += v.rating; ratingCount += 1 }
+    }
+
+    const completedOrNoShow = byStatus.done + byStatus.no_show
+    const noShowRate = completedOrNoShow > 0 ? byStatus.no_show / completedOrNoShow : 0
+    const conversionRate = visits.length > 0 ? byStatus.done / visits.length : 0
+    const avgRating = ratingCount > 0 ? ratingSum / ratingCount : 0
+
+    const topPropertyIds = [...propertyCount.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id]) => id)
+    const topBrokerIds = [...brokerStats.keys()]
+
+    const [props, brokers] = await Promise.all([
+      topPropertyIds.length
+        ? app.prisma.property.findMany({
+            where: { id: { in: topPropertyIds } },
+            select: { id: true, title: true, slug: true, neighborhood: true },
+          }).catch(() => [])
+        : Promise.resolve([]),
+      topBrokerIds.length
+        ? app.prisma.user.findMany({
+            where: { id: { in: topBrokerIds } },
+            select: { id: true, name: true, avatarUrl: true },
+          }).catch(() => [])
+        : Promise.resolve([]),
+    ])
+
+    const propById = new Map(props.map(p => [p.id, p]))
+    const brokerById = new Map(brokers.map(b => [b.id, b]))
+
+    return reply.send({
+      periodDays: days,
+      total: visits.length,
+      byStatus,
+      noShowRate,
+      conversionRate,
+      avgRating,
+      ratingCount,
+      topProperties: topPropertyIds.map(id => ({
+        ...propById.get(id),
+        visits: propertyCount.get(id) ?? 0,
+      })),
+      topBrokers: [...brokerStats.entries()]
+        .map(([id, s]) => ({
+          ...brokerById.get(id),
+          id,
+          total: s.total,
+          done: s.done,
+          avgRating: s.ratingCount > 0 ? s.ratingSum / s.ratingCount : null,
+        }))
+        .sort((a, b) => b.done - a.done)
+        .slice(0, 5),
+    })
+  })
+
   app.get('/', { schema: { tags: ['visits'] } }, async (req, reply) => {
     const q = req.query as { status?: string; from?: string; limit?: string }
     const take = Math.min(Number(q.limit) || 100, 500)

--- a/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { Calendar, Loader2, RefreshCw, Check, X, Phone, MessageCircle, Star } from 'lucide-react'
+import { Calendar, Loader2, RefreshCw, Check, X, Phone, MessageCircle, Star, TrendingUp, AlertTriangle, Award } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
@@ -14,6 +14,18 @@ interface Visit {
   notes: string | null; rating: number | null; feedback: string | null
   property: { id: string; title: string; slug: string | null; neighborhood: string | null; city: string | null } | null
   broker: { id: string; name: string; avatarUrl: string | null } | null
+}
+
+interface Stats {
+  periodDays: number
+  total: number
+  byStatus: Record<string, number>
+  noShowRate: number
+  conversionRate: number
+  avgRating: number
+  ratingCount: number
+  topProperties: { id?: string; title?: string; slug?: string | null; neighborhood?: string | null; visits: number }[]
+  topBrokers: { id: string; name?: string; avatarUrl?: string | null; total: number; done: number; avgRating: number | null }[]
 }
 
 const STATUS: Record<string, { label: string; cls: string }> = {
@@ -31,6 +43,7 @@ function fmtDate(iso: string) {
 export default function AgendaPage() {
   const { getValidToken } = useAuth()
   const [visits, setVisits] = useState<Visit[]>([])
+  const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(false)
   const [filter, setFilter] = useState('')
   const [busy, setBusy] = useState<string | null>(null)
@@ -44,11 +57,13 @@ export default function AgendaPage() {
       const token = await getValidToken()
       const q = new URLSearchParams()
       if (filter) q.set('status', filter)
-      const res = await fetch(`${API_URL}/api/v1/visits?${q}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      const j = await res.json()
-      setVisits(j.data ?? [])
+      const [listRes, statsRes] = await Promise.all([
+        fetch(`${API_URL}/api/v1/visits?${q}`, { headers: { Authorization: `Bearer ${token}` } }),
+        fetch(`${API_URL}/api/v1/visits/stats?days=30`, { headers: { Authorization: `Bearer ${token}` } }),
+      ])
+      const list = await listRes.json()
+      setVisits(list.data ?? [])
+      if (statsRes.ok) setStats(await statsRes.json())
     } catch { setVisits([]) }
     finally { setLoading(false) }
   }, [filter, getValidToken])
@@ -93,6 +108,94 @@ export default function AgendaPage() {
       </div>
 
       <div className="mx-auto max-w-6xl px-4 py-5 sm:px-6 space-y-4">
+        {/* Stats — últimos 30 dias */}
+        {stats && stats.total > 0 && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                  <Calendar size={11} /> Visitas (30d)
+                </div>
+                <p className="mt-1 text-xl font-bold text-white">{stats.total}</p>
+                <p className="mt-0.5 text-[10px] text-gray-500">
+                  {stats.byStatus.pending + stats.byStatus.confirmed} agendadas
+                </p>
+              </div>
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                  <TrendingUp size={11} /> Conversão
+                </div>
+                <p className="mt-1 text-xl font-bold text-emerald-300">
+                  {(stats.conversionRate * 100).toFixed(0)}%
+                </p>
+                <p className="mt-0.5 text-[10px] text-gray-500">{stats.byStatus.done} realizadas</p>
+              </div>
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                  <AlertTriangle size={11} /> No-show
+                </div>
+                <p className={`mt-1 text-xl font-bold ${stats.noShowRate >= 0.2 ? 'text-red-300' : 'text-white'}`}>
+                  {(stats.noShowRate * 100).toFixed(0)}%
+                </p>
+                <p className="mt-0.5 text-[10px] text-gray-500">{stats.byStatus.no_show} não compareceu</p>
+              </div>
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                  <Star size={11} /> Avaliação média
+                </div>
+                <p className="mt-1 text-xl font-bold text-amber-300">
+                  {stats.avgRating > 0 ? stats.avgRating.toFixed(1) : '—'}
+                </p>
+                <p className="mt-0.5 text-[10px] text-gray-500">{stats.ratingCount} avaliações</p>
+              </div>
+            </div>
+
+            {(stats.topProperties.length > 0 || stats.topBrokers.length > 0) && (
+              <div className="grid sm:grid-cols-2 gap-2">
+                {stats.topProperties.length > 0 && (
+                  <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                    <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                      <Award size={11} /> Imóveis mais visitados
+                    </div>
+                    <ul className="mt-2 space-y-1">
+                      {stats.topProperties.slice(0, 3).map((p, i) => (
+                        <li key={p.id ?? i} className="flex items-center justify-between text-xs">
+                          <Link href={p.slug || p.id ? `/imoveis/${p.slug ?? p.id}` : '#'}
+                            className="truncate text-gray-300 hover:text-amber-400">
+                            {p.title ?? 'Imóvel removido'}
+                            {p.neighborhood && <span className="text-gray-600"> · {p.neighborhood}</span>}
+                          </Link>
+                          <span className="ml-2 flex-shrink-0 text-amber-300 font-semibold">{p.visits}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {stats.topBrokers.length > 0 && (
+                  <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+                    <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                      <Award size={11} /> Corretores em destaque
+                    </div>
+                    <ul className="mt-2 space-y-1">
+                      {stats.topBrokers.slice(0, 3).map(b => (
+                        <li key={b.id} className="flex items-center justify-between text-xs">
+                          <span className="truncate text-gray-300">{b.name ?? 'Corretor'}</span>
+                          <span className="ml-2 flex-shrink-0 text-gray-400">
+                            {b.done} <span className="text-gray-600">realizadas</span>
+                            {b.avgRating != null && (
+                              <span className="ml-1.5 text-amber-300">{b.avgRating.toFixed(1)}★</span>
+                            )}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Filters */}
         <div className="flex flex-wrap gap-1">
           {[['', 'Todas'], ['pending', 'Pendentes'], ['confirmed', 'Confirmadas'], ['done', 'Realizadas'], ['cancelled', 'Canceladas']]


### PR DESCRIPTION
## Summary

Quarta peça do ciclo de visitas (depois de gestão #115, notificações #116, feedback público #117). Agora a `imobiliária` enxerga **resultado** — não só agendamentos individuais, mas os números agregados que importam para vender:

- **Novo `GET /api/v1/visits/stats?days=30`** — agrega todas as visitas dos últimos N dias (default 30, max 365) por:
  - Total + contagem por status (pending/confirmed/done/cancelled/no_show)
  - **Taxa de conversão** = done / total
  - **Taxa de no-show** = no_show / (done + no_show) — métrica honesta que ignora as canceladas/agendadas
  - **Avaliação média** + total de avaliações recebidas (do feedback público de #117)
  - **Top 5 imóveis** mais visitados
  - **Top 5 corretores** ranqueados por visitas `done`, com média de rating individual
- **Painel no topo de `/dashboard/agenda`**:
  - 4 KPI cards (total / conversão / no-show / avaliação média)
  - 2 listas (imóveis mais visitados / corretores em destaque)
  - **Alerta visual em vermelho** quando no-show ≥ 20% (sinal forte de processo de confirmação fraco)
  - Só renderiza se houver pelo menos 1 visita no período — não polui o painel quando vazio
- Sem ALTER no DB — agregações em memória sobre a tabela `property_visits` já existente (escopada por `companyId`)

## Test plan

- [ ] Acessar `/dashboard/agenda` com visitas no período → confirmar que os 4 KPIs aparecem corretos
- [ ] Marcar uma visita como `no_show` → no-show rate sobe; ≥ 20% fica vermelho
- [ ] Marcar uma visita como `done` com rating 5 → avaliação média atualiza
- [ ] Top imóveis ordenado por número de visitas (verificar com dados reais)
- [ ] Top corretores ordenado por visitas realizadas
- [ ] Empresa sem nenhuma visita no período → painel some, mostra só lista vazia
- [ ] Isolamento por `companyId` — visitas de outra empresa não entram nas stats


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_