### PR TITLE
Painel Meu Dia — visão mobile-first do corretor (próxima visita, agenda, leads do dia)

### DIFF
--- a/apps/api/src/routes/users/corretor.ts
+++ b/apps/api/src/routes/users/corretor.ts
@@ -41,6 +41,95 @@ export default async function corretorRoutes(app: FastifyInstance) {
     })
   })
 
+  // GET /api/v1/corretor/today — vista enxuta do dia para uso mobile.
+  // Próxima visita destacada + agenda do dia + leads novos + KPIs.
+  app.get('/today', async (req, reply) => {
+    const userId = req.user.sub
+    const cid    = req.user.cid
+    const now    = new Date()
+    const dayStart = new Date(now); dayStart.setHours(0, 0, 0, 0)
+    const dayEnd   = new Date(now); dayEnd.setHours(23, 59, 59, 999)
+
+    const [todayVisits, nextVisit, newLeadsToday, pendingTasks] = await Promise.all([
+      app.prisma.propertyVisit.findMany({
+        where: {
+          companyId: cid,
+          brokerId: userId,
+          scheduledAt: { gte: dayStart, lte: dayEnd },
+        },
+        orderBy: { scheduledAt: 'asc' },
+        take: 50,
+      }),
+      app.prisma.propertyVisit.findFirst({
+        where: {
+          companyId: cid,
+          brokerId: userId,
+          status: { in: ['pending', 'confirmed'] },
+          scheduledAt: { gte: now },
+        },
+        orderBy: { scheduledAt: 'asc' },
+      }),
+      app.prisma.lead.findMany({
+        where: {
+          companyId: cid,
+          assignedToId: userId,
+          createdAt: { gte: dayStart },
+        },
+        select: { id: true, name: true, phone: true, email: true, status: true, source: true, createdAt: true },
+        orderBy: { createdAt: 'desc' },
+        take: 30,
+      }),
+      app.prisma.activity.count({
+        where: {
+          companyId: cid, userId,
+          type: 'task',
+          scheduledAt: { gte: now, lte: new Date(now.getTime() + 24 * 60 * 60 * 1000) },
+        },
+      }),
+    ])
+
+    // Enrich visits with property title for the agenda display.
+    const propIds = [...new Set([
+      ...todayVisits.map(v => v.propertyId),
+      ...(nextVisit ? [nextVisit.propertyId] : []),
+    ])]
+    const props = propIds.length
+      ? await app.prisma.property.findMany({
+          where: { id: { in: propIds } },
+          select: { id: true, title: true, slug: true, street: true, number: true, neighborhood: true, city: true, latitude: true, longitude: true },
+        }).catch(() => [])
+      : []
+    const propById = new Map(props.map(p => [p.id, p]))
+
+    function mapsUrl(p: typeof props[number] | undefined) {
+      if (!p) return null
+      if (p.latitude && p.longitude) {
+        return `https://www.google.com/maps/search/?api=1&query=${p.latitude},${p.longitude}`
+      }
+      const addr = [p.street && p.number ? `${p.street}, ${p.number}` : p.street, p.neighborhood, p.city]
+        .filter(Boolean).join(', ')
+      return addr ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(addr)}` : null
+    }
+
+    return reply.send({
+      now: now.toISOString(),
+      nextVisit: nextVisit
+        ? { ...nextVisit, property: propById.get(nextVisit.propertyId) ?? null, mapsUrl: mapsUrl(propById.get(nextVisit.propertyId)) }
+        : null,
+      todayVisits: todayVisits.map(v => ({
+        ...v,
+        property: propById.get(v.propertyId) ?? null,
+        mapsUrl: mapsUrl(propById.get(v.propertyId)),
+      })),
+      newLeadsToday,
+      kpis: {
+        visitsToday: todayVisits.length,
+        leadsToday: newLeadsToday.length,
+        pendingTasks,
+      },
+    })
+  })
+
   // GET /api/v1/corretor/leads — broker's assigned leads
   app.get('/leads', async (req, reply) => {
     const q      = req.query as any

--- a/apps/web/src/app/(dashboard)/dashboard/corretor/hoje/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/corretor/hoje/page.tsx
@@ -1,0 +1,327 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import {
+  Calendar, MapPin, Phone, MessageCircle, RefreshCw,
+  Check, X, Loader2, UserPlus, Map, Star, Clock, AlertCircle,
+} from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface Property {
+  id: string; title: string; slug: string | null
+  street: string | null; number: string | null
+  neighborhood: string | null; city: string | null
+  latitude: number | null; longitude: number | null
+}
+interface Visit {
+  id: string; visitorName: string; visitorPhone: string
+  scheduledAt: string; status: string; mode: string; notes: string | null
+  property: Property | null; mapsUrl: string | null
+}
+interface Lead {
+  id: string; name: string; phone: string | null; email: string | null
+  status: string; source: string | null; createdAt: string
+}
+interface Today {
+  now: string
+  nextVisit: Visit | null
+  todayVisits: Visit[]
+  newLeadsToday: Lead[]
+  kpis: { visitsToday: number; leadsToday: number; pendingTasks: number }
+}
+
+const STATUS: Record<string, { label: string; cls: string }> = {
+  pending:   { label: 'Pendente',   cls: 'bg-yellow-500/15 text-yellow-300' },
+  confirmed: { label: 'Confirmada', cls: 'bg-blue-500/15 text-blue-300' },
+  done:      { label: 'Realizada',  cls: 'bg-emerald-500/15 text-emerald-300' },
+  cancelled: { label: 'Cancelada',  cls: 'bg-gray-500/15 text-gray-400' },
+  no_show:   { label: 'Não veio',   cls: 'bg-red-500/15 text-red-300' },
+}
+
+function fmtTime(iso: string) {
+  return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+}
+function minutesUntil(iso: string): number {
+  return Math.round((new Date(iso).getTime() - Date.now()) / 60000)
+}
+function fmtCountdown(min: number): string {
+  if (min < 0) return `${-min}min atrás`
+  if (min < 60) return `em ${min}min`
+  const h = Math.floor(min / 60)
+  const m = min % 60
+  return m === 0 ? `em ${h}h` : `em ${h}h ${m}min`
+}
+function relTime(iso: string): string {
+  const sec = (Date.now() - new Date(iso).getTime()) / 1000
+  if (sec < 60) return 'agora'
+  if (sec < 3600) return `${Math.floor(sec / 60)}min atrás`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h atrás`
+  return new Date(iso).toLocaleDateString('pt-BR')
+}
+
+export default function CorretorHojePage() {
+  const { getValidToken } = useAuth()
+  const [data, setData] = useState<Today | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const token = await getValidToken()
+      const res = await fetch(`${API_URL}/api/v1/corretor/today`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) setData(await res.json())
+    } catch { /* keep prior */ }
+    finally { setLoading(false) }
+  }, [getValidToken])
+
+  useEffect(() => { load() }, [load])
+
+  async function patchVisit(id: string, body: Record<string, unknown>) {
+    setBusy(id)
+    try {
+      const token = await getValidToken()
+      await fetch(`${API_URL}/api/v1/visits/${id}`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      await load()
+    } finally { setBusy(null) }
+  }
+
+  const next = data?.nextVisit
+  const nextMin = next ? minutesUntil(next.scheduledAt) : null
+  const isImminent = nextMin != null && nextMin <= 60 && nextMin >= -30
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white pb-8">
+      {/* Header */}
+      <div className="border-b border-gray-800 sticky top-0 z-10 bg-gray-950">
+        <div className="mx-auto max-w-4xl px-4 py-3 flex items-center gap-3">
+          <Calendar size={22} className="text-amber-400" />
+          <div className="flex-1 min-w-0">
+            <h1 className="text-base font-bold leading-tight">Hoje</h1>
+            <p className="text-[11px] text-gray-500 leading-tight">
+              {new Date().toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: 'long' })}
+            </p>
+          </div>
+          <button onClick={load}
+            className="rounded-lg border border-gray-700 p-2 text-gray-300 hover:bg-gray-800">
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-4xl px-4 py-4 space-y-5">
+        {loading && !data ? (
+          <div className="flex justify-center py-10"><Loader2 className="animate-spin text-amber-400" /></div>
+        ) : !data ? (
+          <p className="py-10 text-center text-sm text-gray-600">Sem dados.</p>
+        ) : (
+          <>
+            {/* KPIs */}
+            <div className="grid grid-cols-3 gap-2">
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3 text-center">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500">Visitas</p>
+                <p className="mt-1 text-2xl font-bold text-white">{data.kpis.visitsToday}</p>
+              </div>
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3 text-center">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500">Leads</p>
+                <p className="mt-1 text-2xl font-bold text-amber-300">{data.kpis.leadsToday}</p>
+              </div>
+              <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3 text-center">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500">Tarefas</p>
+                <p className="mt-1 text-2xl font-bold text-blue-300">{data.kpis.pendingTasks}</p>
+              </div>
+            </div>
+
+            {/* Próxima visita — destaque grande */}
+            {next ? (
+              <div className={`rounded-2xl border p-4 ${isImminent ? 'border-amber-500/50 bg-amber-500/5' : 'border-gray-800 bg-gray-900/40'}`}>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-[10px] uppercase tracking-wider text-amber-400 font-semibold">Próxima visita</p>
+                    <p className="mt-1 text-xl font-bold truncate">{next.property?.title ?? 'Imóvel'}</p>
+                    {(next.property?.neighborhood || next.property?.city) && (
+                      <p className="text-xs text-gray-400 mt-0.5">
+                        {[next.property.neighborhood, next.property.city].filter(Boolean).join(' · ')}
+                      </p>
+                    )}
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className="text-2xl font-bold text-amber-300">{fmtTime(next.scheduledAt)}</p>
+                    {nextMin != null && (
+                      <p className={`text-[10px] ${isImminent ? 'text-amber-300' : 'text-gray-500'}`}>
+                        <Clock size={9} className="inline" /> {fmtCountdown(nextMin)}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-3 rounded-lg bg-gray-950/60 px-3 py-2">
+                  <p className="text-xs">
+                    <span className="text-gray-500">Cliente:</span>{' '}
+                    <span className="font-semibold text-white">{next.visitorName}</span>
+                  </p>
+                  {next.notes && (
+                    <p className="mt-1 text-[11px] italic text-gray-400">&ldquo;{next.notes}&rdquo;</p>
+                  )}
+                </div>
+
+                <div className="mt-3 grid grid-cols-3 gap-2">
+                  <a href={`https://wa.me/55${next.visitorPhone.replace(/\D/g, '')}`}
+                     target="_blank" rel="noopener noreferrer"
+                     className="flex items-center justify-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2.5 text-xs font-semibold text-white">
+                    <MessageCircle size={14} /> WhatsApp
+                  </a>
+                  <a href={`tel:${next.visitorPhone.replace(/\D/g, '')}`}
+                     className="flex items-center justify-center gap-1.5 rounded-lg bg-gray-700 px-3 py-2.5 text-xs font-semibold text-white">
+                    <Phone size={14} /> Ligar
+                  </a>
+                  {next.mapsUrl ? (
+                    <a href={next.mapsUrl} target="_blank" rel="noopener noreferrer"
+                       className="flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2.5 text-xs font-semibold text-white">
+                      <Map size={14} /> Maps
+                    </a>
+                  ) : (
+                    <button disabled
+                      className="flex items-center justify-center gap-1.5 rounded-lg bg-gray-800 px-3 py-2.5 text-xs text-gray-500">
+                      <Map size={14} /> Sem mapa
+                    </button>
+                  )}
+                </div>
+
+                {next.status === 'pending' && (
+                  <button onClick={() => patchVisit(next.id, { status: 'confirmed' })} disabled={busy === next.id}
+                    className="mt-2 w-full flex items-center justify-center gap-1.5 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-blue-300 disabled:opacity-50">
+                    <Check size={12} /> Confirmar visita
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-gray-800 bg-gray-900/40 p-4 text-center">
+                <p className="text-sm text-gray-500">Nenhuma visita agendada na sequência.</p>
+              </div>
+            )}
+
+            {/* Agenda do dia */}
+            {data.todayVisits.length > 0 && (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <h2 className="text-xs uppercase tracking-wider text-gray-500 font-semibold">Agenda de hoje</h2>
+                  <Link href="/dashboard/agenda" className="text-xs text-amber-400">Ver tudo →</Link>
+                </div>
+                <div className="space-y-2">
+                  {data.todayVisits.map(v => {
+                    const s = STATUS[v.status] ?? STATUS.pending
+                    const closed = v.status === 'done' || v.status === 'cancelled' || v.status === 'no_show'
+                    return (
+                      <div key={v.id} className={`rounded-xl border border-gray-800 bg-gray-900/40 p-3 ${closed ? 'opacity-60' : ''}`}>
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="text-base font-bold text-amber-300">{fmtTime(v.scheduledAt)}</span>
+                              <span className={`rounded-full px-2 py-0.5 text-[9px] font-medium ${s.cls}`}>{s.label}</span>
+                            </div>
+                            <p className="mt-0.5 text-sm font-semibold text-white truncate">{v.visitorName}</p>
+                            <p className="text-[11px] text-gray-400 truncate">
+                              {v.property?.title ?? 'Imóvel'}
+                              {v.property?.neighborhood && <span className="text-gray-600"> · {v.property.neighborhood}</span>}
+                            </p>
+                          </div>
+                          <div className="flex flex-col gap-1 flex-shrink-0">
+                            <a href={`https://wa.me/55${v.visitorPhone.replace(/\D/g, '')}`} target="_blank" rel="noopener noreferrer"
+                               className="rounded-md bg-emerald-600/20 p-1.5 text-emerald-300">
+                              <MessageCircle size={12} />
+                            </a>
+                            {v.mapsUrl && (
+                              <a href={v.mapsUrl} target="_blank" rel="noopener noreferrer"
+                                 className="rounded-md bg-blue-600/20 p-1.5 text-blue-300">
+                                <MapPin size={12} />
+                              </a>
+                            )}
+                          </div>
+                        </div>
+                        {!closed && (
+                          <div className="mt-2 flex gap-1.5">
+                            {v.status === 'pending' && (
+                              <button onClick={() => patchVisit(v.id, { status: 'confirmed' })} disabled={busy === v.id}
+                                className="flex-1 flex items-center justify-center gap-1 rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-1 text-[11px] text-blue-300 disabled:opacity-50">
+                                <Check size={10} /> Confirmar
+                              </button>
+                            )}
+                            <button onClick={() => patchVisit(v.id, { status: 'done' })} disabled={busy === v.id}
+                              className="flex-1 flex items-center justify-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-300 disabled:opacity-50">
+                              <Star size={10} /> Realizada
+                            </button>
+                            <button onClick={() => patchVisit(v.id, { status: 'no_show' })} disabled={busy === v.id}
+                              className="flex-1 flex items-center justify-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[11px] text-red-300 disabled:opacity-50">
+                              <AlertCircle size={10} /> No-show
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Leads novos do dia */}
+            {data.newLeadsToday.length > 0 && (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <h2 className="text-xs uppercase tracking-wider text-gray-500 font-semibold">Leads novos hoje</h2>
+                  <Link href="/dashboard/leads" className="text-xs text-amber-400">Ver tudo →</Link>
+                </div>
+                <div className="space-y-2">
+                  {data.newLeadsToday.map(l => (
+                    <Link key={l.id} href={`/dashboard/leads/${l.id}`}
+                      className="block rounded-xl border border-gray-800 bg-gray-900/40 p-3 active:bg-gray-900">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <UserPlus size={12} className="text-amber-400 flex-shrink-0" />
+                            <p className="text-sm font-semibold truncate">{l.name}</p>
+                          </div>
+                          <p className="mt-0.5 text-[11px] text-gray-400 truncate">
+                            {l.phone || l.email || 'Sem contato'} · {l.source ?? 'site'}
+                          </p>
+                        </div>
+                        <span className="text-[10px] text-gray-500 flex-shrink-0">{relTime(l.createdAt)}</span>
+                      </div>
+                      {l.phone && (
+                        <div className="mt-2 flex gap-1.5" onClick={e => e.stopPropagation()}>
+                          <a href={`https://wa.me/55${l.phone.replace(/\D/g, '')}`} target="_blank" rel="noopener noreferrer"
+                            className="flex-1 flex items-center justify-center gap-1 rounded-md bg-emerald-600 px-2 py-1.5 text-[11px] font-semibold text-white">
+                            <MessageCircle size={11} /> WhatsApp
+                          </a>
+                          <a href={`tel:${l.phone.replace(/\D/g, '')}`}
+                            className="rounded-md bg-gray-700 px-3 py-1.5 text-[11px] text-white">
+                            <Phone size={11} />
+                          </a>
+                        </div>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {data.todayVisits.length === 0 && data.newLeadsToday.length === 0 && !next && (
+              <p className="py-8 text-center text-sm text-gray-600">
+                Dia leve. Que tal prospectar alguns leads?
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -101,6 +101,7 @@ const midNavItems = [
 ]
 
 const corretorNavItem = { href: '/dashboard/corretor', icon: BriefcaseBusiness, label: 'Meu Painel', highlight: false }
+const corretorHojeItem = { href: '/dashboard/corretor/hoje', icon: Calendar, label: 'Meu Dia', highlight: false }
 
 const lemosbankSubItems = [
   { href: '/dashboard/lemosbank',              icon: Banknote,   label: 'Visão Geral' },
@@ -338,11 +339,11 @@ function NavContent({ onClose }: { onClose?: () => void }) {
         })}
 
         {/* ── Meu Painel (corretor) — last ──────────────────── */}
-        {(() => {
-          const { href, icon: Icon, label } = corretorNavItem
-          const active = pathname === href || pathname.startsWith(href)
+        {[corretorHojeItem, corretorNavItem].map(({ href, icon: Icon, label }) => {
+          const active = pathname === href || (href !== '/dashboard/corretor' && pathname.startsWith(href)) || (href === '/dashboard/corretor' && pathname === href)
           return (
             <Link
+              key={href}
               href={href}
               onClick={onClose}
               className={cn(
@@ -355,7 +356,7 @@ function NavContent({ onClose }: { onClose?: () => void }) {
               {active && <ChevronRight className="ml-auto h-3 w-3 flex-shrink-0" />}
             </Link>
           )
-        })()}
+        })}
       </nav>
 
       {/* Bottom */}


### PR DESCRIPTION
## Summary

Corretor passa o dia na rua, no celular. O painel `/dashboard/corretor` atual é desktop-first (366 linhas, abas para KPIs históricos). Faltava a versão "agora" — o que ele precisa ver entre uma visita e outra.

### Backend

- **`GET /api/v1/corretor/today`** consolida em **1 chamada** tudo que importa pro dia:
  - `nextVisit` — próxima visita `pending`/`confirmed` (com property enrichada + `mapsUrl` pronto)
  - `todayVisits` — agenda completa do dia (00:00 a 23:59)
  - `newLeadsToday` — leads criados hoje atribuídos a este corretor
  - `kpis.visitsToday` / `leadsToday` / `pendingTasks` (tarefas nas próximas 24h)
  - `mapsUrl` montado server-side: usa coords se houver, senão endereço urlencoded — corretor abre direto no Maps com 1 toque

### Frontend — `/dashboard/corretor/hoje`

- **Header sticky** com data por extenso e botão de refresh
- **3 KPIs grandes** lado a lado (Visitas / Leads / Tarefas)
- **Card hero da próxima visita**:
  - Horário em fonte 2xl
  - Contagem regressiva (`em 32min`, `em 1h 15min`); **âmbar quando ≤ 60min**
  - Cliente + observação em destaque
  - **3 botões grandes lado a lado**: WhatsApp / Ligar / Maps (todos com `tap-target` ≥ 44px)
  - Botão "Confirmar visita" extra quando status = pending
- **Agenda do dia** com cards menores:
  - Horário gigante + status badge
  - Atalhos WhatsApp / Maps em ícones
  - Ações inline `Confirmar` / `Realizada` / `No-show`
  - Cartões `done`/`cancelled`/`no_show` ficam com opacity 60%
- **Leads novos hoje** como Link cards (tap em qualquer parte abre o detalhe), atalhos WhatsApp/Ligar embutidos com `stopPropagation`
- **Empty state** amigável quando o dia está leve
- Sidebar: nova entrada **"Meu Dia"** (ícone Calendar) logo antes de "Meu Painel"

## Test plan

- [ ] Login como corretor com pelo menos 1 visita hoje → próxima visita aparece em destaque
- [ ] Contagem regressiva fica âmbar quando faltam < 60min
- [ ] Botão Maps abre Google Maps com coords (se imóvel tem lat/lng) ou endereço (se não)
- [ ] Tocar em "Confirmar" muda status sem recarregar a tela (refetch automático)
- [ ] Tocar em "Realizada" / "No-show" também
- [ ] Lead card abre o detalhe; tocar nos botões WhatsApp/telefone NÃO navega pro detalhe
- [ ] Em iPhone Safari: nenhum elemento causa auto-zoom; tap targets confortáveis
- [ ] Corretor sem nada agendado nem leads novos vê empty state amigável


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_