### PR TITLE
Inbox: métricas de performance do bot WhatsApp (conversão, qualificados, reengajamentos)

### DIFF
--- a/apps/api/src/routes/inbox/index.ts
+++ b/apps/api/src/routes/inbox/index.ts
@@ -105,8 +105,9 @@ export default async function inboxRoutes(app: FastifyInstance) {
     schema: { tags: ['inbox'] },
   }, async (req, reply) => {
     const companyId = req.user.cid
+    const last30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
 
-    const [total, open, bot, unread] = await Promise.all([
+    const [total, open, bot, unread, bot30d, qualified30d, nudges30d] = await Promise.all([
       app.prisma.conversation.count({ where: { companyId } }),
       app.prisma.conversation.count({ where: { companyId, status: { in: ['open', 'assigned'] } } }),
       app.prisma.conversation.count({ where: { companyId, status: 'bot' } }),
@@ -114,13 +115,33 @@ export default async function inboxRoutes(app: FastifyInstance) {
         where: { companyId },
         _sum: { unreadCount: true },
       }),
+      // Conversas iniciadas (bot) nos últimos 30 dias
+      app.prisma.conversation.count({
+        where: { companyId, channel: 'whatsapp', createdAt: { gte: last30d } },
+      }),
+      // Quantas viraram lead (bot concluiu a qualificação)
+      app.prisma.conversation.count({
+        where: { companyId, channel: 'whatsapp', createdAt: { gte: last30d }, leadId: { not: null } },
+      }),
+      // Nudges de reengajamento enviados (#136)
+      app.prisma.auditLog.count({
+        where: { companyId, action: 'whatsapp.bot.nudge' as any, createdAt: { gte: last30d } },
+      }).catch(() => 0),
     ])
+
+    const conversionRate = bot30d > 0 ? qualified30d / bot30d : 0
 
     return reply.send({
       total,
       open,
       bot,
       unreadTotal: unread._sum.unreadCount ?? 0,
+      botPerformance: {
+        conversations30d: bot30d,
+        qualified30d,
+        conversionRate,
+        nudges30d,
+      },
     })
   })
 }

--- a/apps/web/src/app/(dashboard)/dashboard/inbox/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/inbox/page.tsx
@@ -90,6 +90,31 @@ export default function InboxPage() {
         )}
       </div>
 
+      {/* Bot performance (últimos 30 dias) */}
+      {stats?.botPerformance && stats.botPerformance.conversations30d > 0 && (
+        <div className="flex flex-wrap items-center gap-4 rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+          <div className="flex items-center gap-1.5 text-xs text-white/50">
+            <span className="text-blue-400">🤖</span> Bot (30d):
+          </div>
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <span className="text-white/70">
+              <strong className="text-white">{stats.botPerformance.conversations30d}</strong> conversas
+            </span>
+            <span className="text-white/70">
+              <strong className="text-emerald-400">{stats.botPerformance.qualified30d}</strong> qualificados
+            </span>
+            <span className="text-white/70">
+              <strong className="text-amber-400">{Math.round(stats.botPerformance.conversionRate * 100)}%</strong> conversão
+            </span>
+            {stats.botPerformance.nudges30d > 0 && (
+              <span className="text-white/70">
+                <strong className="text-purple-400">{stats.botPerformance.nudges30d}</strong> reengajamentos
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Filters */}
       <div className="flex items-center gap-3 flex-wrap">
         <SearchInputWithVoice

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -557,7 +557,10 @@ export const inboxApi = {
     request<Conversation>(`/api/v1/inbox/${id}`, { method: 'PATCH', token, body: JSON.stringify(body) }),
 
   stats: (token: string) =>
-    request<{ total: number; open: number; bot: number; unreadTotal: number }>('/api/v1/inbox/stats/summary', { token }),
+    request<{
+      total: number; open: number; bot: number; unreadTotal: number
+      botPerformance?: { conversations30d: number; qualified30d: number; conversionRate: number; nudges30d: number }
+    }>('/api/v1/inbox/stats/summary', { token }),
 
   send: (token: string, body: { to: string; text: string; conversationId?: string }) =>
     request('/api/v1/whatsapp/send', { method: 'POST', token, body: JSON.stringify(body) }),


### PR DESCRIPTION
## Summary

Fecha a observabilidade do Robô WhatsApp (#135-137): construímos o bot, agora a empresa vê o ROI dele. Métricas de 30 dias direto no topo do inbox Lemos.chat.

### Backend

`GET /api/v1/inbox/stats/summary` agora inclui `botPerformance`:
- `conversations30d` — conversas WhatsApp iniciadas nos últimos 30 dias
- `qualified30d` — quantas viraram lead (bot concluiu a qualificação → `leadId` preenchido)
- `conversionRate` — qualified / conversations
- `nudges30d` — reengajamentos enviados (#136)

### Frontend — `/dashboard/inbox`

Linha compacta abaixo do header (só renderiza quando houve ≥ 1 conversa em 30d):

```
🤖 Bot (30d):  142 conversas   ·   89 qualificados   ·   63% conversão   ·   24 reengajamentos
```

Cada número com cor própria (qualificados verde, conversão âmbar, reengajamentos roxo).

## Test plan

- [ ] Login → `/dashboard/inbox` → linha do bot aparece com os 4 números
- [ ] Conversão = qualified / conversations arredondado (ex.: 89/142 = 63%)
- [ ] Empresa sem conversas em 30d → linha não renderiza
- [ ] Sem nudges → o item "reengajamentos" some, os outros 3 permanecem
- [ ] Auto-refresh 30s mantém os números atualizados (já era o comportamento do stats)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_