### PR TITLE
Lead scoring automático — engine ativada com sinais reais do DB

### DIFF
--- a/apps/api/src/routes/proposals/index.ts
+++ b/apps/api/src/routes/proposals/index.ts
@@ -127,6 +127,16 @@ export default async function proposalsRoutes(app: FastifyInstance) {
       }
     }
 
+    // Re-pontua o lead — proposta aceita = lead super-quente.
+    if (proposal.leadId) {
+      void (async () => {
+        try {
+          const { scoreLeadFromDb } = await import('../../services/lead-auto-score.service.js')
+          await scoreLeadFromDb(app.prisma, proposal.leadId!)
+        } catch { /* non-fatal */ }
+      })()
+    }
+
     return reply.send({ data: updated })
   })
 

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -641,6 +641,15 @@ export default async function publicRoutes(app: FastifyInstance) {
       },
     })
 
+    // Auto-score: deriva o score a partir dos sinais já presentes (telefone,
+    // e-mail, orçamento, UTM, etc.). Fire-and-forget para não atrasar o 201.
+    void (async () => {
+      try {
+        const { scoreLeadFromDb } = await import('../../services/lead-auto-score.service.js')
+        await scoreLeadFromDb(app.prisma, lead.id)
+      } catch { /* non-fatal */ }
+    })()
+
     // Fire SSE + automation
     const { emitAutomation } = await import('../../services/automation.emitter.js')
     const { emitSSE }        = await import('../../services/sse.emitter.js')
@@ -890,6 +899,15 @@ export default async function publicRoutes(app: FastifyInstance) {
         })
       }
     } catch { /* non-fatal */ }
+
+    // Auto-score: agora que lead + proposta + ProposalEvent estão no DB,
+    // o score reflete o sinal forte de "proposta enviada".
+    void (async () => {
+      try {
+        const { scoreLeadFromDb } = await import('../../services/lead-auto-score.service.js')
+        await scoreLeadFromDb(app.prisma, lead.id)
+      } catch { /* non-fatal */ }
+    })()
 
     return reply.status(201).send({
       id: lead.id,

--- a/apps/api/src/routes/visits/index.ts
+++ b/apps/api/src/routes/visits/index.ts
@@ -174,6 +174,22 @@ export default async function visitsRoutes(app: FastifyInstance) {
         ...(body.feedback !== undefined && { feedback: body.feedback }),
       },
     })
+
+    // Re-pontua leads ligados a este visitante por telefone — visita
+    // realizada/no-show é sinal forte de mudança de temperatura.
+    if (body.status !== undefined) {
+      void (async () => {
+        try {
+          const leads = await app.prisma.lead.findMany({
+            where: { companyId: req.user.cid, phone: updated.visitorPhone },
+            select: { id: true },
+          }).catch(() => [])
+          const { scoreLeadFromDb } = await import('../../services/lead-auto-score.service.js')
+          for (const l of leads) await scoreLeadFromDb(app.prisma, l.id)
+        } catch { /* non-fatal */ }
+      })()
+    }
+
     return reply.send({ data: updated })
   })
 }

--- a/apps/api/src/services/lead-auto-score.service.ts
+++ b/apps/api/src/services/lead-auto-score.service.ts
@@ -1,0 +1,135 @@
+/**
+ * Lead Auto-Score — deriva o LeadBehavior do que está no DB e pontua o lead.
+ *
+ * Diferente do lead-scoring.service genérico (que recebe dados de analytics
+ * externo), aqui usamos os sinais que JÁ temos: telefone, e-mail, propriedades
+ * de interesse (LeadProperty), visitas agendadas/realizadas (PropertyVisit),
+ * propostas enviadas (Proposal), última atividade (lastContactAt + Activity).
+ *
+ * Chamar após qualquer evento que mude esses sinais. Fail-soft: nunca lança.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { calculateLeadScore, type LeadBehavior } from './lead-scoring.service.js'
+
+export async function scoreLeadFromDb(
+  prisma: PrismaClient,
+  leadId: string,
+): Promise<{ score: number; temperature: string } | null> {
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: {
+      id: true, name: true, email: true, phone: true, interest: true, budget: true,
+      utmSource: true, utmMedium: true, contactId: true, lastContactAt: true,
+      createdAt: true, companyId: true,
+    },
+  }).catch(() => null)
+  if (!lead) return null
+
+  const phone = lead.phone ?? null
+  const email = lead.email ?? null
+
+  // Quantos imóveis de interesse este lead já tem (LeadProperty).
+  const favCount = await prisma.leadProperty.count({
+    where: { leadId: lead.id },
+  }).catch(() => 0)
+
+  // Visitas — fortíssimo sinal de intenção. Cruzamos por contato e telefone.
+  let visitScheduledCount = 0
+  let visitDoneCount = 0
+  if (lead.contactId || phone) {
+    const visits = await prisma.propertyVisit.findMany({
+      where: {
+        companyId: lead.companyId,
+        OR: [
+          phone ? { visitorPhone: phone } : {},
+          // future: tie by contactId once that link exists
+        ].filter(o => Object.keys(o).length > 0),
+      },
+      select: { status: true },
+    }).catch(() => [])
+    for (const v of visits) {
+      if (v.status === 'done') visitDoneCount++
+      else if (v.status === 'pending' || v.status === 'confirmed') visitScheduledCount++
+    }
+  }
+
+  // Propostas — sinal mais forte ainda.
+  let proposalCount = 0
+  let proposalAcceptedCount = 0
+  if (lead.contactId) {
+    const proposals = await prisma.proposal.findMany({
+      where: { leadId: lead.id },
+      select: { status: true },
+    }).catch(() => [])
+    proposalCount = proposals.length
+    proposalAcceptedCount = proposals.filter(p => p.status === 'accepted').length
+  }
+
+  // Atividade nas últimas X horas/dias — recência.
+  const lastTouch = lead.lastContactAt ?? lead.createdAt
+  const lastVisitDaysAgo = Math.floor((Date.now() - lastTouch.getTime()) / 86_400_000)
+
+  // Mensagens trocadas (Activity type "message" ou similar).
+  const messagesCount = await prisma.activity.count({
+    where: { leadId: lead.id, type: { in: ['message', 'whatsapp', 'call'] } },
+  }).catch(() => 0)
+
+  const behavior: LeadBehavior = {
+    totalPageViews: 0,
+    propertyViews: favCount,                 // proxy: salvou imóvel = viu
+    photoViews: 0,
+    timeOnSiteMinutes: 0,
+    messagesCount,
+    // Sinais ricos do nosso domínio entram como "cliques fortes" — não há
+    // campo dedicado no LeadBehavior original, então mapeamos como WhatsApp
+    // clicks (peso alto) os eventos de intenção real: visita agendada,
+    // visita realizada, proposta enviada. Cada evento conta como 1 clique
+    // até o cap (3) — depois disso vira saturação.
+    whatsappClicks: Math.min(visitScheduledCount + proposalCount, 3),
+    phoneCallClicks: Math.min(visitDoneCount + proposalAcceptedCount, 2),
+    favoritesCount: favCount,
+    searchesCount: 0,
+    returnVisits: 0,
+    lastVisitDaysAgo,
+    utmSource: lead.utmSource ?? undefined,
+    utmMedium: lead.utmMedium ?? undefined,
+    interest: lead.interest ?? undefined,
+    budget: lead.budget ? Number(lead.budget) : undefined,
+    hasEmail: !!email,
+    hasPhone: !!phone,
+  }
+
+  const result = calculateLeadScore(behavior)
+
+  await prisma.lead.update({
+    where: { id: leadId },
+    data: {
+      score: result.score,
+      // Preserva tags existentes, troca apenas o token de temperatura.
+      tags: { set: await rebuildTagsWithTemperature(prisma, leadId, result.temperature) },
+      metadata: {
+        ...((await prisma.lead.findUnique({
+          where: { id: leadId }, select: { metadata: true },
+        }).catch(() => null))?.metadata as Record<string, unknown> ?? {}),
+        leadScore: result as unknown as object,
+        scoredAt: new Date().toISOString(),
+      } as object,
+    },
+  }).catch(() => {})
+
+  return { score: result.score, temperature: result.temperature }
+}
+
+async function rebuildTagsWithTemperature(
+  prisma: PrismaClient,
+  leadId: string,
+  temperature: string,
+): Promise<string[]> {
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: { tags: true },
+  }).catch(() => null)
+  const existing = (lead?.tags ?? []).filter(t => !t.startsWith('temperature:'))
+  return [...existing, `temperature:${temperature}`]
+}

--- a/apps/web/src/app/(dashboard)/dashboard/leads/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/leads/page.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { formatCurrency } from '@/lib/utils'
 import Link from 'next/link'
-import { UserCheck, Phone, Mail, Star, ChevronLeft, ChevronRight } from 'lucide-react'
+import { UserCheck, Phone, Mail, ChevronLeft, ChevronRight } from 'lucide-react'
 import { SearchInputWithVoice } from '@/components/ui/SearchInputWithVoice'
 
 const STATUS_COLORS: Record<string, string> = {
@@ -121,7 +121,22 @@ export default function LeadsPage() {
   )
 }
 
+const TEMP_BADGE: Record<string, { label: string; cls: string; emoji: string }> = {
+  on_fire: { label: 'Super quente', cls: 'bg-red-100 text-red-700 border-red-300',     emoji: '🔥' },
+  hot:     { label: 'Quente',       cls: 'bg-orange-100 text-orange-700 border-orange-300', emoji: '🌶️' },
+  warm:    { label: 'Morno',        cls: 'bg-yellow-100 text-yellow-700 border-yellow-300', emoji: '☀️' },
+  cold:    { label: 'Frio',         cls: 'bg-blue-50 text-blue-600 border-blue-200',      emoji: '❄️' },
+}
+
+function temperatureFor(score: number): keyof typeof TEMP_BADGE {
+  if (score >= 76) return 'on_fire'
+  if (score >= 51) return 'hot'
+  if (score >= 26) return 'warm'
+  return 'cold'
+}
+
 function LeadRow({ lead }: { lead: Lead }) {
+  const temp = TEMP_BADGE[temperatureFor(lead.score ?? 0)]
   return (
     <Link href={`/dashboard/leads/${lead.id}`} className="flex items-center gap-4 px-4 py-3 hover:bg-muted/50 transition-colors cursor-pointer block">
       {/* Avatar */}
@@ -161,10 +176,12 @@ function LeadRow({ lead }: { lead: Lead }) {
             <p className="text-sm font-medium">{formatCurrency(lead.budget)}</p>
           </div>
         )}
-        <div className="flex items-center gap-1">
-          <Star className="h-3 w-3 text-yellow-500" />
-          <span className="text-sm font-medium">{lead.score}</span>
-        </div>
+        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${temp.cls}`}
+          title={`Score ${lead.score}/100 — ${temp.label}`}>
+          <span>{temp.emoji}</span>
+          <span className="hidden sm:inline">{temp.label}</span>
+          <span className="ml-0.5 font-bold">{lead.score}</span>
+        </span>
         {lead.assignedTo && (
           <div className="hidden md:block text-right">
             <p className="text-xs text-muted-foreground">Corretor</p>


### PR DESCRIPTION
## Summary

`Lead.score` existia no schema (default 0) e a engine `lead-scoring.service.ts` calculava temperatura, mas **nada chamava a engine no fluxo real** — todo lead nascia com score 0 e ninguém atualizava. Os corretores não tinham sinal de priorização.

Em vez de exigir dados de analytics externos que não coletamos, derivo o `LeadBehavior` dos sinais que JÁ estão no DB.

### Backend — `lead-auto-score.service.ts`

`scoreLeadFromDb(prisma, leadId)` cruza:

| Sinal capturado | Mapeado em `LeadBehavior` | Peso na engine |
|---|---|---|
| Tem phone | `hasPhone` | +8 |
| Tem email | `hasEmail` | +5 |
| Tem budget definido | `budget` | +5 |
| `LeadProperty` count (imóveis salvos) | `favoritesCount` + `propertyViews` | +5 / +3 |
| Visitas `pending`/`confirmed` (matched por phone) | parte de `whatsappClicks` | +10 |
| Proposta enviada | parte de `whatsappClicks` | +10 |
| Visita `done` | parte de `phoneCallClicks` | +12 |
| Proposta `accepted` | parte de `phoneCallClicks` | +12 |
| `Activity` tipo message/whatsapp/call | `messagesCount` | +8 |
| `lastContactAt` recente | `lastVisitDaysAgo` | até +15 |
| UTM medium = cpc/ppc | bonus | +3 |

Persiste:
- `Lead.score` (Int 0-100)
- Tag `temperature:<cold|warm|hot|on_fire>` (preserva outras tags)
- `metadata.leadScore` com detalhamento (reasons, priority, suggestedAction, conversionProbability)
- `metadata.scoredAt`

### Gatilhos automáticos (fire-and-forget, fail-soft)

1. **`POST /api/v1/public/leads`** — após criação do lead
2. **`POST /api/v1/public/proposta`** — após criar lead + proposal + ProposalEvent (captura o boost da proposta)
3. **`PATCH /api/v1/visits/:id`** quando `status` muda — re-pontua todos os leads com o mesmo `phone` do visitante
4. **`PATCH /api/v1/proposals/:id`** — re-pontua o `leadId` (aceita = on_fire)

### Frontend — `/dashboard/leads`

- Badge de temperatura colorido com emoji ao lado de cada lead:
  - 🔥 **Super quente** (score ≥ 76) — vermelho
  - 🌶️ **Quente** (51-75) — laranja
  - ☀️ **Morno** (26-50) — amarelo
  - ❄️ **Frio** (0-25) — azul claro
- Mobile: emoji + score visível, label esconde
- Desktop: emoji + label + score
- Tooltip com `Score X/100 — Label` para acessibilidade

## Test plan

- [ ] Criar lead pelo `/public/leads` só com nome+phone → score atualiza (não fica em 0)
- [ ] Mesmo lead salva 3 imóveis (LeadProperty) → score sobe → vira `warm`
- [ ] Lead faz proposta `/public/proposta` → score sobe (~hot)
- [ ] Corretor marca proposta como `accepted` → lead vira `on_fire` (≥76)
- [ ] Lead com visita agendada → boost de +10
- [ ] Visita marcada como `done` → score recalcula automaticamente
- [ ] Lead sem nenhum sinal há 30+ dias → `cold` (recency bonus zera)
- [ ] `/dashboard/leads` mostra badges coloridos; mobile mantém score visível
- [ ] Tooltip do badge mostra "Score X/100 — Label"


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_