### PR TITLE
Contato: padroniza telefone (3723-0045), WhatsApp (98101-0004) e endereço oficial

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/documentos/templates.ts
+++ b/apps/web/src/app/(dashboard)/dashboard/documentos/templates.ts
@@ -12,7 +12,7 @@ export interface DocTemplate {
 const LEMOS_HEADER = `IMOBILIÁRIA LEMOS
 NOEMIA PIRES LEMOS DA SILVA — CRECI/SP 61053-F
 TOMAS CESAR LEMOS SILVA — CRECI/SP 279051
-Rua Simão Caleiro, 2383 — Vila França — Franca/SP — CEP 14401-155
+Rua Simão Caleiro, 2383 — Vila Industrial — Franca/SP — CEP 14400-340
 Tel: (16) 3723-0045`
 
 export const TEMPLATES: DocTemplate[] = [
@@ -645,7 +645,7 @@ CARTA DE DESISTÊNCIA DE COMPRA DE IMÓVEL
 Franca, [data_carta]
 
 À IMOBILIÁRIA LEMOS
-Rua Simão Caleiro, 2383 — Vila França — Franca/SP
+Rua Simão Caleiro, 2383 — Vila Industrial — Franca/SP
 
 Ref.: Desistência de proposta de compra — [imovel_descricao]
 
@@ -1643,7 +1643,7 @@ Tel: (16) 3723-0045`,
 
 INSTRUMENTO PARTICULAR DE CONFISSÃO DE DÍVIDA
 
-CREDOR: IMOBILIÁRIA LEMOS, representada por NOÊMIA PIRES LEMOS DA SILVA, CRECI/SP 61053-F e TOMAS CESAR LEMOS SILVA, CRECI/SP 279051, Rua Simão Caleiro, 2383, Vila França, Franca/SP.
+CREDOR: IMOBILIÁRIA LEMOS, representada por NOÊMIA PIRES LEMOS DA SILVA, CRECI/SP 61053-F e TOMAS CESAR LEMOS SILVA, CRECI/SP 279051, Rua Simão Caleiro, 2383, Vila Industrial, Franca/SP.
 
 DEVEDOR: [devedor_nome], [devedor_estado_civil], RG: [devedor_rg], CPF: [devedor_cpf], residente em [devedor_endereco].
 

--- a/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -651,11 +651,11 @@ export default function SettingsPage() {
 
             <Section title="Endereço">
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <DarkInput label="CEP" value={empresa.zipCode} onChange={e => setEmpresa(p => ({ ...p, zipCode: e.target.value }))} placeholder="14401-155" />
+                <DarkInput label="CEP" value={empresa.zipCode} onChange={e => setEmpresa(p => ({ ...p, zipCode: e.target.value }))} placeholder="14400-340" />
                 <DarkInput label="Cidade" value={empresa.city} onChange={e => setEmpresa(p => ({ ...p, city: e.target.value }))} placeholder="Franca" />
                 <DarkInput label="UF" value={empresa.state} onChange={e => setEmpresa(p => ({ ...p, state: e.target.value }))} placeholder="SP" maxLength={2} />
                 <div className="sm:col-span-3">
-                  <DarkInput label="Endereço Completo" value={empresa.address} onChange={e => setEmpresa(p => ({ ...p, address: e.target.value }))} placeholder="Rua Simão Caleiro, 2383, Vila França" />
+                  <DarkInput label="Endereço Completo" value={empresa.address} onChange={e => setEmpresa(p => ({ ...p, address: e.target.value }))} placeholder="Rua Simão Caleiro, 2383, Vila Industrial" />
                 </div>
               </div>
             </Section>

--- a/apps/web/src/app/(public)/contato/page.tsx
+++ b/apps/web/src/app/(public)/contato/page.tsx
@@ -92,8 +92,8 @@ export default function ContatoPage() {
                 </div>
                 <div>
                   <p className="text-sm font-semibold" style={{ color: '#1B2B5B' }}>Telefone</p>
-                  <a href="tel:1637111990" className="text-gray-600 hover:text-blue-800 transition-colors">
-                    (16) 3711-1990
+                  <a href="tel:1637230045" className="text-gray-600 hover:text-blue-800 transition-colors">
+                    (16) 3723-0045
                   </a>
                 </div>
               </div>
@@ -111,12 +111,12 @@ export default function ContatoPage() {
                 <div>
                   <p className="text-sm font-semibold" style={{ color: '#1B2B5B' }}>WhatsApp</p>
                   <a
-                    href="https://wa.me/5516991686626?text=Olá!%20Gostaria%20de%20mais%20informações."
+                    href="https://wa.me/5516981010004?text=Olá!%20Gostaria%20de%20mais%20informações."
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-600 hover:text-green-700 transition-colors"
                   >
-                    (16) 99168-6626
+                    (16) 98101-0004
                   </a>
                 </div>
               </div>
@@ -154,7 +154,7 @@ export default function ContatoPage() {
                 </div>
                 <div>
                   <p className="text-sm font-semibold" style={{ color: '#1B2B5B' }}>Endereço</p>
-                  <p className="text-gray-600">Franca/SP</p>
+                  <p className="text-gray-600">Rua Simão Caleiro, 2383 — Vila Industrial<br />Franca/SP — CEP 14400-340</p>
                 </div>
               </div>
             </div>
@@ -298,7 +298,7 @@ export default function ContatoPage() {
               Atendimento rápido e personalizado pelo WhatsApp.
             </p>
             <a
-              href="https://wa.me/5516991686626?text=Olá!%20Gostaria%20de%20mais%20informações."
+              href="https://wa.me/5516981010004?text=Olá!%20Gostaria%20de%20mais%20informações."
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2.5 px-8 py-4 rounded-2xl text-base font-bold transition-all hover:scale-105 hover:shadow-xl shadow-lg"

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -236,8 +236,8 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                   <p className="text-white/40 text-xs uppercase tracking-wider mb-0.5">Endereço</p>
                   <p className="text-white/60 text-sm leading-relaxed">
                     Rua Simão Caleiro, 2383<br />
-                    Vila França — Franca/SP<br />
-                    CEP 14401-155
+                    Vila Industrial — Franca/SP<br />
+                    CEP 14400-340
                   </p>
                   <p className="text-white/40 text-xs mt-1">CNPJ: 10.962.301/0001-50</p>
                   <a

--- a/apps/web/src/app/(public)/politica-privacidade/page.tsx
+++ b/apps/web/src/app/(public)/politica-privacidade/page.tsx
@@ -331,7 +331,7 @@ export default function PoliticaPrivacidadePage() {
                 <strong style={{ color: '#1B2B5B' }}>CNPJ:</strong> 10.962.301/0001-50
               </p>
               <p className="text-gray-600">
-                <strong style={{ color: '#1B2B5B' }}>Endereço:</strong> Rua Simão Caleiro, 2383 — Vila França — Franca/SP — CEP 14401-155
+                <strong style={{ color: '#1B2B5B' }}>Endereço:</strong> Rua Simão Caleiro, 2383 — Vila Industrial — Franca/SP — CEP 14400-340
               </p>
               <p className="text-gray-600 mt-3">
                 Para exercer seus direitos ou esclarecer duvidas sobre o tratamento de dados pessoais,

--- a/apps/web/src/app/(public)/termos-uso/page.tsx
+++ b/apps/web/src/app/(public)/termos-uso/page.tsx
@@ -235,7 +235,7 @@ export default function TermosUsoPage() {
                 <strong style={{ color: '#1B2B5B' }}>Imobiliária Lemos</strong> — CNPJ 10.962.301/0001-50
               </p>
               <p className="text-gray-600 text-sm">
-                Rua Simão Caleiro, 2383 — Vila França — Franca/SP — CEP 14401-155
+                Rua Simão Caleiro, 2383 — Vila Industrial — Franca/SP — CEP 14400-340
               </p>
               <a
                 href="mailto:tomas@agoraencontrei.com.br"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -256,7 +256,7 @@ const jsonLdBusiness = {
     streetAddress: 'Rua Simão Caleiro, 2383',
     addressLocality: 'Franca',
     addressRegion: 'SP',
-    postalCode: '14401-155',
+    postalCode: '14400-340',
     addressCountry: 'BR',
   },
   geo: {


### PR DESCRIPTION
## Summary

Padroniza os dados de contato oficiais (confirmados por você) em todo o site — último item da prontidão de lançamento que dependia da sua decisão.

### Dados corrigidos

| Dado | Antes | Agora (oficial) |
|---|---|---|
| Telefone fixo | (16) 3711-1990 (só no /contato) | **(16) 3723-0045** |
| WhatsApp | (16) 99168-6626 (só no /contato) | **(16) 98101-0004** |
| Endereço | "Franca/SP" (incompleto) | **Rua Simão Caleiro, 2383 — Vila Industrial — Franca/SP — CEP 14400-340** |

### Onde foi alinhado

O endereço estava inconsistente (bairro Vila França / CEP 14401-155 em vários lugares). Agora padronizado em **todos** os pontos:
- Página `/contato` (telefone, WhatsApp x2, endereço completo)
- Política de Privacidade + Termos de Uso
- Rodapé público
- JSON-LD (`postalCode` — afeta SEO/Google)
- Templates de documentos jurídicos gerados pelo sistema (contratos de locação, etc.)
- Placeholders do formulário de empresa no admin

### Cards de imóveis

Confirmei que **já usam o número do corretor vinculado** (`p.user.phone` do cadastro), exatamente como você quer. O número hardcoded só aparece como fallback de legado para anúncios antigos sem corretor vinculado. **Sem alteração** — comportamento já correto.

## Test plan

- [ ] `/contato` mostra (16) 3723-0045, WhatsApp 98101-0004 e endereço completo
- [ ] Rodapé do site mostra Vila Industrial / CEP 14400-340
- [ ] Política de Privacidade e Termos de Uso com endereço novo
- [ ] Documento de locação gerado traz o endereço correto
- [ ] Card de imóvel com corretor vinculado usa o WhatsApp do corretor
- [ ] Vercel build verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_