### PR TITLE
Segurança: honeypot anti-bot na captação de leads

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -46,6 +46,8 @@ const LeadCaptureBody = z.object({
   utmCampaign: z.string().optional(),
   // Fotos enviadas pelo cliente no formulário de anúncio
   photoUrls:  z.array(z.string()).max(50).optional(),
+  // Honeypot anti-bot — humanos não preenchem; se vier preenchido, é bot.
+  website:    z.string().optional(),
 })
 
 // ── Location privacy helper ─────────────────────────────────────────────────
@@ -595,6 +597,12 @@ export default async function publicRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: 'VALIDATION_ERROR', message: _bodyParsed.error.message })
     }
     const body = _bodyParsed.data
+
+    // Honeypot: campo invisível preenchido = bot. Devolve sucesso falso
+    // (201) para não revelar a armadilha, mas não cria nada.
+    if (body.website && body.website.trim().length > 0) {
+      return reply.status(201).send({ id: 'ok', message: 'Obrigado! Em breve entraremos em contato.' })
+    }
 
     // Find or create contact
     let contact = body.email

--- a/apps/web/src/app/(public)/imoveis/[slug]/LeadCaptureForm.tsx
+++ b/apps/web/src/app/(public)/imoveis/[slug]/LeadCaptureForm.tsx
@@ -27,6 +27,8 @@ export function LeadCaptureForm({ propertyId, propertyTitle }: Props) {
       email:      (fd.get('email') as string) || undefined,
       message:    (fd.get('message') as string) || undefined,
       interest:   (fd.get('interest') as string) || undefined,
+      // Honeypot anti-bot: campo invisível que humanos não preenchem.
+      website:    (fd.get('website') as string) || undefined,
       propertyId,
     }
 
@@ -66,6 +68,15 @@ export function LeadCaptureForm({ propertyId, propertyTitle }: Props) {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-3">
+        {/* Honeypot anti-bot — escondido de humanos, ignorado por leitores de tela */}
+        <input
+          name="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden="true"
+          className="absolute left-[-9999px] h-0 w-0 opacity-0"
+        />
         <input
           name="name"
           required


### PR DESCRIPTION
## Summary

Camada de segurança anti-bot. O baseline já é forte (auditei): helmet, CORS restrito, rate-limit 200/min, bloqueio de user-agents de scraper, source maps desligados, `poweredByHeader` off, robots bloqueando crawlers de IA/SEO, watermark Cloudinary, SSRF protection no proxy de imagem, Swagger off em produção, mascaramento LGPD. Este PR adiciona honeypot ao formulário de captação.

### Honeypot anti-bot

- Campo oculto `website` no `LeadCaptureForm` (posicionado off-screen, `tabIndex={-1}`, `aria-hidden`) — invisível para humanos e leitores de tela, mas bots que preenchem todos os campos caem nele
- `POST /api/v1/public/leads` valida: se `website` vier preenchido, retorna **201 falso** (não revela a armadilha ao bot) sem criar lead/contact/deal/notificação
- Sem captcha, sem atrito para o usuário real

## Observações honestas sobre segurança (importante)

1. **"100% inviolável" não existe.** O que temos é uma postura forte e em camadas. O código do frontend é sempre entregue ao navegador — minificamos e desligamos source maps, mas é tecnicamente impossível torná-lo invisível. O backend (lógica e dados) já fica protegido no servidor.

2. **A prioridade de segurança real são as 47 vulnerabilidades de dependências** (3 críticas, 22 altas) que aparecem em todo push (Dependabot). Isso é mais urgente que qualquer feature anti-cópia. Recomendo um PR dedicado de `pnpm audit fix` / atualização de pacotes — com cuidado, porque pode quebrar build. Me confirme que quer e eu faço isolado, testando cada atualização.

3. Próximos reforços possíveis (se quiser): honeypot também em proposta/visitas, rate-limit por-rota mais agressivo nas rotas de dados, e enforcement de watermark em 100% das imagens públicas (este último é arriscado — pode afetar imagens já publicadas, faria com teste).

## Test plan

- [ ] Enviar lead normal pelo formulário de imóvel → cria lead (honeypot vazio)
- [ ] Simular bot preenchendo `website` → recebe 201 mas nenhum lead é criado
- [ ] Campo honeypot é invisível na tela e não tabulável
- [ ] Usuário real não percebe diferença


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_