### PR TITLE
Propostas: UI dashboard para o corretor responder em 1 clique

### DIFF
--- a/apps/api/src/routes/proposals/index.ts
+++ b/apps/api/src/routes/proposals/index.ts
@@ -11,6 +11,50 @@ import { z } from 'zod'
 export default async function proposalsRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
 
+  // GET / — lista propostas da empresa, com filtros e enrich.
+  app.get('/', { schema: { tags: ['proposals'] } }, async (req, reply) => {
+    const q = req.query as { status?: string; limit?: string }
+    const take = Math.min(Number(q.limit) || 100, 500)
+
+    const proposals = await app.prisma.proposal.findMany({
+      where: {
+        companyId: req.user.cid,
+        ...(q.status && { status: q.status }),
+      },
+      orderBy: { createdAt: 'desc' },
+      take,
+    })
+
+    const propertyIds = [...new Set(proposals.map(p => p.propertyId))]
+    const contactIds = [...new Set(proposals.map(p => p.contactId).filter((c): c is string => !!c))]
+
+    const [properties, contacts] = await Promise.all([
+      propertyIds.length
+        ? app.prisma.property.findMany({
+            where: { id: { in: propertyIds } },
+            select: { id: true, title: true, slug: true, neighborhood: true, city: true, coverImage: true, price: true },
+          }).catch(() => [])
+        : Promise.resolve([]),
+      contactIds.length
+        ? app.prisma.contact.findMany({
+            where: { id: { in: contactIds } },
+            select: { id: true, name: true, email: true, phone: true },
+          }).catch(() => [])
+        : Promise.resolve([]),
+    ])
+
+    const pById = new Map(properties.map(p => [p.id, p]))
+    const cById = new Map(contacts.map(c => [c.id, c]))
+
+    return reply.send({
+      data: proposals.map(p => ({
+        ...p,
+        property: pById.get(p.propertyId) ?? null,
+        contact: p.contactId ? cById.get(p.contactId) ?? null : null,
+      })),
+    })
+  })
+
   app.patch('/:id', { schema: { tags: ['proposals'] } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const body = z.object({

--- a/apps/web/src/app/(dashboard)/dashboard/propostas/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/propostas/page.tsx
@@ -1,0 +1,302 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import {
+  FileText, Loader2, RefreshCw, Check, X, MessageCircle, ExternalLink,
+  TrendingUp, TrendingDown, Clock, Award,
+} from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface Proposal {
+  id: string
+  status: string
+  offerValue: string
+  paymentMethod: string | null
+  downPayment: string | null
+  financingAmount: string | null
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+  property: { id: string; title: string; slug: string | null; neighborhood: string | null; city: string | null; price: string | null; coverImage: string | null } | null
+  contact: { id: string; name: string; email: string | null; phone: string | null } | null
+}
+
+const STATUS: Record<string, { label: string; cls: string }> = {
+  sent:      { label: 'Em análise',     cls: 'bg-blue-500/15 text-blue-300' },
+  countered: { label: 'Contra-proposta', cls: 'bg-amber-500/15 text-amber-300' },
+  accepted:  { label: 'Aceita',          cls: 'bg-emerald-500/15 text-emerald-300' },
+  rejected:  { label: 'Recusada',        cls: 'bg-red-500/15 text-red-300' },
+  expired:   { label: 'Expirada',        cls: 'bg-gray-500/15 text-gray-400' },
+}
+
+function fmtBRL(v: string | null) {
+  if (!v) return null
+  const n = Number(v)
+  if (!Number.isFinite(n)) return null
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 })
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: '2-digit' })
+}
+
+function diffPct(offer: string, listed: string | null): number | null {
+  const o = Number(offer); const l = Number(listed)
+  if (!Number.isFinite(o) || !Number.isFinite(l) || l === 0) return null
+  return ((o - l) / l) * 100
+}
+
+export default function PropostasPage() {
+  const { getValidToken } = useAuth()
+  const [proposals, setProposals] = useState<Proposal[]>([])
+  const [loading, setLoading] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [busy, setBusy] = useState<string | null>(null)
+  const [counterFor, setCounterFor] = useState<string | null>(null)
+  const [counterValue, setCounterValue] = useState('')
+  const [counterNote, setCounterNote] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const token = await getValidToken()
+      const q = new URLSearchParams()
+      if (filter) q.set('status', filter)
+      const res = await fetch(`${API_URL}/api/v1/proposals?${q}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      setProposals(j.data ?? [])
+    } catch { setProposals([]) }
+    finally { setLoading(false) }
+  }, [filter, getValidToken])
+
+  useEffect(() => { load() }, [load])
+
+  async function patch(id: string, body: Record<string, unknown>) {
+    setBusy(id)
+    try {
+      const token = await getValidToken()
+      await fetch(`${API_URL}/api/v1/proposals/${id}`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      await load()
+    } finally { setBusy(null) }
+  }
+
+  async function submitCounter() {
+    if (!counterFor) return
+    const val = Number(counterValue.replace(/\D/g, '')) / 100
+    if (!val || val <= 0) return
+    await patch(counterFor, { status: 'countered', counterValue: val, note: counterNote || undefined })
+    setCounterFor(null); setCounterValue(''); setCounterNote('')
+  }
+
+  const total = proposals.length
+  const pending = proposals.filter(p => p.status === 'sent' || p.status === 'countered').length
+  const accepted = proposals.filter(p => p.status === 'accepted').length
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <div className="border-b border-gray-800">
+        <div className="mx-auto max-w-6xl px-4 py-4 sm:py-6 sm:px-6 flex items-center gap-3">
+          <FileText size={24} className="text-amber-400" />
+          <div className="flex-1 min-w-0">
+            <h1 className="text-lg sm:text-2xl font-bold">Propostas</h1>
+            <p className="mt-0.5 text-xs sm:text-sm text-gray-400">
+              Responda em 1 clique — o cliente é notificado e enxerga o status no link público
+            </p>
+          </div>
+          <button onClick={load}
+            className="flex items-center gap-1.5 rounded-lg border border-gray-700 px-3 py-2 text-xs text-gray-300 hover:bg-gray-800">
+            <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-6xl px-4 py-5 sm:px-6 space-y-4">
+        {/* KPIs */}
+        {total > 0 && (
+          <div className="grid grid-cols-3 gap-2">
+            <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+              <div className="text-[10px] uppercase tracking-wider text-gray-500">Total</div>
+              <p className="mt-1 text-xl font-bold text-white">{total}</p>
+            </div>
+            <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+              <div className="text-[10px] uppercase tracking-wider text-gray-500">Aguardando resposta</div>
+              <p className="mt-1 text-xl font-bold text-amber-300">{pending}</p>
+            </div>
+            <div className="rounded-xl border border-gray-800 bg-gray-900/40 p-3">
+              <div className="text-[10px] uppercase tracking-wider text-gray-500">Aceitas</div>
+              <p className="mt-1 text-xl font-bold text-emerald-300">{accepted}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="flex flex-wrap gap-1">
+          {[['', 'Todas'], ['sent', 'Em análise'], ['countered', 'Contra-prop.'], ['accepted', 'Aceitas'], ['rejected', 'Recusadas']]
+            .map(([v, l]) => (
+            <button key={v} onClick={() => setFilter(v)}
+              className={`rounded-full px-3 py-1 text-xs ${filter === v ? 'bg-amber-600 text-white' : 'bg-gray-900 text-gray-400 hover:text-white'}`}>
+              {l}
+            </button>
+          ))}
+        </div>
+
+        {loading && total === 0 ? (
+          <div className="flex justify-center py-10"><Loader2 className="animate-spin text-amber-400" /></div>
+        ) : proposals.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-600">Nenhuma proposta.</p>
+        ) : (
+          <div className="space-y-2">
+            {proposals.map(p => {
+              const s = STATUS[p.status] ?? STATUS.sent
+              const busyThis = busy === p.id
+              const offer = fmtBRL(p.offerValue)
+              const listed = fmtBRL(p.property?.price ?? null)
+              const pct = diffPct(p.offerValue, p.property?.price ?? null)
+              const phoneClean = p.contact?.phone?.replace(/\D/g, '') ?? ''
+              const open = p.status === 'sent' || p.status === 'countered'
+
+              return (
+                <div key={p.id} className="rounded-xl border border-gray-800 bg-gray-900/40 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-semibold text-white">{p.contact?.name ?? 'Cliente'}</span>
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${s.cls}`}>{s.label}</span>
+                        <span className="text-[10px] text-gray-500">{fmtDate(p.createdAt)}</span>
+                      </div>
+
+                      <p className="mt-0.5 text-xs text-gray-400 truncate">
+                        {p.property ? (
+                          <Link href={`/imoveis/${p.property.slug ?? p.property.id}`} className="hover:text-amber-400">
+                            {p.property.title}
+                          </Link>
+                        ) : 'Imóvel removido'}
+                        {p.property?.neighborhood && <span className="text-gray-600"> · {p.property.neighborhood}</span>}
+                      </p>
+
+                      <div className="mt-2 flex items-baseline gap-3 flex-wrap">
+                        <span className="text-xl font-bold text-amber-300">{offer ?? '—'}</span>
+                        {listed && (
+                          <span className="text-[11px] text-gray-500">
+                            Anunciado: {listed}
+                            {pct != null && (
+                              <span className={`ml-1 font-semibold ${pct < -5 ? 'text-red-400' : pct > 0 ? 'text-emerald-400' : 'text-gray-400'}`}>
+                                {pct < 0 ? <TrendingDown size={10} className="inline" /> : pct > 0 ? <TrendingUp size={10} className="inline" /> : null}
+                                {' '}{pct >= 0 ? '+' : ''}{pct.toFixed(0)}%
+                              </span>
+                            )}
+                          </span>
+                        )}
+                      </div>
+
+                      {(p.paymentMethod || p.downPayment) && (
+                        <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-gray-500">
+                          {p.paymentMethod && <span className="rounded bg-gray-800 px-1.5 py-0.5">{p.paymentMethod}</span>}
+                          {p.downPayment && <span>Entrada {fmtBRL(p.downPayment)}</span>}
+                          {p.financingAmount && <span>Financ. {fmtBRL(p.financingAmount)}</span>}
+                        </div>
+                      )}
+
+                      {p.notes && (
+                        <details className="mt-2">
+                          <summary className="text-[11px] text-gray-500 cursor-pointer hover:text-gray-300">Ver detalhes</summary>
+                          <pre className="mt-1 whitespace-pre-wrap text-[11px] text-gray-400 font-sans">{p.notes}</pre>
+                        </details>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {phoneClean && (
+                        <a href={`https://wa.me/55${phoneClean}`} target="_blank" rel="noopener noreferrer"
+                          className="text-emerald-400 hover:text-emerald-300" title="WhatsApp">
+                          <MessageCircle size={16} />
+                        </a>
+                      )}
+                      <Link href={`/proposta/${p.id}`} target="_blank" rel="noopener noreferrer"
+                        className="text-gray-400 hover:text-white" title="Link público do cliente">
+                        <ExternalLink size={14} />
+                      </Link>
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  {open && counterFor !== p.id && (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      <button onClick={() => patch(p.id, { status: 'accepted' })} disabled={busyThis}
+                        className="flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-50">
+                        <Check size={12} /> Aceitar
+                      </button>
+                      <button onClick={() => { setCounterFor(p.id); setCounterValue(''); setCounterNote('') }}
+                        disabled={busyThis}
+                        className="flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs text-amber-300 hover:bg-amber-500/20 disabled:opacity-50">
+                        <Award size={12} /> Contra-proposta
+                      </button>
+                      <button onClick={() => patch(p.id, { status: 'rejected' })} disabled={busyThis}
+                        className="flex items-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-xs text-red-300 hover:bg-red-500/20 disabled:opacity-50">
+                        <X size={12} /> Recusar
+                      </button>
+                      {p.status === 'sent' && (
+                        <button onClick={() => patch(p.id, { status: 'expired' })} disabled={busyThis}
+                          className="flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-400 hover:bg-gray-800 disabled:opacity-50">
+                          <Clock size={12} /> Marcar expirada
+                        </button>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Counter-proposal form */}
+                  {counterFor === p.id && (
+                    <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 space-y-2">
+                      <p className="text-xs text-amber-200 font-semibold">Sua contra-proposta</p>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={counterValue}
+                        onChange={e => {
+                          const digits = e.target.value.replace(/\D/g, '')
+                          if (!digits) { setCounterValue(''); return }
+                          const n = Number(digits) / 100
+                          setCounterValue(n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }))
+                        }}
+                        placeholder="R$ 0,00"
+                        className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-white"
+                        style={{ fontSize: '16px' }}
+                      />
+                      <textarea
+                        value={counterNote}
+                        onChange={e => setCounterNote(e.target.value)}
+                        placeholder="Mensagem para o cliente (opcional)"
+                        rows={2}
+                        className="w-full rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-white"
+                        style={{ fontSize: '16px' }}
+                      />
+                      <div className="flex gap-2">
+                        <button onClick={submitCounter} disabled={!counterValue || busyThis}
+                          className="rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-500 disabled:opacity-50">
+                          Enviar contra-proposta
+                        </button>
+                        <button onClick={() => setCounterFor(null)}
+                          className="rounded-md border border-gray-700 px-3 py-1.5 text-xs text-gray-400 hover:bg-gray-800">
+                          Cancelar
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -73,6 +73,7 @@ const midNavItems = [
   { href: '/dashboard/contacts',            icon: Users,            label: 'Contatos',      highlight: false },
   { href: '/dashboard/deals',               icon: TrendingUp,       label: 'Negócios',      highlight: false },
   { href: '/dashboard/agenda',              icon: Calendar,         label: 'Agenda de Visitas', highlight: false },
+  { href: '/dashboard/propostas',           icon: FileText,         label: 'Propostas',     highlight: false },
   { href: '/dashboard/alertas',             icon: Bell,             label: 'Alertas de Match', highlight: false },
   { href: '/dashboard/inbox',               icon: MessageCircle,    label: 'Lemos.chat',    highlight: false },
   { href: '/dashboard/financiamentos',      icon: Landmark,         label: 'Financiamentos',highlight: false },


### PR DESCRIPTION
## Summary

Fecha o ciclo do PR #122 (pipeline visível ao cliente): agora o **corretor tem UI** para responder em 1 clique. O backend PATCH já existia, mas sem tela era inutilizável.

### Backend

- **`GET /api/v1/proposals`** (novo, auth, tenant-scoped): lista propostas da empresa com filtro `?status=`. Enriquece com `property` (id, title, slug, neighborhood, city, price, coverImage) e `contact` (id, name, email, phone) — tudo em batch, sem N+1.

### Frontend — `/dashboard/propostas`

- **3 KPIs**: total / aguardando resposta (sent+countered) / aceitas
- **Filtros chip** por status (Todas / Em análise / Contra-prop. / Aceitas / Recusadas)
- **Cards de proposta** com:
  - Cliente + status badge + data de envio
  - Imóvel como link clicável para o detalhe público
  - **Valor proposto em destaque** (texto âmbar grande) + valor anunciado lado a lado com **diff percentual colorido** (verde quando ≥ preço, vermelho quando < -5%, cinza neutro)
  - Forma de pagamento, entrada, financiamento em chips
  - Detalhes completos em `<details>` para não poluir o card
  - Atalho WhatsApp do contato + link público (`/proposta/[id]`) em ícone external — útil pro corretor ver o que o cliente está vendo
- **Ações inline** (só aparecem em propostas abertas):
  - **Aceitar** → PATCH `{ status: 'accepted' }` → cliente recebe e-mail
  - **Contra-proposta** → abre formulário inline com input monetário formatado em `R$` + textarea de mensagem opcional → PATCH `{ status: 'countered', counterValue, note }` → cliente recebe e-mail "Recebemos uma contra-proposta"
  - **Recusar** → PATCH `{ status: 'rejected' }`
  - **Marcar expirada** (só em `sent`)
- Input/textarea com `fontSize: '16px'` (anti-zoom iOS Safari)
- Entrada **"Propostas"** no sidebar entre Agenda e Alertas

## Test plan

- [ ] Login como corretor → `/dashboard/propostas` lista propostas da empresa, isoladas (não vê de outra empresa)
- [ ] Tocar Aceitar → status muda, cliente recebe e-mail "Sua proposta foi aceita!", `/proposta/[id]` mostra stepper na etapa 3 verde
- [ ] Contra-proposta → digitar "450000" → mostra "R$ 4.500,00" formatado; enviar com note → cliente recebe e-mail; valor da proposta atualizado; novo evento no histórico
- [ ] Recusar → estado vermelho no link público com CTA "Ver outros imóveis"
- [ ] Marcar expirada → mesmo fluxo, e-mail "Sua proposta expirou"
- [ ] Filtros chip funcionam (sent, countered, accepted, rejected)
- [ ] Diff percentual: proposta R$ 400k em imóvel R$ 500k → mostra "-20%" em vermelho com `TrendingDown`
- [ ] Proposta em imóvel removido → mostra "Imóvel removido" sem quebrar


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_