### PR TITLE
QA ponta-a-ponta: corrige 2 rotas de API com 404 (alertas, território)

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/alertas/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alertas/page.tsx
@@ -54,7 +54,7 @@ export default function AlertasPage() {
       const q = new URLSearchParams({ limit: '200' })
       if (filter === 'active') q.set('active', 'true')
       if (filter === 'inactive') q.set('active', 'false')
-      const res = await fetch(`${API_URL}/api/v1/alerts?${q}`, {
+      const res = await fetch(`${API_URL}/api/v1/public/alerts?${q}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       const j = await res.json()

--- a/apps/web/src/app/(public)/meu-painel/page.tsx
+++ b/apps/web/src/app/(public)/meu-painel/page.tsx
@@ -115,7 +115,7 @@ export default function MeuPainelPage() {
     setLoadingAnalytics(true)
     Promise.all([
       fetch(`${API_URL}/api/v1/public/partner-stats/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
-      fetch(`${API_URL}/api/v1/territory/my/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch(`${API_URL}/api/v1/public/territory/my/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
     ]).then(([analyticsData, territoryData]) => {
       if (analyticsData) setAnalytics(analyticsData)
       if (territoryData?.territories) setTerritories(territoryData.territories)


### PR DESCRIPTION
## Summary

Verificação ponta-a-ponta do sistema (auditoria estática profunda + builds). Encontrei **2 chamadas de API com prefixo errado** que dariam 404 — corrigidas neste PR.

### Bugs corrigidos

1. **`/dashboard/alertas`** chamava `GET /api/v1/alerts` → a rota de alertas é registrada sob o prefixo público: `GET /api/v1/public/alerts`. (Bug que eu introduzi no PR #119 — a página de alertas nunca tinha sido testada ao vivo.)
2. **`/meu-painel`** chamava `GET /api/v1/territory/my/:id` → correto é `/api/v1/public/territory/my/:id`. (Pré-existente.)

Ambas eram correções de string na URL do `fetch`.

## Resultado da verificação completa (o que testei)

| Área | Resultado |
|---|---|
| Build API | ✅ ok (só 1 erro pré-existente em `sales-funnel.service.ts`, tolerado por `\|\| true` — não é meu) |
| Typecheck API + Web | ✅ limpo |
| Consistência de preços/planos (14 locais) | ✅ zero drift (aporte 990/922,68/6,8%, Prime 197, VIP 497, pacotes) |
| Links do sidebar → páginas | ✅ todos os ~57 existem |
| Links públicos (header/footer/home) | ✅ ok |
| Rotas dinâmicas (`[slug]`, `[id]`) | ✅ todas têm página |
| ~281 chamadas de API → registradas no server.ts | ⚠️ 2 com prefixo errado (corrigidas aqui) |
| Login/Auth (JWT + argon2 + /me + refresh) | ✅ ok |
| RBAC (master=SUPER_ADMIN, users=ADMIN, tenant-scoping) | ✅ ok |
| Gating de menu no frontend | ✅ ok |
| E-mail (degrada sem SMTP, não quebra) | ✅ ok |
| Agentes IA / Tomás / chat (503 sem ANTHROPIC_API_KEY) | ✅ ok |
| WhatsApp bot (não quebra sem token) | ✅ ok |
| Editor de fotos / vídeo (auth + quota + guards) | ✅ ok |

**Conclusão**: o sistema está coerente. Os únicos defeitos reais foram as 2 rotas 404 (corrigidas). O build de produção web roda na Vercel deste PR como validação final.

> Nota: não consigo clicar na UI ao vivo daqui — esta foi uma verificação estática + build. Recomendo um teste manual do fluxo de cadastro→checkout→Asaas e do bot WhatsApp em produção.

## Test plan

- [ ] `/dashboard/alertas` carrega a lista (não 404)
- [ ] `/meu-painel` carrega territórios do parceiro (não 404)
- [ ] Vercel preview build verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_