### PR TITLE
Launch: consentimento de cookies (LGPD) + GA gated + global error boundary

### DIFF
--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Boundary de erro de nível raiz: captura falhas que escapam do layout.
+// Renderiza o próprio <html>/<body> e usa estilos inline (sem dependências
+// do layout, que pode não ter carregado).
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('Global application error:', error)
+  }, [error])
+
+  return (
+    <html lang="pt-BR">
+      <body style={{ margin: 0, fontFamily: "system-ui, -apple-system, sans-serif", backgroundColor: '#f8f6f1' }}>
+        <div style={{ minHeight: '100dvh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+          <div style={{ maxWidth: 420, width: '100%', textAlign: 'center' }}>
+            <div style={{ margin: '0 auto 24px', width: 80, height: 80, borderRadius: 16, backgroundColor: '#1B2B5B', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 36, color: '#C9A84C' }}>
+              !
+            </div>
+            <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 12, color: '#1B2B5B', fontFamily: 'Georgia, serif' }}>
+              Algo deu errado
+            </h1>
+            <p style={{ fontSize: 14, marginBottom: 32, color: '#1B2B5B', opacity: 0.6 }}>
+              Ocorreu um erro inesperado. Tente novamente ou volte para a página inicial.
+            </p>
+            <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+              <button
+                onClick={reset}
+                style={{ padding: '10px 20px', borderRadius: 8, fontSize: 14, fontWeight: 500, color: '#fff', backgroundColor: '#C9A84C', border: 'none', cursor: 'pointer' }}
+              >
+                Tentar Novamente
+              </button>
+              <a
+                href="/"
+                style={{ padding: '10px 20px', borderRadius: 8, fontSize: 14, fontWeight: 500, color: '#fff', backgroundColor: '#1B2B5B', textDecoration: 'none' }}
+              >
+                Página Inicial
+              </a>
+            </div>
+            {error.digest && (
+              <p style={{ marginTop: 32, fontSize: 12, color: '#1B2B5B', opacity: 0.3 }}>
+                Código: {error.digest}
+              </p>
+            )}
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from '@/components/providers'
 import { ConditionalMetaPixel } from '@/components/ConditionalMetaPixel'
 import { WebVitals } from '@/components/WebVitals'
 import { GoogleAnalytics } from '@/components/GoogleAnalytics'
+import { CookieConsent } from '@/components/CookieConsent'
 import { FRANCA_GEO_KEYWORDS } from '@/data/seo-geo-keywords'
 import './globals.css'
 
@@ -378,6 +379,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="font-sans" style={{ fontFamily: "'Inter', system-ui, -apple-system, sans-serif" }}>
         <Providers>{children}</Providers>
+        {/* ── Banner de consentimento de cookies (LGPD) ───────── */}
+        <CookieConsent />
         {/* ── Meta Pixel condicional (LGPD) ───────────────────── */}
         <ConditionalMetaPixel />
         {/* ── Core Web Vitals monitoring ──────────────────────── */}

--- a/apps/web/src/components/GoogleAnalytics.tsx
+++ b/apps/web/src/components/GoogleAnalytics.tsx
@@ -1,11 +1,47 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import Script from 'next/script'
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+const CONSENT_KEY = 'cookie_consent'
+
+function hasAnalyticsConsent(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = localStorage.getItem(CONSENT_KEY)
+    if (!raw) return false
+    const consent = JSON.parse(raw)
+    return consent?.analytics === true
+  } catch {
+    return false
+  }
+}
 
 export function GoogleAnalytics() {
-  if (!GA_ID) return null
+  const [allowed, setAllowed] = useState(false)
+
+  useEffect(() => {
+    // Só carrega o GA4 após o consentimento de cookies analíticos (LGPD).
+    const check = () => setAllowed(hasAnalyticsConsent())
+    check()
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === CONSENT_KEY) check()
+    }
+    window.addEventListener('storage', handleStorage)
+    // Poll breve para captar o consentimento dado na mesma aba.
+    const interval = setInterval(check, 2000)
+    const timeout = setTimeout(() => clearInterval(interval), 30000)
+
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+      clearInterval(interval)
+      clearTimeout(timeout)
+    }
+  }, [])
+
+  if (!GA_ID || !allowed) return null
 
   return (
     <>


### PR DESCRIPTION
## Summary

Prontidão para comercialização pública. Fiz uma auditoria de launch-readiness (nota 73/100 — base forte) e corrijo aqui os **blockers críticos de LGPD e UX** que eu posso resolver com segurança.

### O que mudou

1. **Banner de consentimento de cookies (LGPD) — CRÍTICO**
   - O componente `CookieConsent` existia mas **nunca era renderizado**. Sem ele, a conformidade LGPD era só fachada. Agora é exibido no layout raiz.

2. **Google Analytics gated por consentimento**
   - O GA4 disparava para **todos os visitantes sem consentimento** (violação LGPD). Agora só carrega após o usuário aceitar cookies analíticos — mesma lógica que o Meta Pixel já usava.

3. **Global error boundary**
   - Novo `global-error.tsx` auto-contido (html/body próprios, estilos inline) para falhas de nível raiz que escapam do layout — evita a tela de erro padrão feia do Next em produção.

## ⚠️ Itens de launch que NÃO mexi (precisam da sua decisão)

A auditoria achou inconsistências de **contato** que eu não corrijo por conta própria — colocar o número errado é pior que inconsistente:

| Onde | Valor atual | Conflito |
|---|---|---|
| `/contato` telefone | (16) 3711-1990 | resto do site usa (16) 3723-0045 |
| `/contato` WhatsApp | (16) 99168-6626 | cards de imóvel usam (16) 99311-6199 (Tomás) |
| `/contato` endereço | só "Franca/SP" | endereço completo está só nas páginas legais |

**Me confirme os números/endereço corretos** e eu padronizo em todo o site num PR.

Outros itens menores da auditoria (todos ✅ ou baixa prioridade): Termos de Uso e Política de Privacidade completos, contrato OK, 404/500 customizados existem, SEO completo (metadata, robots, sitemaps, OG, JSON-LD), GA4+Pixel+Vercel Analytics wired.

## Test plan

- [ ] Primeira visita → banner de cookies aparece após 2s
- [ ] Aceitar → GA4 e Meta Pixel carregam (ver Network)
- [ ] Rejeitar → nem GA4 nem Pixel carregam
- [ ] Recarregar após escolha → banner não reaparece
- [ ] Forçar um erro de raiz → global-error renderiza (não a tela padrão do Next)
- [ ] Vercel preview build verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_