### PR TITLE
Leads: filtros chip por temperatura (🔥 Super quentes / Quentes / Mornos / Frios)

### DIFF
--- a/apps/api/src/routes/leads/index.ts
+++ b/apps/api/src/routes/leads/index.ts
@@ -72,6 +72,22 @@ export default async function leadsRoutes(app: FastifyInstance) {
       ]
     }
 
+    // Temperature filter — maps the bucket to a score range.
+    // Use orderBy=score so quentes vêm primeiro quando filtrando.
+    const TEMP_RANGES: Record<string, { gte?: number; lte?: number }> = {
+      on_fire: { gte: 76 },
+      hot:     { gte: 51, lte: 75 },
+      warm:    { gte: 26, lte: 50 },
+      cold:    { lte: 25 },
+    }
+    let orderBy: any = { createdAt: 'desc' }
+    if (q.temperature && TEMP_RANGES[q.temperature]) {
+      where.score = TEMP_RANGES[q.temperature]
+      orderBy = [{ score: 'desc' }, { createdAt: 'desc' }]
+    } else if (q.sort === 'score') {
+      orderBy = [{ score: 'desc' }, { createdAt: 'desc' }]
+    }
+
     const page  = parseInt(q.page  ?? '1',  10)
     const limit = parseInt(q.limit ?? '50', 10)
 
@@ -119,7 +135,7 @@ export default async function leadsRoutes(app: FastifyInstance) {
           contact:    { select: { id: true, name: true } },
           _count:     { select: { activities: true } },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy,
         skip: (page - 1) * limit,
         take: limit,
       }),

--- a/apps/web/src/app/(dashboard)/dashboard/leads/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/leads/page.tsx
@@ -36,10 +36,15 @@ export default function LeadsPage() {
   const { accessToken } = useAuthStore()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState('')
+  const [temperature, setTemperature] = useState<'' | 'on_fire' | 'hot' | 'warm' | 'cold'>('')
 
   const { data, isLoading } = useQuery({
-    queryKey: ['leads', page, search],
-    queryFn: () => leadsApi.list(accessToken!, { page, limit: 50, search: search || undefined }),
+    queryKey: ['leads', page, search, temperature],
+    queryFn: () => leadsApi.list(accessToken!, {
+      page, limit: 50,
+      search: search || undefined,
+      temperature: temperature || undefined,
+    }),
     enabled: !!accessToken,
   })
 
@@ -52,19 +57,44 @@ export default function LeadsPage() {
         <div>
           <h1 className="text-2xl font-bold">Leads</h1>
           <p className="text-muted-foreground text-sm mt-1">
-            {meta ? `${meta.total} leads no total` : 'Carregando...'}
+            {meta ? `${meta.total} leads${temperature ? ` — filtro: ${TEMP_BADGE[temperature].label}` : ' no total'}` : 'Carregando...'}
           </p>
         </div>
       </div>
 
-      <SearchInputWithVoice
-        containerClassName="max-w-md"
-        placeholder="Buscar por nome, e-mail, telefone..."
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        onVoiceResult={(t) => setSearch(t)}
-      />
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+        <SearchInputWithVoice
+          containerClassName="max-w-md flex-1"
+          placeholder="Buscar por nome, e-mail, telefone..."
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onVoiceResult={(t) => setSearch(t)}
+        />
+
+        {/* Temperature chips */}
+        <div className="flex flex-wrap gap-1.5">
+          {([
+            ['', 'Todos', null],
+            ['on_fire', '🔥 Super quentes', 'border-red-300 bg-red-100 text-red-700'],
+            ['hot', '🌶️ Quentes', 'border-orange-300 bg-orange-100 text-orange-700'],
+            ['warm', '☀️ Mornos', 'border-yellow-300 bg-yellow-100 text-yellow-700'],
+            ['cold', '❄️ Frios', 'border-blue-200 bg-blue-50 text-blue-600'],
+          ] as const).map(([v, l, cls]) => (
+            <button
+              key={v}
+              onClick={() => { setTemperature(v as typeof temperature); setPage(1) }}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                temperature === v
+                  ? (cls ?? 'border-primary bg-primary text-primary-foreground')
+                  : 'border-input bg-background text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {isLoading ? (
         <div className="space-y-3">


### PR DESCRIPTION
## Summary

Fecha o loop do PR #124 (scoring automático): agora o corretor consegue filtrar por temperatura na listagem `/dashboard/leads` e atacar os mais quentes primeiro.

### Backend

- **`GET /api/v1/leads?temperature=on_fire|hot|warm|cold`** — mapeia para faixa de `score`:
  - `on_fire`: 76+
  - `hot`: 51–75
  - `warm`: 26–50
  - `cold`: 0–25
- Quando o filtro de temperatura está ativo, ou quando `?sort=score`, ordena por `score desc` + `createdAt desc` — quentes recentes primeiro.

### Frontend — `/dashboard/leads`

- 5 chips coloridos abaixo da busca:
  - **Todos** (sem filtro)
  - **🔥 Super quentes** — vermelho
  - **🌶️ Quentes** — laranja
  - **☀️ Mornos** — amarelo
  - **❄️ Frios** — azul claro
- Chip ativo herda a cor do badge da temperatura (coerência visual com PR #124).
- Inativo: cinza neutro com hover.
- Subtitle dinâmico: `42 leads — filtro: Quentes` quando filtrando, `42 leads no total` quando não.
- Trocar filtro reseta `page` para 1.

## Test plan

- [ ] Listagem com leads em várias temperaturas → todos visíveis em "Todos"
- [ ] Clicar "🔥 Super quentes" → só leads com `score ≥ 76` aparecem
- [ ] Quando filtrado, ordem é score desc (mais quente em cima)
- [ ] Clicar "Todos" volta para ordem por `createdAt desc`
- [ ] Total no header reflete o filtro (`X leads — filtro: ...`)
- [ ] Mobile: chips fazem wrap em múltiplas linhas, fontes legíveis


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_