### PR TITLE
Visitas: agendamento resiliente (corrige "Erro ao agendar") + atalho Editar meu site

### DIFF
--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -29,43 +29,41 @@ export default async function visitRoutes(app: FastifyInstance) {
     const property = await app.prisma.property.findFirst({
       where: { id: body.propertyId },
       select: { companyId: true, title: true, street: true, city: true },
-    })
+    }).catch(() => null)
     if (!property) return reply.status(404).send({ error: 'PROPERTY_NOT_FOUND' })
 
     const companyId = property.companyId
     const visitDateTime = new Date(`${body.preferredDate}T${body.preferredTime}:00`)
+    if (isNaN(visitDateTime.getTime())) {
+      return reply.status(400).send({ error: 'INVALID_DATE', message: 'Data ou horário inválido.' })
+    }
     const title = body.propertyTitle ?? property.title ?? 'Imóvel'
 
-    // 1. Find or create a lead (Contact)
-    let contact = await app.prisma.contact.findFirst({
-      where: { phone: body.phone, companyId },
-    })
-    if (!contact) {
-      contact = await app.prisma.contact.create({
-        data: {
-          name: body.name,
-          phone: body.phone,
-          email: body.email ?? null,
-          companyId,
-          type: 'INDIVIDUAL',
-        },
+    // 1. Find or create a lead (Contact) — best-effort (não pode quebrar o agendamento)
+    let contact: { id: string } | null = null
+    try {
+      contact = await app.prisma.contact.findFirst({
+        where: { phone: body.phone, companyId },
+        select: { id: true },
       })
+      if (!contact) {
+        contact = await app.prisma.contact.create({
+          data: {
+            name: body.name,
+            phone: body.phone,
+            email: body.email ?? null,
+            companyId,
+            type: 'INDIVIDUAL',
+          },
+          select: { id: true },
+        })
+      }
+    } catch (err) {
+      app.log.warn({ err }, 'visit: contact upsert failed (non-fatal)')
     }
 
-    // 2. Create an Activity (visit) in the agent's agenda
-    const activity = await app.prisma.activity.create({
-      data: {
-        companyId,
-        contactId: contact.id,
-        type: 'visit',
-        title: `Visita: ${title}`,
-        description: `Cliente: ${body.name} (${body.phone})\nImóvel: ${title}\nData: ${visitDateTime.toLocaleDateString('pt-BR')} às ${body.preferredTime}\n${body.notes ? `Obs: ${body.notes}` : ''}`,
-        scheduledAt: visitDateTime,
-      },
-    })
-
-    // Structured visit record so the dashboard agenda can manage status,
-    // confirmation and post-visit feedback (separate from the free-form Activity).
+    // 2. PRINCIPAL: registro estruturado da visita (agenda do dashboard).
+    //    É o critério de sucesso — se isto falhar, retorna erro real.
     const propertyVisit = await app.prisma.propertyVisit.create({
       data: {
         companyId,
@@ -77,7 +75,32 @@ export default async function visitRoutes(app: FastifyInstance) {
         mode: 'in_person',
         notes: body.notes ?? null,
       },
-    }).catch(() => null)
+    }).catch((err: unknown) => {
+      app.log.error({ err }, 'visit: propertyVisit.create failed')
+      return null
+    })
+
+    if (!propertyVisit) {
+      return reply.status(500).send({ error: 'SCHEDULE_FAILED', message: 'Não foi possível agendar. Tente novamente.' })
+    }
+
+    // 3. Activity na timeline livre — best-effort.
+    let activity: { id: string } | null = null
+    try {
+      activity = await app.prisma.activity.create({
+        data: {
+          companyId,
+          contactId: contact?.id ?? null,
+          type: 'visit',
+          title: `Visita: ${title}`,
+          description: `Cliente: ${body.name} (${body.phone})\nImóvel: ${title}\nData: ${visitDateTime.toLocaleDateString('pt-BR')} às ${body.preferredTime}\n${body.notes ? `Obs: ${body.notes}` : ''}`,
+          scheduledAt: visitDateTime,
+        },
+        select: { id: true },
+      })
+    } catch (err) {
+      app.log.warn({ err }, 'visit: activity.create failed (non-fatal)')
+    }
 
     // In-app + e-mail notification for company admins so the visit is
     // surfaced the moment it is scheduled.
@@ -105,36 +128,40 @@ export default async function visitRoutes(app: FastifyInstance) {
       app.log.warn({ err }, 'visit notify failed')
     }
 
-    // 3. Create a Deal (lead pipeline) if not exists
-    const existingDeal = await app.prisma.deal.findFirst({
-      where: {
-        contactId: contact.id,
-        companyId,
-        status: { in: ['OPEN', 'IN_PROGRESS'] },
-        properties: { some: { propertyId: body.propertyId } },
-      },
-    })
-    if (!existingDeal) {
-      // Find the first active broker/user in this company to assign the deal
-      const broker = await app.prisma.user.findFirst({
-        where: { companyId, status: 'ACTIVE' },
-        select: { id: true },
-      })
-      if (broker) {
-        await app.prisma.deal.create({
-          data: {
-            companyId,
+    // 4. Create a Deal (lead pipeline) if not exists — best-effort.
+    try {
+      if (contact) {
+        const existingDeal = await app.prisma.deal.findFirst({
+          where: {
             contactId: contact.id,
-            brokerId: broker.id,
-            title: `Visita agendada — ${title}`,
-            status: 'OPEN',
-            value: null,
-            properties: {
-              create: { propertyId: body.propertyId },
-            },
+            companyId,
+            status: { in: ['OPEN', 'IN_PROGRESS'] },
+            properties: { some: { propertyId: body.propertyId } },
           },
-        }).catch(() => {/* deal creation is optional */})
+          select: { id: true },
+        })
+        if (!existingDeal) {
+          const broker = await app.prisma.user.findFirst({
+            where: { companyId, status: 'ACTIVE' },
+            select: { id: true },
+          })
+          if (broker) {
+            await app.prisma.deal.create({
+              data: {
+                companyId,
+                contactId: contact.id,
+                brokerId: broker.id,
+                title: `Visita agendada — ${title}`,
+                status: 'OPEN',
+                value: null,
+                properties: { create: { propertyId: body.propertyId } },
+              },
+            })
+          }
+        }
       }
+    } catch (err) {
+      app.log.warn({ err }, 'visit: deal creation failed (non-fatal)')
     }
 
     // 4. Send WhatsApp to company agent (if configured)
@@ -173,7 +200,7 @@ export default async function visitRoutes(app: FastifyInstance) {
       }
     }
 
-    return reply.send({ success: true, activityId: activity.id, contactId: contact.id })
+    return reply.send({ success: true, visitId: propertyVisit.id, activityId: activity?.id ?? null, contactId: contact?.id ?? null })
   })
 
   // GET /api/v1/public/visits/:id/feedback — fetch visit info for the public

--- a/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
@@ -180,7 +180,14 @@ const SUB_TABS = [
 export function SystemConfigPanel() {
   const { getValidToken, user } = useAuth()
   const qc = useQueryClient()
-  const [subTab, setSubTab] = useState('empresa')
+  // Deep-link: ?panel=cores abre direto a aba "Cores & Botões"
+  // (atalho "Editar meu site"). Lê window.location p/ evitar Suspense.
+  const [subTab, setSubTab] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return new URLSearchParams(window.location.search).get('panel') ?? 'empresa'
+    }
+    return 'empresa'
+  })
   const [saved, setSaved] = useState(false)
 
   // Keep a current access token in local state so child components that

--- a/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -146,7 +146,16 @@ export default function SettingsPage() {
     { id: 'sistema',      label: 'Sistema',       icon: Settings,  show: isManager },
   ].filter(t => t.show)
 
-  const [activeTab, setActiveTab] = useState('empresa')
+  // Deep-link: /dashboard/settings?tab=sistema abre a aba direto (ex.: atalho
+  // "Editar meu site" do menu). Lê window.location p/ evitar Suspense de
+  // useSearchParams no build.
+  const [activeTab, setActiveTab] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const t = new URLSearchParams(window.location.search).get('tab')
+      if (t && TABS.some(x => x.id === t)) return t
+    }
+    return 'empresa'
+  })
 
   // ── Empresa ────────────────────────────────────────────────────────────────
   const [empresa, setEmpresa] = useState({

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -105,6 +105,7 @@ const midNavItems = [
 
 const corretorNavItem = { href: '/dashboard/corretor', icon: BriefcaseBusiness, label: 'Meu Painel', highlight: false }
 const corretorHojeItem = { href: '/dashboard/corretor/hoje', icon: Calendar, label: 'Meu Dia', highlight: false }
+const editarSiteItem = { href: '/dashboard/settings?tab=sistema&panel=cores', icon: Palette, label: 'Editar meu site', highlight: true }
 
 const lemosbankSubItems = [
   { href: '/dashboard/lemosbank',              icon: Banknote,   label: 'Visão Geral' },
@@ -340,6 +341,28 @@ function NavContent({ onClose }: { onClose?: () => void }) {
             </Link>
           )
         })}
+
+        {/* ── Editar meu site — atalho destacado ────────────── */}
+        {(() => {
+          const { href, icon: Icon, label } = editarSiteItem
+          const active = pathname.startsWith('/dashboard/settings')
+          return (
+            <Link
+              href={href}
+              onClick={onClose}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors border',
+                active
+                  ? 'text-white border-yellow-400/40'
+                  : 'text-yellow-400/80 hover:text-yellow-300 hover:bg-yellow-400/5 border-yellow-400/20',
+              )}
+              style={active ? { background: 'linear-gradient(135deg, rgba(201,168,76,0.2), rgba(232,198,106,0.1))' } : undefined}
+            >
+              <Icon className="h-4 w-4 flex-shrink-0 text-yellow-400/70" />
+              <span className="truncate">{label}</span>
+            </Link>
+          )
+        })()}
 
         {/* ── Meu Painel (corretor) — last ──────────────────── */}
         {[corretorHojeItem, corretorNavItem].map(({ href, icon: Icon, label }) => {


### PR DESCRIPTION
## Summary

Resolve a falha de agendamento de visita (print "Erro ao agendar") + adiciona o atalho "Editar meu site".

### 🐛 Agendamento de visita resiliente

O `POST /api/v1/public/visits` tinha operações de DB **sem try/catch** (contact, activity, deal). Se qualquer uma lançasse exceção, a request retornava 500 e o usuário via **"Erro ao agendar. Tente novamente."** — mesmo que a visita pudesse ser registrada.

Reescrevi o handler:
- **PropertyVisit (registro da agenda) = critério de sucesso.** Criado primeiro; se falhar, retorna erro real (`SCHEDULE_FAILED`).
- **contact, activity, deal, notify, WhatsApp = best-effort** (try/catch + log). Falha secundária **não derruba mais** o agendamento.
- **Validação de data**: retorna `400 INVALID_DATE` em vez de estourar 500 se data/hora inválida.
- Activity agora aceita `contactId` nulo (não depende mais do contact ter sido criado).

Resultado: o cliente consegue agendar mesmo que algum passo acessório falhe; e quando há erro de verdade, ele é logado para diagnóstico em vez de virar 500 silencioso.

### ✏️ Atalho "Editar meu site"

- Entrada destacada (dourada) **"Editar meu site"** no menu → abre `/dashboard/settings?tab=sistema&panel=cores` direto na aba **"Cores & Botões"** (color pickers de primária/hover/destaque/botões/fundos, CSS/JS custom, etc.).
- `settings/page.tsx` e `SystemConfigPanel.tsx` agora leem `?tab` / `?panel` via `window.location` (lazy init — sem `useSearchParams`, pra não exigir Suspense e não arriscar o build).
- Deixa óbvio pro parceiro/corretor que ele edita 100% do próprio site.

## Test plan

- [ ] Agendar visita no site → sucesso (sem "Erro ao agendar")
- [ ] Visita aparece em `/dashboard/agenda`
- [ ] Forçar data inválida → 400 claro, não 500
- [ ] Menu "Editar meu site" → abre Configurações já na aba Cores & Botões
- [ ] Editar uma cor e salvar → reflete no site
- [ ] Vercel build verde


---
_Generated by [Claude Code](https://claude.ai/code/session_01PseGL3WWVXr4gV1YMihaAe)_