### PR TITLE
Robô WhatsApp qualificador (2/3): reengajamento de leads abandonados

### DIFF
--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -1033,4 +1033,69 @@ export async function runScheduledJobs(app: FastifyInstance) {
       app.log.error({ err }, '[scheduled] daily-broker-digest failed')
     }
   }
+
+  // ── 12. Reengajamento do bot WhatsApp ───────────────────────────────────
+  // Conversa parada em modo bot (status='bot') significa que o lead começou
+  // mas abandonou o fluxo de qualificação (concluir move pra 'open'). Manda
+  // um nudge único entre 1h e 24h após a última mensagem.
+  try {
+    if (env.WHATSAPP_TOKEN && env.WHATSAPP_PHONE_ID) {
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+
+      const stalled = await app.prisma.conversation.findMany({
+        where: {
+          status: 'bot',
+          channel: 'whatsapp',
+          lastMessageAt: { lt: oneHourAgo, gte: oneDayAgo },
+        },
+        select: { id: true, phone: true, companyId: true, contactName: true },
+        take: 200,
+      }).catch(() => [])
+
+      if (stalled.length > 0) {
+        const { whatsappService } = await import('./whatsapp.service.js')
+        let nudged = 0
+
+        for (const conv of stalled) {
+          const already = await app.prisma.auditLog.findFirst({
+            where: { resource: 'conversation', resourceId: conv.id, action: 'whatsapp.bot.nudge' as any },
+          }).catch(() => null)
+          if (already) continue
+
+          const first = (conv.contactName ?? '').split(' ')[0]
+          const msg = `${first ? `Oi ${first}! ` : 'Oi! '}Vi que você começou a busca por um imóvel com a gente mas não finalizou. 😊\n\nQuer continuar de onde parou? É rapidinho — me responde aqui que eu te ajudo a encontrar as melhores opções!`
+
+          try {
+            const phone = conv.phone.replace(/\D/g, '')
+            const dest = phone.startsWith('55') ? phone : `55${phone}`
+            await whatsappService.sendText(dest, msg)
+            await app.prisma.message.create({
+              data: { conversationId: conv.id, direction: 'outbound', type: 'text', content: msg, status: 'sent', sentBy: 'bot' },
+            }).catch(() => {})
+          } catch (err) {
+            app.log.warn({ err }, '[scheduled] bot-nudge send failed')
+          }
+
+          await app.prisma.auditLog.create({
+            data: {
+              companyId: conv.companyId,
+              action: 'whatsapp.bot.nudge' as any,
+              resource: 'conversation',
+              resourceId: conv.id,
+              payload: { sentAt: now.toISOString() },
+            },
+          }).catch(() => {})
+
+          nudged++
+        }
+
+        if (nudged > 0) {
+          app.log.info(`[scheduled] whatsapp-bot-nudge: sent ${nudged} re-engagement nudges`)
+        }
+      }
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] whatsapp-bot-nudge failed')
+  }
 }


### PR DESCRIPTION
## Summary

PR 2/3 do Robô WhatsApp qualificador. Lead começa a conversa mas some no meio (não responde orçamento, urgência, etc.) — sem reengajamento, ele esfria e some. Este PR recupera esses leads automaticamente.

### Como funciona

Conversas presas em `status = 'bot'` significam abandono mid-flow: quando o lead conclui a qualificação (#135), o handoff move o status para `'open'`. Logo, `status='bot'` + `lastMessageAt` antigo = abandonou.

- Novo bloco em `scheduled.jobs.ts` (índice 12): a cada tick varre `Conversation` com:
  - `status = 'bot'`, `channel = 'whatsapp'`
  - `lastMessageAt` entre 1h e 24h atrás (janela: já esfriou um pouco mas ainda quente o suficiente pra recuperar)
- Envia **1 nudge único** via WhatsApp: mensagem amigável com primeiro nome convidando a continuar
- Registra a mensagem outbound (`sentBy='bot'`) na Conversation — aparece no inbox
- **Dedup** via `auditLog` action `whatsapp.bot.nudge` — nunca manda dois nudges pra mesma conversa
- Só roda se `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID` configurados; cap 200/tick

### Mensagem

```
Oi <Nome>! Vi que você começou a busca por um imóvel com a gente
mas não finalizou. 😊

Quer continuar de onde parou? É rapidinho — me responde aqui que
eu te ajudo a encontrar as melhores opções!
```

## Test plan

- [ ] Iniciar conversa no bot e parar no meio (não responder orçamento) → após 1h, rodar `runScheduledJobs` → nudge enviado
- [ ] Rodar de novo → não manda 2º nudge (dedup via auditLog)
- [ ] Conversa com `lastMessageAt` < 1h → não recebe nudge (cedo demais)
- [ ] Conversa com `lastMessageAt` > 24h → não recebe (tarde demais)
- [ ] Conversa que já virou `open` (concluiu o fluxo) → não recebe nudge
- [ ] Mensagem do nudge aparece no inbox da conversa (sentBy=bot)
- [ ] Sem WHATSAPP_TOKEN → bloco é pulado silenciosamente


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_