### PR TITLE
Configurações: toggles de notificação no perfil (e-mail, digest diário, WhatsApp)

### DIFF
--- a/apps/api/src/routes/users/index.ts
+++ b/apps/api/src/routes/users/index.ts
@@ -16,6 +16,9 @@ const UpdateUserBody = z.object({
   hasDataAccess: z.boolean().optional(),
   welcomeMessage: z.string().optional(),
   welcomeDuration: z.number().optional(),
+  notifyEmail: z.boolean().optional(),
+  notifyWhatsapp: z.boolean().optional(),
+  dailyDigest: z.boolean().optional(),
 })
 
 // All available system modules for granular permission control
@@ -354,14 +357,17 @@ export default async function usersRoutes(app: FastifyInstance) {
 
     const existingUser = await app.prisma.user.findUnique({ where: { id }, select: { id: true, name: true, role: true, phone: true, bio: true, creciNumber: true, settings: true } })
 
-    // Extract permission fields that go into settings JSON
-    const { accessLevel, moduleAccess, hasDataAccess, welcomeMessage, welcomeDuration, ...directFields } = body
+    // Extract permission/preference fields that go into settings JSON
+    const { accessLevel, moduleAccess, hasDataAccess, welcomeMessage, welcomeDuration, notifyEmail, notifyWhatsapp, dailyDigest, ...directFields } = body
     const updateData: any = { ...directFields }
 
-    // Update settings if permission fields are provided
-    if (accessLevel !== undefined || moduleAccess !== undefined || hasDataAccess !== undefined || welcomeMessage !== undefined || welcomeDuration !== undefined) {
+    // Update settings if permission or preference fields are provided
+    if (accessLevel !== undefined || moduleAccess !== undefined || hasDataAccess !== undefined || welcomeMessage !== undefined || welcomeDuration !== undefined || notifyEmail !== undefined || notifyWhatsapp !== undefined || dailyDigest !== undefined) {
       const currentSettings = (existingUser?.settings as Record<string, any>) ?? {}
       const newSettings = { ...currentSettings }
+      if (notifyEmail !== undefined) newSettings.notifyEmail = notifyEmail
+      if (notifyWhatsapp !== undefined) newSettings.notifyWhatsapp = notifyWhatsapp
+      if (dailyDigest !== undefined) newSettings.dailyDigest = dailyDigest
       if (accessLevel) {
         newSettings.accessLevel = accessLevel
         if (accessLevel === 'full') newSettings.moduleAccess = ALL_MODULES

--- a/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -469,6 +469,7 @@ export default function SettingsPage() {
 
   // ── Profile ───────────────────────────────────────────────────────────────
   const [profile, setProfile] = useState({ name: '', phone: '', creciNumber: '', bio: '' })
+  const [notifPrefs, setNotifPrefs] = useState({ notifyEmail: true, notifyWhatsapp: true, dailyDigest: true })
   const [profileSaved, setProfileSaved] = useState(false)
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
@@ -477,6 +478,12 @@ export default function SettingsPage() {
   useEffect(() => {
     if (user) {
       setProfile({ name: user.name ?? '', phone: user.phone ?? '', creciNumber: user.creciNumber ?? '', bio: (user as User & { bio?: string }).bio ?? '' })
+      const s = (user as any).settings ?? {}
+      setNotifPrefs({
+        notifyEmail: s.notifyEmail !== false,
+        notifyWhatsapp: s.notifyWhatsapp !== false,
+        dailyDigest: s.dailyDigest !== false,
+      })
     }
   }, [user])
 
@@ -518,7 +525,7 @@ export default function SettingsPage() {
       if (avatarFile) {
         avatarUrl = await uploadAvatar()
       }
-      return usersApi.update(token!, user!.id, { ...profile, ...(avatarUrl ? { avatarUrl } : {}) })
+      return usersApi.update(token!, user!.id, { ...profile, ...notifPrefs, ...(avatarUrl ? { avatarUrl } : {}) })
     },
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: ['me'] })
@@ -1133,6 +1140,26 @@ export default function SettingsPage() {
                 <DarkInput label="CRECI" value={profile.creciNumber} onChange={e => setProfile(p => ({ ...p, creciNumber: e.target.value }))} placeholder="000000-F" />
               </div>
               <DarkTextarea label="Bio / Apresentação" value={profile.bio} onChange={e => setProfile(p => ({ ...p, bio: e.target.value }))} rows={3} placeholder="Sobre você, especialidades, tempo de mercado..." />
+            </Section>
+
+            <Section title="Notificações">
+              <div className="space-y-3">
+                <Toggle
+                  checked={notifPrefs.notifyEmail}
+                  onChange={v => setNotifPrefs(p => ({ ...p, notifyEmail: v }))}
+                  label="Receber notificações por e-mail (novos leads, visitas, propostas)"
+                />
+                <Toggle
+                  checked={notifPrefs.dailyDigest}
+                  onChange={v => setNotifPrefs(p => ({ ...p, dailyDigest: v }))}
+                  label="Receber resumo diário às 07h (agenda, leads quentes, propostas pendentes)"
+                />
+                <Toggle
+                  checked={notifPrefs.notifyWhatsapp}
+                  onChange={v => setNotifPrefs(p => ({ ...p, notifyWhatsapp: v }))}
+                  label="Receber alertas por WhatsApp (quando configurado)"
+                />
+              </div>
             </Section>
 
             <div className="flex items-center gap-3">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -264,7 +264,7 @@ export const usersApi = {
   create: (token: string, body: { name: string; email: string; password: string; role: string; phone?: string; creciNumber?: string }) =>
     request<User>('/api/v1/users', { method: 'POST', token, body: JSON.stringify(body) }),
 
-  update: (token: string, id: string, body: { name?: string; phone?: string; bio?: string; creciNumber?: string; avatarUrl?: string; role?: string }) =>
+  update: (token: string, id: string, body: { name?: string; phone?: string; bio?: string; creciNumber?: string; avatarUrl?: string; role?: string; notifyEmail?: boolean; notifyWhatsapp?: boolean; dailyDigest?: boolean }) =>
     request<User>(`/api/v1/users/${id}`, { method: 'PATCH', token, body: JSON.stringify(body) }),
 
   delete: (token: string, id: string) =>


### PR DESCRIPTION
## Summary

Fecha o loop do digest (#130): o backend já respeitava `settings.dailyDigest` e `settings.notifyEmail`, mas o corretor não tinha como mexer nisso. Agora controla pela aba **Perfil** das configurações.

### Backend

- `UpdateUserBody` (`PATCH /api/v1/users/:id`) aceita 3 novos campos: `notifyEmail`, `notifyWhatsapp`, `dailyDigest`.
- Mesclados no `settings` JSON do usuário (junto com as prefs de acesso que já existiam) — não sobrescreve nada existente.

### Frontend — `/dashboard/settings` aba Perfil

Nova seção **"Notificações"** com 3 toggles (componente `Toggle` já existente, estilo consistente):
- **E-mail** — novos leads, visitas, propostas
- **Resumo diário às 07h** — agenda, leads quentes, propostas pendentes (o digest do #130)
- **WhatsApp** — alertas quando configurado

- Estado inicializado a partir de `user.settings`, tratando ausência como `true` (default ligado) — coerente com o backend que só faz skip quando o valor é explicitamente `=== false`.
- Salva junto com o resto do perfil no mesmo botão "Salvar".

## Test plan

- [ ] Abrir `/dashboard/settings` → aba Perfil → seção Notificações aparece com os 3 toggles
- [ ] Toggles refletem o estado atual do usuário (default todos ligados)
- [ ] Desligar "Resumo diário" + salvar → `settings.dailyDigest = false` persistido
- [ ] No próximo tick das 07h, esse corretor NÃO recebe o digest (validado pelo job do #130)
- [ ] Desligar "E-mail" → não recebe notificações de novos leads (validado pelo `notification.service`)
- [ ] Religar tudo + salvar → volta a receber
- [ ] Recarregar a página → toggles refletem o estado salvo


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_