### PR TITLE
Voz (erro honesto + OPENAI_API_KEY), galeria visual de temas, tela de prontidão

### DIFF
--- a/apps/api/src/routes/master/index.ts
+++ b/apps/api/src/routes/master/index.ts
@@ -468,6 +468,63 @@ export default async function masterRoutes(app: FastifyInstance) {
     })
   })
 
+  // GET /launch-readiness — verifica se todas as integrações críticas para
+  // o lançamento público estão configuradas. Read-only, nunca expõe valores
+  // (só booleanos). Detecta Asaas em sandbox vs produção.
+  app.get('/launch-readiness', {
+    schema: { tags: ['master'], summary: 'Launch readiness — env/integration check' },
+  }, async (_req, reply) => {
+    const e = process.env
+    const has = (...keys: string[]) => keys.every(k => !!(e[k] && String(e[k]).trim().length > 0))
+    const asaasBase = e.ASAAS_BASE_URL ?? 'https://www.asaas.com/api/v3'
+    const asaasSandbox = /sandbox/i.test(asaasBase)
+
+    const checks = [
+      { key: 'database',   label: 'Banco de dados',          configured: has('DATABASE_URL'), critical: true,
+        note: 'Conexão PostgreSQL' },
+      { key: 'jwt',        label: 'Segredos (JWT/Cookie)',   configured: has('JWT_SECRET', 'COOKIE_SECRET'), critical: true,
+        note: 'Autenticação e sessões' },
+      { key: 'asaas',      label: 'Asaas (pagamentos)',       configured: has('ASAAS_API_KEY'), critical: true,
+        note: asaasSandbox ? '⚠️ Em SANDBOX — troque para produção antes de cobrar' : 'Modo produção',
+        warn: asaasSandbox },
+      { key: 'whatsapp',   label: 'WhatsApp',                 configured: has('WHATSAPP_TOKEN', 'WHATSAPP_PHONE_ID'), critical: true,
+        note: 'Bot qualificador + notificações' },
+      { key: 'smtp',       label: 'E-mail (SMTP)',            configured: has('SMTP_HOST', 'SMTP_USER', 'SMTP_PASS', 'SMTP_FROM'), critical: true,
+        note: 'Notificações, digest, propostas' },
+      { key: 'anthropic',  label: 'IA (Anthropic)',           configured: has('ANTHROPIC_API_KEY'), critical: false,
+        note: 'Tomás e agentes de IA' },
+      { key: 'openai',     label: 'OpenAI (voz/legendas)',    configured: has('OPENAI_API_KEY'), critical: false,
+        note: 'Busca por voz, legendas de vídeo' },
+      { key: 's3',         label: 'AWS S3 (uploads)',         configured: has('AWS_S3_BUCKET', 'AWS_ACCESS_KEY_ID'), critical: true,
+        note: 'Upload de fotos de imóveis' },
+      { key: 'cloudinary', label: 'Cloudinary (watermark)',   configured: has('CLOUDINARY_CLOUD_NAME'), critical: false,
+        note: 'Presets e marca d\'água nas imagens' },
+      { key: 'redis',      label: 'Redis (filas/cache)',      configured: has('REDIS_URL'), critical: false,
+        note: 'BullMQ e cache; sem ele usa fallback em memória' },
+      { key: 'maps',       label: 'Google Maps / Street View', configured: has('GOOGLE_MAPS_API_KEY'), critical: false,
+        note: 'Mapas e fachadas' },
+      { key: 'clicksign',  label: 'Clicksign (assinatura)',   configured: has('CLICKSIGN_ACCESS_TOKEN'), critical: false,
+        note: 'Assinatura digital de contratos' },
+      { key: 'ga',         label: 'Google Analytics',         configured: has('NEXT_PUBLIC_GA_MEASUREMENT_ID'), critical: false,
+        note: 'Definido no app web; pode aparecer vazio aqui' },
+    ]
+
+    const criticalMissing = checks.filter(c => c.critical && !c.configured).map(c => c.label)
+    const warnings = checks.filter(c => (c as any).warn).map(c => c.label)
+    const ready = criticalMissing.length === 0 && warnings.length === 0
+
+    return reply.send({
+      success: true,
+      data: {
+        ready,
+        criticalMissing,
+        warnings,
+        checks,
+        timestamp: new Date().toISOString(),
+      },
+    })
+  })
+
   // GET /ai-config — AI feature configuration per plan
   app.get('/ai-config', {
     schema: { tags: ['master'], summary: 'AI feature configuration per plan' },

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -1301,8 +1301,9 @@ export default async function publicRoutes(app: FastifyInstance) {
 
       const apiKey = process.env.OPENAI_API_KEY ?? env.OPENAI_API_KEY
       if (!apiKey) {
-        // Sem chave OpenAI: retorna vazio para o frontend usar busca textual
-        return reply.send({ transcript: '', filters: {} })
+        // Transcrição não configurada — sinaliza claramente (não é "não
+        // entendi o áudio"; é falta de OPENAI_API_KEY no servidor).
+        return reply.send({ transcript: '', filters: {}, reason: 'not_configured' })
       }
 
       // Ler buffer do áudio
@@ -1340,13 +1341,13 @@ export default async function publicRoutes(app: FastifyInstance) {
       if (!whisperRes.ok) {
         const errText = await whisperRes.text()
         app.log.warn({ status: whisperRes.status, body: errText }, '[voice-search] Whisper error')
-        return reply.send({ transcript: '', filters: {} })
+        return reply.send({ transcript: '', filters: {}, reason: 'failed' })
       }
 
       const whisperData = await whisperRes.json() as { text: string }
       const transcript = (whisperData.text ?? '').trim()
 
-      if (!transcript) return reply.send({ transcript: '', filters: {} })
+      if (!transcript) return reply.send({ transcript: '', filters: {}, reason: 'no_speech' })
 
       // Interpretar transcrição com IA (reutiliza função existente)
       let filters: Record<string, unknown> = {}

--- a/apps/web/src/app/(dashboard)/dashboard/admin/webhooks/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/admin/webhooks/page.tsx
@@ -48,6 +48,17 @@ export default function WebhooksHealthPage() {
     refetchInterval: 60_000,
   })
 
+  const { data: readiness } = useQuery({
+    queryKey: ['launch-readiness'],
+    queryFn: async () => {
+      const token = await getValidToken()
+      const res = await masterApi.launchReadiness(token!)
+      return res.data
+    },
+    enabled: isSuperAdmin,
+    refetchInterval: 60_000,
+  })
+
   if (!isSuperAdmin) {
     return (
       <div className="min-h-screen bg-gray-950 text-white flex items-center justify-center">
@@ -75,6 +86,36 @@ export default function WebhooksHealthPage() {
       </div>
 
       <div className="mx-auto max-w-5xl px-4 py-5 sm:px-6 space-y-5">
+        {/* Prontidão de lançamento */}
+        {readiness && (
+          <div className={`rounded-2xl border p-4 ${readiness.ready ? 'border-emerald-500/30 bg-emerald-500/5' : 'border-amber-500/40 bg-amber-500/5'}`}>
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-lg">{readiness.ready ? '✅' : '⚠️'}</span>
+              <h2 className="text-sm font-bold">
+                {readiness.ready ? 'Pronto para lançamento' : 'Pendências antes do lançamento'}
+              </h2>
+            </div>
+            {readiness.criticalMissing?.length > 0 && (
+              <p className="text-xs text-red-300 mb-1">Faltando (crítico): {readiness.criticalMissing.join(', ')}</p>
+            )}
+            {readiness.warnings?.length > 0 && (
+              <p className="text-xs text-amber-300 mb-2">Atenção: {readiness.warnings.join(', ')}</p>
+            )}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 mt-2">
+              {readiness.checks?.map((c: any) => (
+                <div key={c.key} className="flex items-start gap-2 text-xs">
+                  <span className="flex-shrink-0 mt-0.5">{c.configured ? (c.warn ? '🟡' : '🟢') : (c.critical ? '🔴' : '⚪')}</span>
+                  <div className="min-w-0">
+                    <span className="text-white">{c.label}</span>
+                    {c.critical && <span className="ml-1 text-[9px] text-gray-500 uppercase">crítico</span>}
+                    <p className="text-[10px] text-gray-500 leading-tight">{c.note}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {isLoading ? (
           <div className="flex justify-center py-10"><Loader2 className="animate-spin text-amber-400" /></div>
         ) : !data ? (

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -6,6 +6,7 @@ import {
   Bot, MessageCircle, BarChart3, Globe, Code, EyeOff, Users,
   FileText, Lock, Loader2, X,
 } from 'lucide-react'
+import { ALL_THEMES } from '@/lib/site-factory/theme-registry'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -554,36 +555,58 @@ export function DynamicPlans() {
                 </div>
               )}
 
-              {/* Layout + Color side by side */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-xs sm:text-sm font-medium text-gray-300 mb-1">
-                    Layout do site
-                  </label>
-                  <select
-                    value={checkoutForm.layoutType}
-                    onChange={(e) => setCheckoutForm(f => ({ ...f, layoutType: e.target.value }))}
-                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 sm:py-2.5 text-white text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent outline-none"
-                  >
-                    <option value="urban_tech">Urban Tech</option>
-                    <option value="clean">Clean</option>
-                    <option value="classic">Classic</option>
-                    <option value="bold">Bold</option>
-                  </select>
+              {/* Layout — galeria visual de temas prontos */}
+              <div>
+                <label className="block text-xs sm:text-sm font-medium text-gray-300 mb-2">
+                  Escolha o visual do seu site
+                </label>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
+                  {ALL_THEMES.map((t) => {
+                    const selected = checkoutForm.layoutType === t.key
+                    const dark = ['luxury_gold', 'bold_agency'].includes(t.key)
+                    return (
+                      <button
+                        key={t.key}
+                        type="button"
+                        onClick={() => setCheckoutForm(f => ({ ...f, layoutType: t.key, primaryColor: t.accentHex }))}
+                        className={`text-left rounded-xl border-2 overflow-hidden transition-all ${
+                          selected ? 'border-amber-400 ring-2 ring-amber-400/30' : 'border-gray-700 hover:border-gray-500'
+                        }`}
+                      >
+                        {/* Mini mockup do tema */}
+                        <div className="p-2.5" style={{ backgroundColor: dark ? '#0b0f1a' : '#ffffff' }}>
+                          <div className="flex items-center gap-1 mb-1.5">
+                            <div className="h-1.5 flex-1 rounded-full" style={{ backgroundColor: t.accentHex }} />
+                            <div className="h-1.5 w-3 rounded-full" style={{ backgroundColor: dark ? '#374151' : '#e5e7eb' }} />
+                          </div>
+                          <div className="h-1 w-3/4 rounded-full mb-1" style={{ backgroundColor: dark ? '#4b5563' : '#d1d5db' }} />
+                          <div className="h-1 w-1/2 rounded-full mb-2" style={{ backgroundColor: dark ? '#374151' : '#e5e7eb' }} />
+                          <div className="h-3.5 w-12 rounded-md" style={{ backgroundColor: t.accentHex }} />
+                        </div>
+                        {/* Rótulo */}
+                        <div className="px-2.5 py-1.5 bg-gray-800/80">
+                          <div className="flex items-center gap-1.5">
+                            <span className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: t.accentHex }} />
+                            <p className="text-[11px] font-semibold text-white truncate">{t.name}</p>
+                            {selected && <CheckCircle className="w-3 h-3 text-amber-400 ml-auto flex-shrink-0" />}
+                          </div>
+                          <p className="text-[9px] text-gray-400 truncate mt-0.5">{t.tagline}</p>
+                        </div>
+                      </button>
+                    )
+                  })}
                 </div>
-                <div>
-                  <label className="block text-xs sm:text-sm font-medium text-gray-300 mb-1">
-                    Cor principal
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="color"
-                      value={checkoutForm.primaryColor}
-                      onChange={(e) => setCheckoutForm(f => ({ ...f, primaryColor: e.target.value }))}
-                      className="w-9 h-9 rounded-lg border border-gray-700 bg-gray-800 cursor-pointer flex-shrink-0"
-                    />
-                    <span className="text-xs text-gray-400">{checkoutForm.primaryColor}</span>
-                  </div>
+                {/* Cor principal — ajuste fino */}
+                <div className="mt-3 flex items-center gap-2">
+                  <label className="text-xs text-gray-400">Cor principal:</label>
+                  <input
+                    type="color"
+                    value={checkoutForm.primaryColor}
+                    onChange={(e) => setCheckoutForm(f => ({ ...f, primaryColor: e.target.value }))}
+                    className="w-9 h-9 rounded-lg border border-gray-700 bg-gray-800 cursor-pointer flex-shrink-0"
+                  />
+                  <span className="text-xs text-gray-400">{checkoutForm.primaryColor}</span>
+                  <span className="text-[10px] text-gray-500 ml-1">Você poderá editar tudo depois no painel.</span>
                 </div>
               </div>
 

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -310,13 +310,17 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
             return
           }
 
-          const data = await res.json() as { transcript: string }
+          const data = await res.json() as { transcript: string; reason?: string }
 
           if (data.transcript?.trim()) {
             // Send the transcribed text as a chat message
             sendMessage(data.transcript)
           } else {
-            setAudioError('Não consegui entender o áudio. Tente novamente.')
+            setAudioError(
+              data.reason === 'not_configured'
+                ? 'Voz indisponível no momento. Pode digitar sua mensagem normalmente.'
+                : 'Não consegui entender o áudio. Tente novamente.',
+            )
             setAudioState('error')
             setTimeout(() => { setAudioState('idle'); setAudioError(null) }, 3000)
           }

--- a/apps/web/src/components/ui/VoiceInputButton.tsx
+++ b/apps/web/src/components/ui/VoiceInputButton.tsx
@@ -199,10 +199,14 @@ export function VoiceInputButton({
             return
           }
 
-          const data = await res.json() as { transcript?: string; filters?: Record<string, string> }
+          const data = await res.json() as { transcript?: string; filters?: Record<string, string>; reason?: string }
 
           if (!data.transcript || data.transcript.trim().length === 0) {
-            flashError('Não consegui entender o que foi dito. Tente falar mais devagar e mais próximo do microfone.')
+            flashError(
+              data.reason === 'not_configured'
+                ? 'Busca por voz indisponível no momento. Você pode digitar normalmente.'
+                : 'Não consegui entender o que foi dito. Tente falar mais devagar e mais próximo do microfone.',
+            )
             return
           }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1474,6 +1474,9 @@ export const masterApi = {
   webhookHealth: (token: string) =>
     request<{ success: boolean; data: any }>('/api/v1/master/webhook-health', { token }),
 
+  launchReadiness: (token: string) =>
+    request<{ success: boolean; data: any }>('/api/v1/master/launch-readiness', { token }),
+
   repasseQueue: (token: string, params?: { status?: string }) =>
     request<{ success: boolean; data: any }>(`/api/v1/master/repasse-queue?${toQS(params)}`, { token }),
 


### PR DESCRIPTION
## Summary — 3 itens (go-live + UX do cadastro)

### 1. 🎤 Voz/transcrição (Tomás, busca inteligente, todos os campos de áudio)
Investiguei o fluxo inteiro (VoiceInputButton, TomasWidget, `/public/voice-search`, `ai.service.transcribeAudio`) — o código está **correto**. A voz usa **Whisper (OpenAI)** e exige `OPENAI_API_KEY` no servidor. Sem a chave, retornava transcript vazio e o usuário via "Não consegui entender o áudio" (culpando o microfone).
- Endpoint agora retorna `reason`: `not_configured` | `failed` | `no_speech`.
- VoiceInputButton + TomasWidget mostram **"Voz indisponível no momento, pode digitar normalmente"** quando falta a chave.

**⚠️ AÇÃO SUA: setar `OPENAI_API_KEY` em produção** — não estava na sua lista de env. Sem ela a voz não roda (no iOS Safari não há alternativa nativa confiável). Depois de setar, funciona em todos os campos de áudio (todos usam o mesmo endpoint).

### 2. 🎨 Galeria visual de temas no cadastro do site
O `<select>` de layout (só nomes: Urban Tech/Clean/...) virou uma **galeria de 9 temas com preview visual** — cada card é um mini mockup na cor de destaque do tema + nome + tagline. Selecionar aplica a cor principal (ainda ajustável). Nota: "Você poderá editar tudo depois no painel."

### 3. ✅ Tela de prontidão de lançamento
`GET /api/v1/master/launch-readiness` + painel em `/dashboard/admin/webhooks`: semáforo de todas as integrações (inclui OpenAI) e alerta de **Asaas em sandbox**.

## Test plan
- [ ] Setar OPENAI_API_KEY → voz funciona no Tomás e na busca
- [ ] Cadastro de site → galeria de temas com previews coloridos; selecionar aplica a cor
- [ ] `/dashboard/admin/webhooks` → OpenAI 🟢 após setar a chave; Asaas sandbox → 🟡
