### PR TITLE
fix(launch): webhook fail-closed, remove sucesso falso e ativa landing de planos

### DIFF
--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -41,9 +41,18 @@ export default async function saasWebhookRoutes(app: FastifyInstance) {
     },
     bodyLimit: 65536, // 64KB max payload
   }, async (req, reply) => {
-    // 1. Validate webhook secret
+    // 1. Validate webhook secret (fail-closed in production)
     const webhookToken = (req.headers['asaas-access-token'] as string) || ''
-    if (env.ASAAS_WEBHOOK_SECRET && !safeStringEqual(webhookToken, env.ASAAS_WEBHOOK_SECRET)) {
+    if (!env.ASAAS_WEBHOOK_SECRET) {
+      // No secret configured. In production this is unsafe — without it anyone
+      // could forge a PAYMENT_CONFIRMED and activate a tenant for free — so we
+      // reject. In dev/test we warn and continue to keep local testing easy.
+      if (env.NODE_ENV === 'production') {
+        app.log.error('[saas-webhook] ASAAS_WEBHOOK_SECRET not configured — rejecting webhook (fail-closed)')
+        return reply.status(503).send({ error: 'WEBHOOK_SECRET_NOT_CONFIGURED' })
+      }
+      app.log.warn('[saas-webhook] ASAAS_WEBHOOK_SECRET not set — skipping signature check (dev only)')
+    } else if (!safeStringEqual(webhookToken, env.ASAAS_WEBHOOK_SECRET)) {
       app.log.warn('[saas-webhook] Invalid webhook token')
 
       await app.prisma.auditLog.create({

--- a/apps/web/src/app/(public)/parceiros/checkout/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/checkout/page.tsx
@@ -136,12 +136,11 @@ function CheckoutContent() {
 
       if (!res.ok) {
         if (data.error === 'ASAAS_NOT_CONFIGURED') {
-          // Fallback: registrar interesse e mostrar mensagem
-          setResult({
-            subscriptionId: 'PENDING_MANUAL',
-            status: 'PENDING',
-          })
-          setStep('success')
+          // Pagamento online indisponível: NÃO mostrar sucesso falso — orientar
+          // o cliente a concluir pelo WhatsApp, para não dar a impressão de que
+          // a assinatura já foi paga.
+          setError('O pagamento online está temporariamente indisponível. Fale com a gente no WhatsApp (16) 98101-0004 para concluir sua assinatura.')
+          setStep('form')
           return
         }
         setError(data.message ?? data.error ?? 'Erro ao processar pagamento. Tente novamente.')

--- a/apps/web/src/app/(public)/parceiros/planos/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/planos/page.tsx
@@ -1,13 +1,13 @@
-import { redirect } from 'next/navigation'
 import type { Metadata } from 'next'
+import { PlanosContent } from '../PlanosContent'
 
 export const metadata: Metadata = {
-  title: 'Seja um Parceiro — Planos e Ferramentas | AgoraEncontrei',
+  title: 'Planos e Preços — Seja um Parceiro | AgoraEncontrei',
   description:
-    'Acesse o dashboard privado do AgoraEncontrei. Calculadora ROI de leilões, sentinela territorial, analytics de leads e alertas inteligentes. Planos a partir de R$ 197/mês.',
-  alternates: { canonical: 'https://www.agoraencontrei.com.br/parceiros/cadastro' },
+    'Conheça os planos do AgoraEncontrei para imobiliárias e corretores: site próprio, CRM com IA, planos PRIME e VIP e pacotes de imóveis. Tecnologia de ponta a partir de R$ 197/mês.',
+  alternates: { canonical: 'https://www.agoraencontrei.com.br/parceiros/planos' },
 }
 
 export default function ParceirosPlanos() {
-  redirect('/parceiros/cadastro')
+  return <PlanosContent />
 }


### PR DESCRIPTION
## Resumo

Primeira leva de correções **P0 de prontidão para lançamento comercial**, focada no caminho do cliente pagante. Mudanças pequenas e cirúrgicas, sem alterar o que já funciona.

### 1. `fix(security)` — webhook do Asaas passa a ser **fail-closed**
`saas-webhook.ts` antes **pulava** a validação de assinatura quando `ASAAS_WEBHOOK_SECRET` não estava configurado — qualquer um poderia forjar um `PAYMENT_CONFIRMED` e **ativar um tenant de graça**.
- Agora, em **produção**, sem o segredo configurado o webhook **rejeita (503)**.
- Em dev/test continua apenas avisando, para não atrapalhar testes locais.
- ⚠️ **Config necessária:** setar `ASAAS_WEBHOOK_SECRET` no Railway e registrar o mesmo no painel do Asaas.

### 2. `fix(ux)` — remove o "sucesso falso" no checkout de especialista
Quando o Asaas não estava configurado, a tela mostrava **sucesso sem pagamento**. Agora mostra erro honesto orientando o cliente a concluir pelo WhatsApp.

### 3. `feat(vendas)` — `/parceiros/planos` vira uma landing real
A rota era só um `redirect('/parceiros/cadastro')`. Agora renderiza o `PlanosContent` (componente de vendas **já pronto** no repo, antes órfão): planos Site/CRM, PRIME/VIP e pacotes. CTAs validados — sem links quebrados.

## Verificação
- Build será validado pelo **preview da Vercel** neste PR.
- `env.NODE_ENV` já existe no schema (usado no fail-closed).
- Nenhuma funcionalidade existente alterada.

## Fora do escopo (próximos passos)
- P0 restante de **config** (seu): `ASAAS_API_KEY`, `ASAAS_WEBHOOK_SECRET`, `SMTP_*`, WhatsApp; registrar os **dois** webhooks no Asaas; confirmar wildcard `*.agoraencontrei.com.br`.
- Bug do enum `SpecialistCategory` (Imobiliária/Loteadora) — requer migration Prisma, será PR separado.
- Mesma proteção fail-closed no webhook de especialistas (`payments.ts`, hoje `@ts-nocheck`).

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_