### PR TITLE
Robô WhatsApp qualificador (1/3): urgência + scoring + handoff humano

### DIFF
--- a/apps/api/src/routes/whatsapp/index.ts
+++ b/apps/api/src/routes/whatsapp/index.ts
@@ -257,27 +257,49 @@ async function runBot(app: FastifyInstance, conversation: any, phone: string, in
 
     case 'ASK_PROPERTY': {
       next.propertySearch = input.trim()
+      next.step = 'ASK_URGENCY'
+      if (env.WHATSAPP_TOKEN) await BOT_STEPS.ASK_URGENCY(phone)
+      break
+    }
+
+    case 'ASK_URGENCY': {
+      // Accept the interactive button id or free text fallback.
+      const urgency = input.startsWith('urgency_')
+        ? input.replace('urgency_', '')
+        : /(já|agora|urg)/i.test(input) ? 'urgent'
+        : /(mês|mes|semana)/i.test(input) ? 'month'
+        : 'exploring'
+      next.urgency = urgency
       next.step = 'DONE'
 
-      // Create lead in CRM
-      const name = state.name ?? contactName(conversation)
-      const budget = parseBudget(state.budget)
+      const finalState = { ...state, urgency }
+      const name = finalState.name ?? contactName(conversation)
+      const budget = parseBudget(finalState.budget)
+      const urgencyLabel = urgency === 'urgent' ? 'Alta (quer já)'
+        : urgency === 'month' ? 'Média (neste mês)' : 'Baixa (pesquisando)'
 
       const lead = await app.prisma.lead.create({
         data: {
           companyId,
           name,
           phone,
-          interest: state.interest,
+          interest: finalState.interest,
           budget,
           source: 'whatsapp',
           status: 'NEW',
-          notes: `Busca: ${input.trim()}`,
-          metadata: { botState: state } as any,
+          notes: [
+            `Qualificado via WhatsApp bot.`,
+            `Busca: ${finalState.propertySearch ?? '—'}`,
+            `Orçamento informado: ${finalState.budget ?? '—'}`,
+            `Urgência: ${urgencyLabel}`,
+          ].join('\n'),
+          tags: urgency === 'urgent' ? ['urgente', 'whatsapp_bot'] : ['whatsapp_bot'],
+          metadata: { botState: finalState } as any,
         },
       })
 
-      // Link lead to conversation
+      // Link lead to conversation; handoff: urgentes vão direto pra fila
+      // humana (open), os demais ficam open também mas sem flag.
       await app.prisma.conversation.update({
         where: { id: conversation.id },
         data: { leadId: lead.id, status: 'open' },
@@ -288,10 +310,43 @@ async function runBot(app: FastifyInstance, conversation: any, phone: string, in
           companyId,
           leadId: lead.id,
           type: 'system',
-          title: 'Lead capturado via WhatsApp',
-          description: `Bot qualificou: ${name}, interesse: ${state.interest}, orçamento: ${state.budget}`,
+          title: 'Lead qualificado via WhatsApp',
+          description: `Bot: ${name} · ${finalState.interest ?? '?'} · ${finalState.budget ?? '?'} · urgência ${urgencyLabel}`,
         },
-      })
+      }).catch(() => {})
+
+      // Score imediatamente com os sinais coletados (#124).
+      let scored: { score: number; temperature: string } | null = null
+      try {
+        const { scoreLeadFromDb } = await import('../../services/lead-auto-score.service.js')
+        scored = await scoreLeadFromDb(app.prisma, lead.id)
+      } catch { /* non-fatal */ }
+
+      // Notifica o time — urgentes com prioridade visual no corpo.
+      try {
+        const { notify } = await import('../../services/notification.service.js')
+        const tempLabel = scored
+          ? (scored.score >= 76 ? '🔥 Super quente' : scored.score >= 51 ? '🌶️ Quente' : scored.score >= 26 ? '☀️ Morno' : '❄️ Frio')
+          : ''
+        await notify({
+          prisma: app.prisma,
+          companyId,
+          type: 'lead_captured',
+          title: urgency === 'urgent'
+            ? `🔥 Lead URGENTE via WhatsApp: ${name}`
+            : `Novo lead via WhatsApp: ${name}`,
+          body: [
+            `${name} foi qualificado pelo bot do WhatsApp.`,
+            `Telefone: ${phone}`,
+            `Interesse: ${finalState.interest === 'buy' ? 'Comprar' : finalState.interest === 'rent' ? 'Alugar' : '—'}`,
+            `Orçamento: ${finalState.budget ?? '—'}`,
+            `Busca: ${finalState.propertySearch ?? '—'}`,
+            `Urgência: ${urgencyLabel}`,
+            scored ? `Score: ${scored.score}/100 ${tempLabel}` : '',
+          ].filter(Boolean).join('\n'),
+          payload: { leadId: lead.id, phone, conversationId: conversation.id, urgency, score: scored?.score ?? null },
+        })
+      } catch { /* non-fatal */ }
 
       if (env.WHATSAPP_TOKEN) await BOT_STEPS.DONE(phone, name)
       await clearState(app.redis, phone)

--- a/apps/api/src/services/whatsapp.service.ts
+++ b/apps/api/src/services/whatsapp.service.ts
@@ -78,11 +78,12 @@ export const whatsappService = {
 // ── Qualification Bot ────────────────────────────────────────────────────────
 
 type BotState = {
-  step: 'GREET' | 'ASK_NAME' | 'ASK_INTEREST' | 'ASK_BUDGET' | 'ASK_PROPERTY' | 'DONE'
+  step: 'GREET' | 'ASK_NAME' | 'ASK_INTEREST' | 'ASK_BUDGET' | 'ASK_PROPERTY' | 'ASK_URGENCY' | 'DONE'
   name?: string
   interest?: string
   budget?: string
   propertySearch?: string
+  urgency?: string  // urgent | month | exploring
 }
 
 export const BOT_STEPS = {
@@ -115,7 +116,20 @@ export const BOT_STEPS = {
   ASK_PROPERTY: async (to: string) => {
     await whatsappService.sendText(
       to,
-      'Que tipo de imóvel você procura? Localização preferida? 📍',
+      'Que tipo de imóvel você procura? Qual bairro ou região prefere? 📍',
+    )
+    return {}
+  },
+
+  ASK_URGENCY: async (to: string) => {
+    await whatsappService.sendInteractive(
+      to,
+      'Para te atender melhor: qual a sua urgência? ⏱️',
+      [
+        { id: 'urgency_urgent', title: 'Quero já 🔥' },
+        { id: 'urgency_month', title: 'Neste mês' },
+        { id: 'urgency_exploring', title: 'Só pesquisando' },
+      ],
     )
     return {}
   },


### PR DESCRIPTION
## Summary

Primeiro PR do **Robô WhatsApp qualificador**. Já existia um bot básico de 6 passos (`whatsapp.service.ts` + webhook em `/api/v1/whatsapp/webhook`, state em Redis 24h). Este PR fecha o ciclo de qualificação ligando-o ao scoring (#124) e ao handoff humano.

### O que mudou

Fluxo antes: `GREET → ASK_NAME → ASK_BUDGET → ASK_PROPERTY → DONE` (criava Lead cru, score 0).

Fluxo agora: `GREET → ASK_NAME → ASK_BUDGET → ASK_PROPERTY → **ASK_URGENCY** → DONE`.

- **Novo passo ASK_URGENCY** com botões interativos: *Quero já 🔥 / Neste mês / Só pesquisando*. Fallback por texto livre (regex) se o usuário digitar em vez de tocar.
- **Lead enriquecido**: notas estruturadas (busca, orçamento, urgência), tag `urgente` quando aplicável, `botState` completo em metadata.
- **Scoring imediato**: chama `scoreLeadFromDb` (#124) ao criar o lead — nasce com score + temperatura corretos, não em 0.
- **Notificação priorizada**: time recebe `🔥 Lead URGENTE via WhatsApp: <nome>` para urgentes, ou título normal para os demais. Corpo traz interesse, orçamento, busca, urgência e score+temperatura.
- **Handoff**: vincula o Lead à Conversation e move `status` de `bot` → `open` (sai do modo bot, entra na fila humana do inbox que já existe).

### Não mudou (de propósito)

- Provider Meta Cloud API, webhook, dedup, Conversation/Message models — tudo reusado
- Tomás (agente web) segue intocado
- Redis como store de estado do fluxo (24h TTL)

### Próximos PRs do bot (não neste)

- Auto-agendamento de visita pelo próprio chat quando urgência alta
- Reengajamento se o lead abandonar no meio do fluxo
- Resposta a perguntas livres com busca de imóveis (integrar catálogo)

## Test plan

- [ ] Mandar mensagem para o número do WhatsApp → bot cumprimenta e pergunta comprar/alugar
- [ ] Responder nome → pergunta orçamento → pergunta tipo/bairro → **pergunta urgência com 3 botões**
- [ ] Tocar "Quero já 🔥" → Lead criado com tag `urgente`, notificação com título 🔥, status da conversa vira `open`
- [ ] Lead criado tem score > 0 (calculado pelo auto-score)
- [ ] Digitar "é pra já" em vez de tocar botão → cai em `urgent` pelo fallback regex
- [ ] Conferir no inbox: conversa saiu do modo bot e aparece na fila aberta com lead vinculado
- [ ] Timeline do lead mostra atividade "Lead qualificado via WhatsApp"


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_