### PR TITLE
Match cliente-imóvel + lembrete 1h antes (combate no-show)

### DIFF
--- a/apps/api/src/routes/alerts/index.ts
+++ b/apps/api/src/routes/alerts/index.ts
@@ -62,7 +62,8 @@ export default async function alertsRoutes(app: FastifyInstance) {
         '<h2>Alerta cancelado</h2><p>Você não receberá mais avisos de imóveis compatíveis.</p></body></html>')
   })
 
-  // GET / — admin only
+  // GET / — admin: only alerts of this tenant (or cross-tenant, companyId=null);
+  // SUPER_ADMIN sees every alert.
   app.get('/', {
     schema: { tags: ['alerts'], summary: 'List property alerts (admin)' },
     preHandler: [app.authenticate],
@@ -71,7 +72,12 @@ export default async function alertsRoutes(app: FastifyInstance) {
     const page  = parseInt(q.page  ?? '1',  10)
     const limit = parseInt(q.limit ?? '50', 10)
 
+    const tenantFilter = req.user.role === 'SUPER_ADMIN'
+      ? {}
+      : { OR: [{ companyId: req.user.cid }, { companyId: null }] }
+
     const where: any = {
+      ...tenantFilter,
       ...(q.active !== undefined && { active: q.active === 'true' }),
       ...(q.email && { email: { contains: q.email, mode: 'insensitive' } }),
     }

--- a/apps/api/src/routes/properties/index.ts
+++ b/apps/api/src/routes/properties/index.ts
@@ -676,6 +676,12 @@ export default async function propertiesRoutes(app: FastifyInstance) {
       after:  updated  as any,
     })
 
+    // Match the listing against client alerts when it transitions to ACTIVE
+    // (draft properties only fire match when first activated).
+    if (body.status === 'ACTIVE' && existing.status !== 'ACTIVE') {
+      void notifyMatchingAlerts(app.prisma, updated as any)
+    }
+
     // Auto-post to Instagram when property becomes ACTIVE
     let autoPostStatus: string | null = null
     if (body.status === 'ACTIVE' && existing.status !== 'ACTIVE') {

--- a/apps/api/src/services/property-match.service.ts
+++ b/apps/api/src/services/property-match.service.ts
@@ -105,7 +105,7 @@ export async function notifyMatchingAlerts(
 
   const alerts = await prisma.propertyAlert
     .findMany({ where: { active: true, AND: and } as never, take: 200 })
-    .catch(() => [] as Array<{ id: string; email: string; name: string | null; token: string | null }>)
+    .catch(() => [] as Array<{ id: string; email: string; name: string | null; phone: string | null; token: string | null }>)
 
   if (!alerts.length) return 0
 
@@ -120,6 +120,21 @@ export async function notifyMatchingAlerts(
         subject: 'Encontramos um imóvel compatível com seu perfil',
         html: matchEmailHtml(alert.name, property.title, priceLabel, location, url, alert.token),
       }).catch(() => {})
+    }
+  }
+
+  // WhatsApp para quem cadastrou telefone — canal mais direto que e-mail.
+  const { env } = await import('../utils/env.js')
+  if (env.WHATSAPP_TOKEN && env.WHATSAPP_PHONE_ID) {
+    const { whatsappService } = await import('./whatsapp.service.js')
+    for (const alert of alerts) {
+      if (!alert.phone) continue
+      const phone = alert.phone.replace(/\D/g, '')
+      if (phone.length < 10) continue
+      const dest = phone.startsWith('55') ? phone : `55${phone}`
+      const first = alert.name?.split(' ')[0] ?? 'Olá'
+      const msg = `${first}, achamos um imóvel que combina com o que você procura!\n\n🏠 ${property.title}\n📍 ${location}\n💰 ${priceLabel}\n\nVer: ${url}`
+      await whatsappService.sendText(dest, msg).catch(() => {})
     }
   }
 

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -595,6 +595,127 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] visit-reminder-24h failed')
   }
 
+  // ── 7b'. Lembrete de visita 1h antes (PropertyVisit) ──────────────────
+  // Recado curto direto antes da visita — em geral o que efetivamente
+  // reduz no-show. WhatsApp com link do Google Maps para o visitante;
+  // notificação in-app para o corretor.
+  try {
+    const in30min = new Date(now.getTime() + 30 * 60 * 1000)
+    const in90min = new Date(now.getTime() + 90 * 60 * 1000)
+
+    const soon = await app.prisma.propertyVisit.findMany({
+      where: {
+        status: { in: ['pending', 'confirmed'] },
+        scheduledAt: { gte: in30min, lte: in90min },
+      },
+      take: 200,
+    })
+
+    if (soon.length > 0) {
+      const { notify } = await import('./notification.service.js')
+      let reminded = 0
+
+      for (const visit of soon) {
+        const already = await app.prisma.auditLog.findFirst({
+          where: {
+            resource: 'property_visit',
+            resourceId: visit.id,
+            action: 'visit.reminder.1h' as any,
+          },
+        }).catch(() => null)
+        if (already) continue
+
+        const prop = await app.prisma.property.findUnique({
+          where: { id: visit.propertyId },
+          select: { title: true, street: true, number: true, neighborhood: true, city: true, state: true, latitude: true, longitude: true },
+        }).catch(() => null)
+
+        const propTitle = prop?.title ?? 'o imóvel'
+        const addressParts = [
+          prop?.street && prop?.number ? `${prop.street}, ${prop.number}` : prop?.street,
+          prop?.neighborhood, prop?.city, prop?.state,
+        ].filter(Boolean)
+        const addressLabel = addressParts.join(', ') || ''
+        const mapsUrl = prop?.latitude && prop?.longitude
+          ? `https://www.google.com/maps/search/?api=1&query=${prop.latitude},${prop.longitude}`
+          : addressLabel
+            ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(addressLabel)}`
+            : null
+
+        const timeLabel = visit.scheduledAt.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+
+        // WhatsApp para o visitante com link do mapa.
+        if (env.WHATSAPP_TOKEN && env.WHATSAPP_PHONE_ID && visit.visitorPhone) {
+          const phone = visit.visitorPhone.replace(/\D/g, '')
+          const dest = phone.startsWith('55') ? phone : `55${phone}`
+          const first = visit.visitorName.split(' ')[0]
+          const msg = [
+            `Oi ${first}! Em ~1h temos sua visita em ${propTitle} às ${timeLabel}.`,
+            addressLabel ? `📍 ${addressLabel}` : null,
+            mapsUrl ? `🗺️ Como chegar: ${mapsUrl}` : null,
+            'Qualquer imprevisto, é só responder por aqui!',
+          ].filter(Boolean).join('\n')
+          try {
+            const { whatsappService } = await import('./whatsapp.service.js')
+            await whatsappService.sendText(dest, msg)
+          } catch (err) {
+            app.log.warn({ err }, '[scheduled] visit-reminder-1h whatsapp failed')
+          }
+        }
+
+        // Notificação ao corretor — o "vai sair pra rua" do dia.
+        await notify({
+          prisma: app.prisma,
+          companyId: visit.companyId,
+          userId: visit.brokerId ?? null,
+          type: 'visit_requested',
+          title: 'Visita em ~1h',
+          body: `${visit.visitorName} tem visita às ${timeLabel} em ${propTitle}.${addressLabel ? `\n${addressLabel}` : ''}\nTel: ${visit.visitorPhone}`,
+          payload: {
+            visitId: visit.id,
+            propertyId: visit.propertyId,
+            scheduledAt: visit.scheduledAt.toISOString(),
+            mapsUrl,
+          },
+          email: false, // 24h já mandou e-mail — 1h é só push curto
+        }).catch(() => {})
+
+        emitAutomation({
+          companyId: visit.companyId,
+          event: 'visita_lembrete_1h' as any,
+          data: {
+            visitId: visit.id,
+            visitorName: visit.visitorName,
+            visitorPhone: visit.visitorPhone,
+            propertyId: visit.propertyId,
+            propertyTitle: propTitle,
+            scheduledAt: visit.scheduledAt.toISOString(),
+            mapsUrl: mapsUrl ?? '',
+            brokerId: visit.brokerId ?? '',
+          },
+        })
+
+        await app.prisma.auditLog.create({
+          data: {
+            companyId: visit.companyId,
+            action: 'visit.reminder.1h' as any,
+            resource: 'property_visit',
+            resourceId: visit.id,
+            payload: { scheduledAt: visit.scheduledAt.toISOString(), sentAt: now.toISOString() },
+          },
+        }).catch(() => {})
+
+        reminded++
+      }
+
+      if (reminded > 0) {
+        app.log.info(`[scheduled] visit-reminder-1h: emitted ${reminded} reminders`)
+      }
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] visit-reminder-1h failed')
+  }
+
   // ── 7c. Pedido de feedback pós-visita ─────────────────────────────────
   // Visitas marcadas como done sem rating há 2h-7d → manda link para o
   // visitante avaliar. WhatsApp se configurado, e-mail como fallback.

--- a/apps/web/src/app/(dashboard)/dashboard/alertas/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alertas/page.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Bell, Loader2, RefreshCw, Phone, Mail, MapPin, Check, X } from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface Alert {
+  id: string
+  email: string
+  name: string | null
+  phone: string | null
+  companyId: string | null
+  city: string | null
+  neighborhood: string | null
+  type: string | null
+  purpose: string | null
+  minPrice: string | null
+  maxPrice: string | null
+  bedrooms: number | null
+  active: boolean
+  lastMatchedAt: string | null
+  createdAt: string
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  HOUSE: 'Casa', APARTMENT: 'Apartamento', LAND: 'Terreno', FARM: 'Sítio',
+  RANCH: 'Fazenda', WAREHOUSE: 'Galpão', OFFICE: 'Sala', STORE: 'Comercial',
+  STUDIO: 'Studio', PENTHOUSE: 'Cobertura', CONDO: 'Condomínio', KITNET: 'Kitnet',
+}
+
+function fmtPrice(v: string | null) {
+  if (!v) return null
+  const n = Number(v)
+  if (!Number.isFinite(n)) return null
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 })
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' })
+}
+
+export default function AlertasPage() {
+  const { getValidToken } = useAuth()
+  const [alerts, setAlerts] = useState<Alert[]>([])
+  const [loading, setLoading] = useState(false)
+  const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('active')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const token = await getValidToken()
+      const q = new URLSearchParams({ limit: '200' })
+      if (filter === 'active') q.set('active', 'true')
+      if (filter === 'inactive') q.set('active', 'false')
+      const res = await fetch(`${API_URL}/api/v1/alerts?${q}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      setAlerts(j.data ?? [])
+    } catch { setAlerts([]) }
+    finally { setLoading(false) }
+  }, [filter, getValidToken])
+
+  useEffect(() => { load() }, [load])
+
+  const activeCount = alerts.filter(a => a.active).length
+  const withMatch = alerts.filter(a => a.lastMatchedAt).length
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <div className="border-b border-gray-800">
+        <div className="mx-auto max-w-6xl px-4 py-4 sm:py-6 sm:px-6 flex items-center gap-3">
+          <Bell size={24} className="text-amber-400" />
+          <div className="flex-1 min-w-0">
+            <h1 className="text-lg sm:text-2xl font-bold">Alertas de Match</h1>
+            <p className="mt-0.5 text-xs sm:text-sm text-gray-400">
+              Clientes esperando por imóveis com perfil específico — quando um match é encontrado, eles são avisados automaticamente
+            </p>
+          </div>
+          <button onClick={load}
+            className="flex items-center gap-1.5 rounded-lg border border-gray-700 px-3 py-2 text-xs text-gray-300 hover:bg-gray-800">
+            <RefreshCw size={13} />
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-6xl px-4 py-5 sm:px-6 space-y-4">
+        {/* KPIs */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+            <div className="text-[10px] uppercase tracking-wider text-gray-500">Alertas ativos</div>
+            <p className="mt-1 text-xl font-bold text-white">{activeCount}</p>
+          </div>
+          <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+            <div className="text-[10px] uppercase tracking-wider text-gray-500">Já receberam match</div>
+            <p className="mt-1 text-xl font-bold text-emerald-300">{withMatch}</p>
+          </div>
+          <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3 col-span-2 sm:col-span-1">
+            <div className="text-[10px] uppercase tracking-wider text-gray-500">Total cadastrado</div>
+            <p className="mt-1 text-xl font-bold text-white">{alerts.length}</p>
+          </div>
+        </div>
+
+        {/* Filter chips */}
+        <div className="flex flex-wrap gap-1">
+          {([['active', 'Ativos'], ['inactive', 'Cancelados'], ['all', 'Todos']] as const).map(([v, l]) => (
+            <button key={v} onClick={() => setFilter(v)}
+              className={`rounded-full px-3 py-1 text-xs ${filter === v ? 'bg-amber-600 text-white' : 'bg-gray-900 text-gray-400 hover:text-white'}`}>
+              {l}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-10"><Loader2 className="animate-spin text-amber-400" /></div>
+        ) : alerts.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-600">Nenhum alerta cadastrado.</p>
+        ) : (
+          <div className="space-y-2">
+            {alerts.map(a => {
+              const criteria: string[] = []
+              if (a.type) criteria.push(TYPE_LABEL[a.type] ?? a.type)
+              if (a.purpose) criteria.push(a.purpose === 'RENT' ? 'Alugar' : 'Comprar')
+              if (a.bedrooms) criteria.push(`${a.bedrooms}+ qtos`)
+              const min = fmtPrice(a.minPrice)
+              const max = fmtPrice(a.maxPrice)
+              if (min && max) criteria.push(`${min}–${max}`)
+              else if (max) criteria.push(`até ${max}`)
+              else if (min) criteria.push(`a partir de ${min}`)
+              const where = [a.neighborhood, a.city].filter(Boolean).join(', ')
+
+              return (
+                <div key={a.id} className="rounded-xl border border-gray-800 bg-gray-900/40 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-semibold text-white">{a.name ?? a.email.split('@')[0]}</span>
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${a.active ? 'bg-emerald-500/15 text-emerald-300' : 'bg-gray-700/40 text-gray-400'}`}>
+                          {a.active ? 'Ativo' : 'Cancelado'}
+                        </span>
+                        {a.lastMatchedAt && (
+                          <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
+                            <Check size={10} className="inline mr-0.5" /> match em {fmtDate(a.lastMatchedAt)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-3 text-[11px] text-gray-400">
+                        <span className="inline-flex items-center gap-1"><Mail size={11} /> {a.email}</span>
+                        {a.phone && <span className="inline-flex items-center gap-1"><Phone size={11} /> {a.phone}</span>}
+                        {where && <span className="inline-flex items-center gap-1"><MapPin size={11} /> {where}</span>}
+                      </div>
+                      {criteria.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1">
+                          {criteria.map((c, i) => (
+                            <span key={i} className="rounded-md bg-gray-800 px-2 py-0.5 text-[10px] text-gray-300">{c}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="text-right text-[10px] text-gray-500 flex-shrink-0">
+                      {fmtDate(a.createdAt)}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -73,6 +73,7 @@ const midNavItems = [
   { href: '/dashboard/contacts',            icon: Users,            label: 'Contatos',      highlight: false },
   { href: '/dashboard/deals',               icon: TrendingUp,       label: 'Negócios',      highlight: false },
   { href: '/dashboard/agenda',              icon: Calendar,         label: 'Agenda de Visitas', highlight: false },
+  { href: '/dashboard/alertas',             icon: Bell,             label: 'Alertas de Match', highlight: false },
   { href: '/dashboard/inbox',               icon: MessageCircle,    label: 'Lemos.chat',    highlight: false },
   { href: '/dashboard/financiamentos',      icon: Landmark,         label: 'Financiamentos',highlight: false },
   { href: '/dashboard/portals',             icon: Globe,            label: 'Portais',       highlight: false },


### PR DESCRIPTION
## Summary

Dois itens da agenda em um PR — match cliente-imóvel completo + lembrete 1h antes (combate ao no-show).

### 1. Match cliente-imóvel

O serviço base já existia e era chamado no `POST /properties`, mas faltavam três gaps importantes — todos endereçados aqui.

- **WhatsApp ao cliente** quando o alerta tem telefone cadastrado. Mensagem curta com título, localização, preço e link — canal mais direto que e-mail.
- **Match também no `PATCH /properties/:id`** quando o status transiciona para `ACTIVE` (antes ficava só no POST, então imóveis criados como `DRAFT`/`INACTIVE` nunca casavam ao serem ativados depois).
- **Isolamento multi-tenant em `GET /api/v1/alerts`**: antes retornava todos os alertas do sistema para qualquer admin autenticado (vazamento). Agora cada empresa só vê os seus + cross-tenant (`companyId=null`). `SUPER_ADMIN` segue vendo tudo.
- **Nova página `/dashboard/alertas`** (tema dark, mobile-friendly) com 3 KPIs (ativos / com match / total), filtros e cards com critérios formatados (`Casa · Comprar · 3+ qtos · R$ 500k–800k`).
- **Entrada no sidebar** "Alertas de Match".

### 2. Lembrete 1h antes (combate no-show)

- Novo bloco no `scheduled.jobs`: visitas `pending`/`confirmed` em 30-90 min à frente recebem **WhatsApp curto** com endereço e **link do Google Maps** (coordenadas se disponíveis, senão endereço formatado urlencoded).
- **Notificação in-app** ao corretor — o "vai sair pra rua" do dia. E-mail desabilitado neste reminder (24h já mandou; 1h é push curto).
- Dedup via `auditLog` action `visit.reminder.1h` — 1 disparo único por visita.
- Emite `automation event 'visita_lembrete_1h'` para regras adicionais.
- Fecha o gap das métricas de no-show expostas em #118 — 24h é cedo demais para impedir esquecimento de última hora.

## Test plan

- [ ] **Match**: cadastrar `PropertyAlert` com phone → criar imóvel ACTIVE que case → WhatsApp + e-mail entregues
- [ ] **Match**: criar imóvel DRAFT → PATCH para ACTIVE → match dispara
- [ ] **Match**: ADMIN da empresa A não vê alertas exclusivos da B; SUPER_ADMIN vê tudo
- [ ] **1h reminder**: agendar visita com `scheduledAt` ≈ 1h à frente → WhatsApp recebido com link do Maps
- [ ] **1h reminder**: imóvel com `latitude`+`longitude` → URL usa coordenadas (`?api=1&query=lat,lng`)
- [ ] **1h reminder**: imóvel sem coords → URL usa endereço urlencoded
- [ ] **1h reminder**: rodar `runScheduledJobs` 2x → segunda vez `emitted 0` (dedup funcionando)
