### PR TITLE
Parceiros: cadastro avisa do aporte R$990 + contrato antes do checkout

### DIFF
--- a/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
@@ -225,7 +225,11 @@ function CadastroParceirosContent() {
             }
             <div>
               <p className="text-sm font-bold" style={{ color: '#1B2B5B' }}>Plano {selectedPlan} selecionado — R$ {selectedPlan === 'VIP' ? '497' : '197'}/mês</p>
-              <p className="text-xs text-gray-500">Após o cadastro, você será redirecionado ao checkout para ativar seu dashboard privado.</p>
+              <p className="text-xs text-gray-500">
+                Inclui aporte inicial único de R$ 990 (à vista no PIX com 6,80% de desconto = R$ 922,68, ou parcelado no boleto/cartão),
+                cobrado junto com a 1ª mensalidade. Após o cadastro você vai ao checkout. Ao continuar, você concorda com o{' '}
+                <a href="/parceiros/contrato" target="_blank" rel="noreferrer" className="underline" style={{ color: '#1B2B5B' }}>Contrato de Adesão</a>.
+              </p>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Fecha uma incoerência do fluxo: a página de cadastro de parceiro (`/parceiros/cadastro`) prometia só "R$ 197/497/mês" e mandava direto ao checkout, sem avisar do aporte inicial de R$ 990 que aparece lá. O parceiro era pego de surpresa.

Agora o badge do plano no cadastro informa:
- Aporte inicial único de R$ 990 (PIX R$ 922,68 com 6,80% off, ou parcelado boleto/cartão)
- Que é cobrado junto com a 1ª mensalidade
- Link para o Contrato de Adesão (transparência antes do checkout)

Transparência de preço total antes do pagamento também é boa prática sob o CDC.

## Test plan

- [ ] Acessar `/parceiros/cadastro?plan=PRIME` → badge mostra R$ 197/mês + aviso do aporte R$ 990 + link do contrato
- [ ] Idem para VIP (R$ 497/mês)
- [ ] Link do contrato abre `/parceiros/contrato`
- [ ] Plano START (grátis) → sem badge de aporte (correto)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_