### PR TITLE
Master Intel: imóveis mais vistos do marketplace (cross-tenant)

### DIFF
--- a/apps/api/src/services/master/intelligence.service.ts
+++ b/apps/api/src/services/master/intelligence.service.ts
@@ -13,6 +13,7 @@ import type {
   GeoMetrics,
   GrowthEngineMetrics,
   MasterIntelligenceResponse,
+  TopPropertyMetric,
 } from '../../types/master-intelligence.js'
 import { buildForecast } from './forecast.service.js'
 import { buildRetention } from './retention.service.js'
@@ -271,8 +272,35 @@ async function buildGrowthEngine(prisma: any): Promise<GrowthEngineMetrics> {
   }
 }
 
+// ── Top Marketplace Properties (cross-tenant, por views) ────────────────────
+
+async function buildTopProperties(prisma: any): Promise<TopPropertyMetric[]> {
+  const rows = await prisma.property.findMany({
+    where: { status: 'ACTIVE', authorizedPublish: true },
+    select: {
+      id: true, title: true, slug: true, city: true, neighborhood: true,
+      price: true, views: true, coverImage: true,
+      company: { select: { name: true, tradeName: true } },
+    },
+    orderBy: { views: 'desc' },
+    take: 10,
+  }).catch(() => [])
+
+  return rows.map((p: any) => ({
+    id: p.id,
+    title: p.title,
+    slug: p.slug ?? null,
+    city: p.city ?? null,
+    neighborhood: p.neighborhood ?? null,
+    price: p.price != null ? Number(p.price) : null,
+    views: p.views ?? 0,
+    coverImage: p.coverImage ?? null,
+    companyName: p.company?.tradeName || p.company?.name || null,
+  }))
+}
+
 export async function buildMasterIntelligence(prisma: any): Promise<MasterIntelligenceResponse> {
-  const [revenue, sales, retention, forecast, affiliates, geo, growthEngine] = await Promise.all([
+  const [revenue, sales, retention, forecast, affiliates, geo, growthEngine, topProperties] = await Promise.all([
     buildRevenue(prisma),
     buildSales(prisma),
     buildRetention(prisma),
@@ -280,6 +308,7 @@ export async function buildMasterIntelligence(prisma: any): Promise<MasterIntell
     buildAffiliateMetrics(prisma),
     buildGeo(prisma),
     buildGrowthEngine(prisma),
+    buildTopProperties(prisma),
   ])
 
   const channels = await buildChannelAttribution(prisma)
@@ -318,6 +347,7 @@ export async function buildMasterIntelligence(prisma: any): Promise<MasterIntell
     geo,
     advisor,
     growthEngine,
+    topProperties,
     generatedAt: new Date().toISOString(),
   }
 }

--- a/apps/api/src/types/master-intelligence.ts
+++ b/apps/api/src/types/master-intelligence.ts
@@ -257,5 +257,18 @@ export interface MasterIntelligenceResponse {
   geo: GeoMetrics
   advisor: AdvisorInsights
   growthEngine: GrowthEngineMetrics
+  topProperties: TopPropertyMetric[]
   generatedAt: string
+}
+
+export interface TopPropertyMetric {
+  id: string
+  title: string
+  slug: string | null
+  city: string | null
+  neighborhood: string | null
+  price: number | null
+  views: number
+  coverImage: string | null
+  companyName: string | null
 }

--- a/apps/web/src/app/(dashboard)/dashboard/master/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/master/page.tsx
@@ -89,7 +89,7 @@ export default function MasterPage() {
     )
   }
 
-  const { revenue, sales, channels, retention, forecast, unitEconomics, affiliates, geo, advisor, growthEngine } = intel
+  const { revenue, sales, channels, retention, forecast, unitEconomics, affiliates, geo, advisor, growthEngine, topProperties } = intel
 
   // Chart data
   const planChartData = (revenue?.receitaPorPlano || []).map((p: any) => ({
@@ -577,6 +577,34 @@ export default function MasterPage() {
               <div key={`${c.city}-${c.state}`} className="flex items-center justify-between bg-gray-50 rounded-lg p-2 text-sm">
                 <span className="text-gray-700">{c.city}{c.state ? ` - ${c.state}` : ''}</span>
                 <span className="text-gray-500 text-xs">{c.leads} leads</span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {(topProperties || []).length > 0 && (
+        <CollapsibleSection
+          id="topProps" title="Imóveis mais vistos (marketplace)" icon={<Building2 className="h-4 w-4 text-amber-600" />}
+          expanded={expandedSection === 'topProps'} onToggle={() => toggleSection('topProps')}
+          summary={`${topProperties.length} imóveis | ${topProperties.reduce((s: number, p: any) => s + (p.views ?? 0), 0).toLocaleString('pt-BR')} views`}
+        >
+          <div className="space-y-1.5">
+            {topProperties.map((p: any, i: number) => (
+              <div key={p.id} className="flex items-center gap-2 bg-gray-50 rounded-lg p-2 text-sm">
+                <span className="text-xs font-bold text-gray-400 w-5 flex-shrink-0">{i + 1}</span>
+                {p.coverImage && (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img src={p.coverImage} alt={p.title} className="h-9 w-9 rounded object-cover flex-shrink-0" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="text-gray-800 truncate text-xs font-medium">{p.title}</p>
+                  <p className="text-gray-400 text-[10px] truncate">
+                    {[p.neighborhood, p.city].filter(Boolean).join(' · ')}
+                    {p.companyName && <span> · {p.companyName}</span>}
+                  </p>
+                </div>
+                <span className="text-amber-600 text-xs font-semibold flex-shrink-0">{(p.views ?? 0).toLocaleString('pt-BR')} views</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Auditei o Master Intel (já é bem completo: MRR/ARR, churn, afiliados, growth engine, forecast, geo, advisor). O gap real e mais autocontido era **imóveis mais vistos do marketplace** — o dado existe em `Property.views`, mas não havia agregação cross-tenant, endpoint nem UI.

### Backend

- Novo type `TopPropertyMetric` em `master-intelligence.ts`
- `buildTopProperties(prisma)` no `intelligence.service.ts`: busca top 10 properties `status=ACTIVE` + `authorizedPublish=true` de **todos os tenants**, ordenadas por `views desc`, com a empresa dona anexada (tradeName ou name)
- Roda em paralelo com os outros builders no `Promise.all` do `buildMasterIntelligence`
- Adicionado ao `MasterIntelligenceResponse` como `topProperties`

### Frontend — `/dashboard/master`

Nova `CollapsibleSection` "**Imóveis mais vistos (marketplace)**" (ícone Building2 âmbar) antes do banner de status:
- Ranking 1-10 com posição, thumbnail, título, bairro/cidade e empresa dona
- Views por imóvel em destaque âmbar
- Header da seção mostra total de imóveis + soma de views
- Reusa o componente `CollapsibleSection` existente (consistência)

### Por que essa escolha

O audit mostrou que quase tudo do Master Intel já estava pronto. Outros gaps (repasse queue UI, webhook health UI, CAC/LTV aguardando integração de mídia) ou dependem de integrações externas ou são de menor valor. "Top properties" é cross-tenant puro, dado já existente, e dá ao super-admin a visão de marketplace que faltava.

## Test plan

- [ ] Login como SUPER_ADMIN → `/dashboard/master` → seção "Imóveis mais vistos" aparece
- [ ] Ranking ordenado por views desc (mais visto em #1)
- [ ] Cada item mostra thumbnail, título, localização, empresa dona
- [ ] Header da seção soma corretamente o total de views
- [ ] Imóveis de empresas diferentes aparecem juntos (cross-tenant)
- [ ] Só properties ACTIVE + authorizedPublish entram (rascunhos/inativos não)
- [ ] Plataforma sem properties → seção não renderiza
- [ ] Usuário não-SUPER_ADMIN → endpoint `/master/intelligence` segue bloqueado (sem regressão)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_