### PR TITLE
Segurança: honeypot anti-bot em proposta e agendamento de visita

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -736,6 +736,11 @@ export default async function publicRoutes(app: FastifyInstance) {
     const body = req.body as any
     const { name, email, phone, cpf, propertyId, proposta } = body ?? {}
 
+    // Honeypot anti-bot: campo invisível preenchido = bot.
+    if (typeof body?.website === 'string' && body.website.trim().length > 0) {
+      return reply.status(201).send({ id: 'ok', message: 'Proposta recebida! Nossa equipe entrará em contato em até 24 horas.' })
+    }
+
     if (!name || !phone) {
       return reply.status(400).send({ error: 'MISSING_FIELDS', message: 'Nome e telefone são obrigatórios.' })
     }

--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -13,6 +13,12 @@ export default async function visitRoutes(app: FastifyInstance) {
       preferredDate: string  // ISO date string
       preferredTime: string  // HH:mm
       notes?: string
+      website?: string  // honeypot anti-bot
+    }
+
+    // Honeypot: campo invisível preenchido = bot. Sucesso falso, nada criado.
+    if (typeof body.website === 'string' && body.website.trim().length > 0) {
+      return reply.send({ success: true })
     }
 
     if (!body.propertyId || !body.name || !body.phone || !body.preferredDate || !body.preferredTime) {

--- a/apps/web/src/app/(public)/imoveis/ScheduleVisitModal.tsx
+++ b/apps/web/src/app/(public)/imoveis/ScheduleVisitModal.tsx
@@ -44,6 +44,7 @@ export function ScheduleVisitModal({ propertyId, propertyTitle, propertySlug }: 
   const [phone, setPhone] = useState('')
   const [email, setEmail] = useState('')
   const [notes, setNotes] = useState('')
+  const [website, setWebsite] = useState('') // honeypot anti-bot
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -83,6 +84,7 @@ export function ScheduleVisitModal({ propertyId, propertyTitle, propertySlug }: 
           preferredDate: selectedDate,
           preferredTime: selectedTime,
           notes: notes.trim() || undefined,
+          website: website || undefined,
         }),
       })
       if (!res.ok) throw new Error('Erro ao agendar')
@@ -205,6 +207,16 @@ export function ScheduleVisitModal({ propertyId, propertyTitle, propertySlug }: 
                   </div>
 
                   <div className="space-y-3">
+                    {/* Honeypot anti-bot — invisível para humanos */}
+                    <input
+                      name="website"
+                      value={website}
+                      onChange={e => setWebsite(e.target.value)}
+                      tabIndex={-1}
+                      autoComplete="off"
+                      aria-hidden="true"
+                      className="absolute left-[-9999px] h-0 w-0 opacity-0"
+                    />
                     <div>
                       <label className="text-xs font-semibold text-gray-600 flex items-center gap-1 mb-1">
                         <User className="w-3.5 h-3.5" /> Nome *

--- a/apps/web/src/app/(public)/imoveis/[slug]/PropostaOnline.tsx
+++ b/apps/web/src/app/(public)/imoveis/[slug]/PropostaOnline.tsx
@@ -113,6 +113,7 @@ export function PropostaOnline({ propertyId, propertyTitle, propertyPrice, prope
   const [form, setForm] = useState<FormState>(INITIAL)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const [website, setWebsite] = useState('') // honeypot anti-bot
   const [proposalCode, setProposalCode] = useState('')
   const [proposalHash, setProposalHash] = useState('')
   const [codeCopied, setCodeCopied] = useState(false)
@@ -161,6 +162,7 @@ export function PropostaOnline({ propertyId, propertyTitle, propertyPrice, prope
           cpf: form.cpf || undefined,
           propertyId,
           proposta,
+          website: website || undefined,
         }),
       })
       // Gerar hash SHA-256 para validade jurídica
@@ -282,6 +284,16 @@ export function PropostaOnline({ propertyId, propertyTitle, propertyPrice, prope
                   <h3 className="font-semibold text-gray-800 flex items-center gap-2">
                     <User className="w-4 h-4" style={{ color: '#C9A84C' }} /> Dados do Comprador
                   </h3>
+                  {/* Honeypot anti-bot — invisível para humanos */}
+                  <input
+                    name="website"
+                    value={website}
+                    onChange={e => setWebsite(e.target.value)}
+                    tabIndex={-1}
+                    autoComplete="off"
+                    aria-hidden="true"
+                    className="absolute left-[-9999px] h-0 w-0 opacity-0"
+                  />
                   <div>
                     <label className={labelCls}>Nome completo *</label>
                     <input className={inputCls} value={form.nome} onChange={e => set('nome', e.target.value)} placeholder="João da Silva" />


### PR DESCRIPTION
## Summary

Estende o honeypot anti-bot (do PR #141, que cobriu a captação de leads) aos demais formulários públicos que **geram dados**.

### Cobertura

- **`POST /api/v1/public/proposta`** — valida `website`; se preenchido, retorna 201 falso sem criar proposta/lead/contato/notificação
- **`POST /api/v1/public/visits`** — valida `website`; se preenchido, retorna sucesso falso sem criar visita/contato/activity/deal
- Campo oculto adicionado ao **PropostaOnline** e ao **ScheduleVisitModal** (off-screen, `tabIndex={-1}`, `aria-hidden`) — invisível a humanos e leitores de tela

### Fora de escopo (de propósito)

- **Avaliação** (`/public/avaliacao`) — é endpoint de cálculo (retorna estimativa de valor, não cria registro), então o honeypot agrega pouco e poderia bloquear consultas legítimas.

### Estado da proteção anti-bot

Agora todos os formulários que criam dados (leads, propostas, visitas) têm honeypot + a proteção de plataforma já existente (rate-limit 200/min, bloqueio de user-agents de scraper, CORS restrito).

## Test plan

- [ ] Enviar proposta normal → criada (honeypot vazio)
- [ ] Bot preenchendo `website` na proposta → 201 falso, nada criado
- [ ] Agendar visita normal → criada
- [ ] Bot preenchendo `website` na visita → sucesso falso, nada criado
- [ ] Campos honeypot invisíveis e não-tabuláveis em ambos os forms


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_