### PR TITLE
Meu Dia: Pitche agora — leads quentes sem contato hoje em destaque

### DIFF
--- a/apps/api/src/routes/users/corretor.ts
+++ b/apps/api/src/routes/users/corretor.ts
@@ -111,6 +111,36 @@ export default async function corretorRoutes(app: FastifyInstance) {
       return addr ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(addr)}` : null
     }
 
+    // Top leads quentes que NÃO receberam pitch hoje. "Pitch" = qualquer
+    // Activity tipo whatsapp/call/email registrada hoje.
+    const hotCandidates = await app.prisma.lead.findMany({
+      where: {
+        companyId: cid,
+        assignedToId: userId,
+        score: { gte: 51 },
+        status: { notIn: ['WON', 'LOST', 'ARCHIVED'] },
+      },
+      select: { id: true, name: true, phone: true, score: true, status: true, interest: true, budget: true },
+      orderBy: { score: 'desc' },
+      take: 20,
+    })
+
+    let topHotLeads: typeof hotCandidates = []
+    if (hotCandidates.length > 0) {
+      const pitchedIds = new Set<string>(
+        (await app.prisma.activity.findMany({
+          where: {
+            companyId: cid, userId,
+            leadId: { in: hotCandidates.map(l => l.id) },
+            type: { in: ['whatsapp', 'call', 'email'] },
+            createdAt: { gte: dayStart },
+          },
+          select: { leadId: true },
+        }).catch(() => [])).map(a => a.leadId).filter((id): id is string => !!id),
+      )
+      topHotLeads = hotCandidates.filter(l => !pitchedIds.has(l.id)).slice(0, 2)
+    }
+
     return reply.send({
       now: now.toISOString(),
       nextVisit: nextVisit
@@ -122,6 +152,7 @@ export default async function corretorRoutes(app: FastifyInstance) {
         mapsUrl: mapsUrl(propById.get(v.propertyId)),
       })),
       newLeadsToday,
+      topHotLeads,
       kpis: {
         visitsToday: todayVisits.length,
         leadsToday: newLeadsToday.length,

--- a/apps/web/src/app/(dashboard)/dashboard/corretor/hoje/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/corretor/hoje/page.tsx
@@ -25,11 +25,21 @@ interface Lead {
   id: string; name: string; phone: string | null; email: string | null
   status: string; source: string | null; createdAt: string
 }
+interface HotLead {
+  id: string
+  name: string
+  phone: string | null
+  score: number
+  status: string
+  interest: string | null
+  budget: string | null
+}
 interface Today {
   now: string
   nextVisit: Visit | null
   todayVisits: Visit[]
   newLeadsToday: Lead[]
+  topHotLeads?: HotLead[]
   kpis: { visitsToday: number; leadsToday: number; pendingTasks: number }
 }
 
@@ -140,6 +150,54 @@ export default function CorretorHojePage() {
                 <p className="mt-1 text-2xl font-bold text-blue-300">{data.kpis.pendingTasks}</p>
               </div>
             </div>
+
+            {/* Pitche agora — leads quentes sem contato hoje */}
+            {(data.topHotLeads?.length ?? 0) > 0 && (
+              <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-[10px] uppercase tracking-wider text-red-300 font-semibold">🔥 Pitche agora</p>
+                  <span className="text-[9px] text-gray-500">sem contato hoje</span>
+                </div>
+                <div className="space-y-2">
+                  {data.topHotLeads!.map(l => {
+                    const temp = l.score >= 76 ? { emoji: '🔥', label: 'Super quente' } : { emoji: '🌶️', label: 'Quente' }
+                    const phoneClean = l.phone?.replace(/\D/g, '') ?? ''
+                    return (
+                      <div key={l.id} className="rounded-xl bg-gray-950/60 p-3">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              <span>{temp.emoji}</span>
+                              <p className="text-sm font-bold text-white truncate">{l.name}</p>
+                              <span className="text-[10px] font-bold text-red-300 flex-shrink-0">{l.score}</span>
+                            </div>
+                            <p className="text-[10px] text-gray-400 mt-0.5">
+                              {temp.label}
+                              {l.interest && <span> · {l.interest === 'buy' ? 'Comprar' : 'Alugar'}</span>}
+                              {l.budget && (
+                                <span> · até R$ {Number(l.budget).toLocaleString('pt-BR', { maximumFractionDigits: 0 })}</span>
+                              )}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="mt-2 flex gap-1.5">
+                          <Link href={`/dashboard/leads/${l.id}`}
+                            className="flex-1 flex items-center justify-center gap-1 rounded-md bg-red-600 hover:bg-red-500 px-2 py-1.5 text-[11px] font-semibold text-white">
+                            Pitch agora →
+                          </Link>
+                          {phoneClean && (
+                            <a href={`https://wa.me/55${phoneClean}`} target="_blank" rel="noopener noreferrer"
+                              className="flex items-center justify-center rounded-md bg-emerald-600/20 px-2 py-1.5 text-emerald-300">
+                              <MessageCircle size={12} />
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
 
             {/* Próxima visita — destaque grande */}
             {next ? (


### PR DESCRIPTION
## Summary

Corretor abre o painel "Meu Dia" no celular pra ver agenda + leads novos. Agora também vê uma seção destacada no topo: **🔥 Pitche agora** — leads quentes que ele ainda não pitchou hoje. Combina os 4 sistemas que construímos: scoring (PR #124-126) + recomendações (PR #127-128) + painel mobile (PR #121) + timeline de atividades.

### Backend — `GET /api/v1/corretor/today`

Novo campo `topHotLeads[]` com:
- `score >= 51` (hot ou on_fire)
- `status NOT IN (WON, LOST, ARCHIVED)` — só pipeline ativo
- **Filtro anti-spam**: leads SEM `Activity` tipo `whatsapp`/`call`/`email` registrada hoje pelo próprio corretor (que ele já tocou hoje some da lista)
- Ordem por `score desc`, top 2

### Frontend — `/dashboard/corretor/hoje`

Nova seção destacada **acima** da Próxima Visita (prioridade máxima):

- Card vermelho com `border-red-500/30 bg-red-500/5` — chama atenção
- Header `🔥 Pitche agora` + subtítulo "sem contato hoje"
- Cada lead em mini-card cinza com:
  - Emoji da temperatura (🔥 on_fire / 🌶️ hot)
  - Nome em destaque + score numérico em vermelho
  - Linha de contexto: temperatura, interesse (Comprar/Alugar), budget
  - **Botão "Pitch agora →"** (vermelho, full-width) levando ao `/dashboard/leads/<id>` — onde o corretor já encontra as recomendações automáticas + botão WhatsApp por imóvel
  - Atalho WhatsApp lateral quando phone disponível

### Como o ciclo se fecha

| Hora | Evento |
|---|---|
| 03h | Job nightly recalcula scores, leads esfriam por recency |
| 08h | Corretor abre `/corretor/hoje` no celular |
| 08h | Vê 2 leads `🔥` que não tocou hoje → toca "Pitch agora" |
| 08h | Detalhe do lead mostra 3 imóveis recomendados (PR #127) |
| 08h | Toca "Enviar via WhatsApp" no melhor match (PR #128) |
| 08h | Activity `whatsapp` é criada — lead sai da lista "Pitche agora" |
| 09h | Volta pro Meu Dia → vê próximo lead quente, ou trabalha a agenda |

A seção esconde-by-default: dia em que todos os quentes já foram tocados = card some, painel fica limpo.

## Test plan

- [ ] Login como corretor com 3+ leads score≥51 → vê os top 2 no painel
- [ ] Tocar "Pitch agora" em um lead → leva a `/dashboard/leads/<id>`
- [ ] Lá, tocar "Enviar via WhatsApp" em uma recomendação → cria Activity
- [ ] Voltar pro `/corretor/hoje` → aquele lead some, próximo aparece
- [ ] Corretor sem leads quentes → seção não renderiza
- [ ] Lead com status `WON` ou `LOST` → não aparece mesmo com score alto
- [ ] Lead pitchado por OUTRO corretor hoje → ainda aparece pra mim (filtro é por `userId`)
- [ ] Mobile: cards e botões com tap targets confortáveis


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_