### PR TITLE
Pipeline de proposta visível ao cliente — stepper público + e-mails contextuais

### DIFF
--- a/apps/api/src/routes/proposals/index.ts
+++ b/apps/api/src/routes/proposals/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Proposals — admin actions over Proposal records.
+ *
+ * PATCH /api/v1/proposals/:id — change status (counter/accept/reject),
+ *   appends a ProposalEvent, notifies the buyer with the tracking link.
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+
+export default async function proposalsRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+
+  app.patch('/:id', { schema: { tags: ['proposals'] } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const body = z.object({
+      status:        z.enum(['sent', 'countered', 'accepted', 'rejected', 'expired']).optional(),
+      counterValue:  z.number().positive().optional(),
+      note:          z.string().max(2000).optional(),
+    }).parse(req.body)
+
+    const proposal = await app.prisma.proposal.findFirst({
+      where: { id, companyId: req.user.cid },
+    })
+    if (!proposal) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const updated = await app.prisma.proposal.update({
+      where: { id },
+      data: {
+        ...(body.status !== undefined && { status: body.status }),
+        ...(body.counterValue !== undefined && { offerValue: body.counterValue }),
+      },
+    })
+
+    // Append a timeline event so the buyer page shows the change.
+    await app.prisma.proposalEvent.create({
+      data: {
+        proposalId: id,
+        type: body.status ?? 'countered',
+        actorType: 'broker',
+        value: body.counterValue ?? null,
+        note: body.note ?? null,
+      },
+    }).catch(() => {})
+
+    // Notifica o comprador com o link de acompanhamento — fechar o loop.
+    if (proposal.contactId) {
+      const contact = await app.prisma.contact.findUnique({
+        where: { id: proposal.contactId },
+        select: { email: true, name: true },
+      }).catch(() => null)
+
+      if (contact?.email) {
+        try {
+          const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+          if (isEmailConfigured()) {
+            const trackingUrl = `https://www.agoraencontrei.com.br/proposta/${id}`
+            const labels: Record<string, string> = {
+              countered: 'Recebemos uma contra-proposta',
+              accepted:  'Sua proposta foi aceita!',
+              rejected:  'Sua proposta foi recusada',
+              expired:   'Sua proposta expirou',
+              sent:      'Sua proposta está em análise',
+            }
+            const subject = labels[body.status ?? 'countered'] ?? 'Atualização da sua proposta'
+            const firstName = (contact.name ?? '').split(' ')[0] || 'Cliente'
+            await sendEmail({
+              to: contact.email,
+              subject: `${subject} — AgoraEncontrei`,
+              html: `<div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto">
+  <div style="background:#1B2B5B;color:#fff;padding:20px 24px;border-radius:8px 8px 0 0">
+    <strong style="font-size:16px">AgoraEncontrei</strong>
+  </div>
+  <div style="border:1px solid #e5e7eb;border-top:0;padding:24px;border-radius:0 0 8px 8px">
+    <h2 style="margin:0 0 8px;font-size:18px;color:#111">${firstName}, ${subject.toLowerCase()}</h2>
+    ${body.note ? `<p style="margin:0 0 16px;color:#444;line-height:1.6">${body.note.replace(/</g, '&lt;')}</p>` : ''}
+    <a href="${trackingUrl}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:bold;padding:12px 24px;border-radius:8px;text-decoration:none">Ver detalhes da proposta</a>
+  </div>
+</div>`,
+            })
+          }
+        } catch { /* non-fatal */ }
+      }
+    }
+
+    return reply.send({ data: updated })
+  })
+
+  app.get('/:id', { schema: { tags: ['proposals'] } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const proposal = await app.prisma.proposal.findFirst({
+      where: { id, companyId: req.user.cid },
+      include: { events: { orderBy: { createdAt: 'asc' } } },
+    })
+    if (!proposal) return reply.status(404).send({ error: 'NOT_FOUND' })
+    return reply.send({ data: proposal })
+  })
+}

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -805,6 +805,47 @@ export default async function publicRoutes(app: FastifyInstance) {
         },
       }).catch(() => null)
       proposalId = created?.id ?? null
+
+      // Initial event so the public timeline has a starting point.
+      if (proposalId) {
+        await app.prisma.proposalEvent.create({
+          data: {
+            proposalId,
+            type: 'sent',
+            actorType: 'buyer',
+            value: proposta.valorProposta / 100,
+            note: 'Proposta enviada pelo cliente.',
+          },
+        }).catch(() => {})
+      }
+
+      // E-mail ao comprador com link de acompanhamento — fechar o loop.
+      if (proposalId && email) {
+        try {
+          const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+          if (isEmailConfigured()) {
+            const trackingUrl = `https://www.agoraencontrei.com.br/proposta/${proposalId}`
+            const valueLabel = (proposta.valorProposta / 100).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 })
+            await sendEmail({
+              to: email,
+              subject: 'Sua proposta foi recebida — AgoraEncontrei',
+              html: `<div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto">
+  <div style="background:#1B2B5B;color:#fff;padding:20px 24px;border-radius:8px 8px 0 0">
+    <strong style="font-size:16px">AgoraEncontrei</strong>
+  </div>
+  <div style="border:1px solid #e5e7eb;border-top:0;padding:24px;border-radius:0 0 8px 8px">
+    <h2 style="margin:0 0 8px;font-size:18px;color:#111">Olá, ${name.split(' ')[0]}!</h2>
+    <p style="margin:0 0 16px;color:#444;line-height:1.6">
+      Recebemos sua proposta de <strong>${valueLabel}</strong>. Nossa equipe vai analisar e te
+      responde em até 24h. Acompanhe o andamento em tempo real pelo link abaixo:
+    </p>
+    <a href="${trackingUrl}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:bold;padding:12px 24px;border-radius:8px;text-decoration:none">Acompanhar minha proposta</a>
+  </div>
+</div>`,
+            })
+          }
+        } catch { /* non-fatal */ }
+      }
     }
 
     // In-app notification (notification center + platform admins). Email is
@@ -1150,6 +1191,43 @@ export default async function publicRoutes(app: FastifyInstance) {
   // POST /api/v1/public/visits — schedule a visit (public, no auth)
   const { default: visitRoutes } = await import('./visits.js')
   app.register(visitRoutes, { prefix: '/visits' })
+
+  // GET /api/v1/public/proposals/:id — tracking page for the buyer. Only
+  // exposes sanitized fields: status, value, events, basic property info.
+  app.get('/proposals/:id', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const proposal = await app.prisma.proposal.findUnique({
+      where: { id },
+      include: { events: { orderBy: { createdAt: 'asc' } } },
+    }).catch(() => null)
+    if (!proposal) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const prop = await app.prisma.property.findUnique({
+      where: { id: proposal.propertyId },
+      select: { title: true, slug: true, neighborhood: true, city: true, coverImage: true },
+    }).catch(() => null)
+
+    return reply.send({
+      id: proposal.id,
+      status: proposal.status,
+      offerValue: proposal.offerValue,
+      paymentMethod: proposal.paymentMethod,
+      downPayment: proposal.downPayment,
+      financingAmount: proposal.financingAmount,
+      expiresAt: proposal.expiresAt,
+      createdAt: proposal.createdAt,
+      updatedAt: proposal.updatedAt,
+      property: prop,
+      events: proposal.events.map(e => ({
+        id: e.id,
+        type: e.type,
+        actorType: e.actorType,
+        value: e.value,
+        note: e.note,
+        createdAt: e.createdAt,
+      })),
+    })
+  })
 
   // GET /api/v1/public/neighborhoods — unique neighborhoods for autocomplete
   app.get('/neighborhoods', async (req, reply) => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -101,6 +101,7 @@ import outgoingWebhooksRoutes from './routes/outgoing-webhooks/index.js'
 import marketRoutes from './routes/market/index.js'
 import systemEventsRoutes from './routes/system-events/index.js'
 import visitsRoutes from './routes/visits/index.js'
+import proposalsRoutes from './routes/proposals/index.js'
 import hunterRoutes from './routes/hunter/index.js'
 import affiliateRoutes from './routes/affiliates/index.js'
 import saasFinanceRoutes from './routes/saas-finance/index.js'
@@ -844,6 +845,7 @@ async function bootstrap() {
   await app.register(marketRoutes,           { prefix: '/api/v1/market' })
   await app.register(systemEventsRoutes,     { prefix: '/api/v1/system-events' })
   await app.register(visitsRoutes,           { prefix: '/api/v1/visits' })
+  await app.register(proposalsRoutes,        { prefix: '/api/v1/proposals' })
   await app.register(publicApiRoutes,        { prefix: '/public-api' })
   await app.register(hunterRoutes,           { prefix: '/api/v1/hunter' })
   await app.register(affiliateRoutes,        { prefix: '/api/v1/affiliates' })

--- a/apps/web/src/app/(public)/proposta/[id]/page.tsx
+++ b/apps/web/src/app/(public)/proposta/[id]/page.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface ProposalEvent {
+  id: string
+  type: string
+  actorType: string | null
+  value: string | null
+  note: string | null
+  createdAt: string
+}
+
+interface PublicProposal {
+  id: string
+  status: string
+  offerValue: string
+  paymentMethod: string | null
+  downPayment: string | null
+  financingAmount: string | null
+  expiresAt: string | null
+  createdAt: string
+  updatedAt: string
+  property: { title: string; slug: string | null; neighborhood: string | null; city: string | null; coverImage: string | null } | null
+  events: ProposalEvent[]
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  draft:     'Rascunho',
+  sent:      'Em análise',
+  countered: 'Contra-proposta',
+  accepted:  'Aceita',
+  rejected:  'Recusada',
+  expired:   'Expirada',
+}
+const STATUS_COLOR: Record<string, string> = {
+  draft:     'bg-gray-200 text-gray-700',
+  sent:      'bg-blue-100 text-blue-800',
+  countered: 'bg-amber-100 text-amber-800',
+  accepted:  'bg-emerald-100 text-emerald-800',
+  rejected:  'bg-red-100 text-red-800',
+  expired:   'bg-gray-100 text-gray-500',
+}
+
+const STEPS = [
+  { key: 'sent', label: 'Proposta enviada' },
+  { key: 'countered', label: 'Em negociação' },
+  { key: 'accepted', label: 'Aceita' },
+]
+
+function stepIndex(status: string): number {
+  if (status === 'accepted') return 2
+  if (status === 'countered') return 1
+  if (status === 'rejected' || status === 'expired') return -1
+  return 0
+}
+
+function fmtBRL(v: string | null) {
+  if (!v) return null
+  const n = Number(v)
+  if (!Number.isFinite(n)) return null
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 })
+}
+
+function fmtDateTime(iso: string) {
+  return new Date(iso).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+export default function PublicProposalPage() {
+  const { id } = useParams<{ id: string }>()
+  const [data, setData] = useState<PublicProposal | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`${API_URL}/api/v1/public/proposals/${id}`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error('not_found')))
+      .then(j => { if (!cancelled) setData(j) })
+      .catch(() => { if (!cancelled) setError(true) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [id])
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] text-[#1B2B5B]">Carregando…</main>
+  }
+
+  if (error || !data) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f9f7f4] px-4">
+        <div className="max-w-md rounded-2xl bg-white p-8 text-center shadow">
+          <h1 className="text-xl font-bold text-[#1B2B5B]">Proposta não encontrada</h1>
+          <p className="mt-2 text-sm text-gray-600">O link expirou ou está incorreto.</p>
+          <Link href="/" className="mt-6 inline-block rounded-lg bg-[#1B2B5B] px-5 py-2.5 text-sm font-medium text-white">Voltar ao site</Link>
+        </div>
+      </main>
+    )
+  }
+
+  const currentStep = stepIndex(data.status)
+  const isRejected = data.status === 'rejected' || data.status === 'expired'
+  const value = fmtBRL(data.offerValue)
+  const down = fmtBRL(data.downPayment)
+  const fin = fmtBRL(data.financingAmount)
+  const location = [data.property?.neighborhood, data.property?.city].filter(Boolean).join(', ')
+
+  return (
+    <main className="min-h-screen bg-[#f9f7f4] px-4 py-8">
+      <div className="mx-auto max-w-2xl space-y-4">
+        {/* Header */}
+        <div className="rounded-2xl bg-white p-6 shadow">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs uppercase tracking-wider text-[#C9A84C] font-semibold">Imobiliária Lemos</p>
+            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${STATUS_COLOR[data.status] ?? STATUS_COLOR.sent}`}>
+              {STATUS_LABEL[data.status] ?? data.status}
+            </span>
+          </div>
+          <h1 className="mt-3 text-2xl font-bold text-[#1B2B5B]">Sua proposta</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Enviada em {fmtDateTime(data.createdAt)}
+          </p>
+
+          {data.property && (
+            <div className="mt-4 flex gap-3 rounded-xl border border-gray-100 p-3">
+              {data.property.coverImage && (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img src={data.property.coverImage} alt={data.property.title}
+                  className="h-16 w-16 flex-shrink-0 rounded-lg object-cover" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-[#1B2B5B] truncate">{data.property.title}</p>
+                {location && <p className="text-xs text-gray-500 mt-0.5">{location}</p>}
+                {data.property.slug && (
+                  <Link href={`/imoveis/${data.property.slug}`} className="text-xs text-[#1B2B5B] underline">
+                    Ver imóvel →
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Valor */}
+          <div className="mt-4 rounded-xl bg-[#f9f7f4] p-4 text-center">
+            <p className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">Valor proposto</p>
+            <p className="mt-1 text-3xl font-bold text-[#1B2B5B]">{value ?? '—'}</p>
+            {(down || fin) && (
+              <div className="mt-2 flex justify-center gap-4 text-xs text-gray-600">
+                {down && <span>Entrada {down}</span>}
+                {fin && <span>Financ. {fin}</span>}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Stepper */}
+        <div className="rounded-2xl bg-white p-6 shadow">
+          <h2 className="text-sm font-semibold text-[#1B2B5B]">Status da negociação</h2>
+          {isRejected ? (
+            <div className="mt-4 rounded-xl bg-red-50 p-4 text-center">
+              <p className="text-sm font-semibold text-red-700">
+                {data.status === 'expired' ? 'Sua proposta expirou.' : 'Sua proposta foi recusada.'}
+              </p>
+              <p className="mt-1 text-xs text-red-600">Que tal explorar outras opções com nosso time?</p>
+              <Link href="/imoveis" className="mt-3 inline-block rounded-lg bg-[#1B2B5B] px-4 py-2 text-xs font-medium text-white">
+                Ver outros imóveis
+              </Link>
+            </div>
+          ) : (
+            <div className="mt-4 flex items-center justify-between">
+              {STEPS.map((step, i) => {
+                const done = i <= currentStep
+                const isActive = i === currentStep
+                return (
+                  <div key={step.key} className="flex flex-1 items-center">
+                    <div className="flex flex-col items-center text-center flex-1">
+                      <div className={`flex h-9 w-9 items-center justify-center rounded-full text-xs font-bold ${
+                        done ? 'bg-[#C9A84C] text-[#1B2B5B]' : 'bg-gray-200 text-gray-400'
+                      } ${isActive ? 'ring-4 ring-[#C9A84C]/30' : ''}`}>
+                        {done ? '✓' : i + 1}
+                      </div>
+                      <p className={`mt-2 text-[10px] font-medium ${done ? 'text-[#1B2B5B]' : 'text-gray-400'}`}>{step.label}</p>
+                    </div>
+                    {i < STEPS.length - 1 && (
+                      <div className={`h-0.5 flex-1 mx-1 ${i < currentStep ? 'bg-[#C9A84C]' : 'bg-gray-200'}`} />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Timeline */}
+        {data.events.length > 0 && (
+          <div className="rounded-2xl bg-white p-6 shadow">
+            <h2 className="text-sm font-semibold text-[#1B2B5B]">Histórico</h2>
+            <ol className="mt-4 space-y-3">
+              {data.events.slice().reverse().map(ev => (
+                <li key={ev.id} className="flex gap-3 border-l-2 border-[#C9A84C] pl-3 py-1">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-semibold text-[#1B2B5B]">
+                      {STATUS_LABEL[ev.type] ?? ev.type}
+                      {ev.actorType && (
+                        <span className="ml-2 font-normal text-gray-500">
+                          · {ev.actorType === 'buyer' ? 'Cliente' : ev.actorType === 'broker' ? 'Corretor' : ev.actorType === 'seller' ? 'Proprietário' : 'Sistema'}
+                        </span>
+                      )}
+                    </p>
+                    {ev.value && <p className="text-xs text-gray-600 mt-0.5">{fmtBRL(ev.value)}</p>}
+                    {ev.note && <p className="text-xs text-gray-700 mt-0.5">{ev.note}</p>}
+                    <p className="text-[10px] text-gray-400 mt-1">{fmtDateTime(ev.createdAt)}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        <p className="text-center text-[11px] text-gray-400">
+          Sua proposta é confidencial e visível apenas para você e nossa equipe.
+        </p>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Quando o cliente envia proposta online (`/proposta`), o sistema já criava o `Proposal` + `ProposalEvent`, mas faltava o lado dele: nenhum link, nenhum acompanhamento, nenhum feedback de status. O cliente ficava no escuro até o corretor ligar.

### Loop fechado

1. **Cliente envia proposta** → recebe e-mail com link `agoraencontrei.com.br/proposta/<id>` ("Acompanhar minha proposta")
2. **Cliente acessa o link** → vê valor, imóvel, status atual, stepper visual e histórico
3. **Corretor muda status** (via `PATCH /api/v1/proposals/:id`) → cliente recebe novo e-mail com assunto contextual e o mesmo link
4. **Cliente volta no link** → vê a evolução em tempo real (próxima vez que abrir)

### Backend

- **`POST /api/v1/public/proposta`** (modificado): cria `ProposalEvent` inicial (`type=sent`, `actorType=buyer`) e dispara e-mail ao comprador com o link de acompanhamento.
- **`GET /api/v1/public/proposals/:id`** (novo, sem auth): retorna versão sanitizada — status, valor, entrada, financiamento, imóvel (apenas dados públicos) e events. Não expõe `companyId`, `contactId`, `leadId`, nem qualquer payload sensível do vendedor.
- **`PATCH /api/v1/proposals/:id`** (novo, auth): muda status, opcionalmente atualiza valor de contra-proposta, append automático de `ProposalEvent` com `actorType=broker`, dispara e-mail contextual ao comprador (`"Recebemos uma contra-proposta"`, `"Sua proposta foi aceita!"`, etc.).
- Tenant-scoped por `companyId: req.user.cid`. Fail-soft nos envios de e-mail.

### Frontend — `/proposta/[id]` (público)

- **Tema navy/gold** consistente com o site.
- **Header card** com status badge colorido por tipo + data de envio.
- **Card do imóvel** com cover, título, localização e link "Ver imóvel".
- **Valor em destaque** (3xl bold) + linha menor com entrada e financiamento se houver.
- **Stepper visual** de 3 passos: Enviada → Em negociação → Aceita; passos concluídos em dourado, atual com `ring`.
- **Estado terminal vermelho** quando `rejected`/`expired` substitui o stepper, com CTA para `/imoveis`.
- **Histórico cronológico reverso** (mais recente em cima) com `actorType` traduzido (Cliente/Corretor/Proprietário/Sistema).
- Estados de loading, not-found e fail-soft.

## Test plan

- [ ] Enviar proposta pelo `/imoveis/<slug>` (modal) → comprador recebe e-mail com link `proposta/<id>`
- [ ] Abrir o link → stepper na etapa 1 ("Enviada"), histórico com 1 evento `sent` do `buyer`
- [ ] `PATCH /api/v1/proposals/<id> { status: 'countered', counterValue: 450000, note: '...' }` → comprador recebe e-mail; recarregar a página → stepper na etapa 2 + novo evento `countered` do `broker`
- [ ] `PATCH ... { status: 'accepted' }` → stepper na etapa 3, badge verde
- [ ] `PATCH ... { status: 'rejected' }` → estado vermelho com CTA "Ver outros imóveis"
- [ ] `GET /api/v1/public/proposals/<id-inexistente>` → 404 + tela amigável
- [ ] Confirmar isolamento: response do GET público não inclui `companyId`/`contactId`/`leadId`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_