### PR TITLE
Robô WhatsApp qualificador (3/3): bot envia imóveis recomendados na hora

### DIFF
--- a/apps/api/src/routes/whatsapp/index.ts
+++ b/apps/api/src/routes/whatsapp/index.ts
@@ -348,7 +348,45 @@ async function runBot(app: FastifyInstance, conversation: any, phone: string, in
         })
       } catch { /* non-fatal */ }
 
-      if (env.WHATSAPP_TOKEN) await BOT_STEPS.DONE(phone, name)
+      // Entrega valor imediato: envia até 2 imóveis recomendados (#127)
+      // antes da mensagem de encerramento.
+      let sentRecs = false
+      if (env.WHATSAPP_TOKEN) {
+        try {
+          const { recommendForLead } = await import('../../services/lead-recommender.service.js')
+          const recs = await recommendForLead(app.prisma, lead.id, 2)
+          if (recs.length > 0) {
+            const lines = recs.map((r, i) => {
+              const price = r.purpose === 'RENT' ? r.priceRent : r.price
+              const priceLabel = price != null && Number(price) > 0
+                ? `R$ ${Number(price).toLocaleString('pt-BR')}`
+                : 'Valor sob consulta'
+              const loc = [r.neighborhood, r.city].filter(Boolean).join(', ')
+              const url = `https://www.agoraencontrei.com.br/imoveis/${r.slug ?? r.id}`
+              return `${i + 1}. *${r.title}*${loc ? `\n📍 ${loc}` : ''}\n💰 ${priceLabel}\n🔗 ${url}`
+            }).join('\n\n')
+            await whatsappService.sendText(
+              phone,
+              `${name.split(' ')[0]}, separei ${recs.length === 1 ? 'um imóvel' : 'alguns imóveis'} que combina${recs.length === 1 ? '' : 'm'} com o que você procura: 🏠\n\n${lines}`,
+            )
+            await app.prisma.message.create({
+              data: { conversationId: conversation.id, direction: 'outbound', type: 'text', content: `[${recs.length} recomendações enviadas]`, status: 'sent', sentBy: 'bot' },
+            }).catch(() => {})
+            sentRecs = true
+          }
+        } catch { /* non-fatal */ }
+      }
+
+      if (env.WHATSAPP_TOKEN) {
+        if (sentRecs) {
+          await whatsappService.sendText(
+            phone,
+            `Um corretor vai te chamar em breve pra agendar uma visita. Se quiser ver mais opções, é só responder por aqui! 🙌`,
+          ).catch(() => {})
+        } else {
+          await BOT_STEPS.DONE(phone, name)
+        }
+      }
       await clearState(app.redis, phone)
       return
     }


### PR DESCRIPTION
## Summary

PR 3/3 do Robô WhatsApp qualificador — fecha o ciclo. Antes, ao terminar a qualificação o bot só dizia "um corretor vai te contatar". Agora ele **entrega valor na hora**: envia até 2 imóveis que casam com o perfil do lead.

### Como funciona

Ao concluir o passo `ASK_URGENCY` (lead já criado + scored em #135):
- Chama `recommendForLead(prisma, lead.id, 2)` (o recommender do #127, que cruza interesse + orçamento + busca nas notas)
- Se houver matches, envia uma mensagem formatada via WhatsApp:

```
João, separei alguns imóveis que combinam com o que você procura: 🏠

1. *Casa 3 quartos no Bom Jesus*
📍 Bom Jesus, Franca
💰 R$ 450.000
🔗 https://www.agoraencontrei.com.br/imoveis/casa-bom-jesus

2. *Apartamento Centro*
📍 Centro, Franca
💰 R$ 380.000
🔗 https://www.agoraencontrei.com.br/imoveis/apto-centro
```

- Mensagem de encerramento adaptada: se enviou recomendações, convida a ver mais ("é só responder por aqui"); senão, usa o `DONE` padrão
- Registra a entrega no inbox (`Message` com `sentBy='bot'`)
- **Fail-soft**: qualquer erro nas recomendações não quebra o fluxo (lead já está salvo e o handoff já aconteceu)

### Ciclo completo do bot (PRs #135 + #136 + #137)

1. Lead manda mensagem → bot qualifica (intenção, orçamento, busca, urgência)
2. Cria Lead com score + notifica time (urgentes com 🔥)
3. **Envia imóveis recomendados na hora** ← este PR
4. Handoff: conversa vira `open` no inbox
5. Se abandonar no meio → nudge de reengajamento (1h-24h depois)

## Test plan

- [ ] Completar o fluxo do bot com interesse=comprar, orçamento R$ 400k, busca "casa centro" → bot envia 1-2 imóveis matching antes do encerramento
- [ ] Imóveis enviados têm título, localização, preço e link público correto
- [ ] Lead sem nenhum imóvel compatível no catálogo → cai no DONE padrão (sem recomendações), fluxo não quebra
- [ ] Imóvel para aluguel → mostra priceRent
- [ ] Mensagem de recomendações aparece no inbox da conversa
- [ ] Erro forçado no recommender → fluxo segue até o fim sem travar


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_