### PR TITLE
fix(launch): enum Imobiliária/Loteadora + redirect pós-verificação para o painel

### DIFF
--- a/apps/api/src/routes/specialists/index.ts
+++ b/apps/api/src/routes/specialists/index.ts
@@ -175,6 +175,7 @@ export default async function specialistsRoute(app: FastifyInstance) {
         'ARQUITETO', 'ENGENHEIRO', 'CORRETOR', 'AVALIADOR',
         'DESIGNER_INTERIORES', 'FOTOGRAFO', 'VIDEOMAKER',
         'ADVOGADO_IMOBILIARIO', 'DESPACHANTE', 'OUTRO',
+        'IMOBILIARIA', 'LOTEADORA',
       ]),
       bio: z.string().optional(),
       city: z.string().default('Franca'),

--- a/apps/web/src/app/(public)/verificar-email/page.tsx
+++ b/apps/web/src/app/(public)/verificar-email/page.tsx
@@ -43,8 +43,8 @@ function VerificarEmailContent() {
         // Auto-login after verification
         if (data.accessToken && data.user) {
           setAuth(data.user, data.accessToken, data.expiresIn, data.refreshToken)
-          // Redirect to plans page after 2 seconds
-          setTimeout(() => router.push('/parceiros/planos'), 2000)
+          // Redirect the new subscriber straight to their dashboard after 2s.
+          setTimeout(() => router.push('/dashboard'), 2000)
         }
       } catch {
         setStatus('error')
@@ -73,11 +73,11 @@ function VerificarEmailContent() {
             </div>
             <h1 className="text-xl font-bold mb-2" style={{ color: '#1B2B5B' }}>E-mail verificado!</h1>
             <p className="text-gray-500 mb-6">{message}</p>
-            <p className="text-sm text-gray-400 mb-4">Redirecionando para a escolha do plano...</p>
-            <Link href="/parceiros/planos"
+            <p className="text-sm text-gray-400 mb-4">Redirecionando para o seu painel...</p>
+            <Link href="/dashboard"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold text-sm text-white"
               style={{ background: '#1B2B5B' }}>
-              Escolher meu plano
+              Ir para o meu painel
             </Link>
           </>
         )}

--- a/packages/database/prisma/migrations/20260612230000_add_imobiliaria_loteadora_specialist_category/migration.sql
+++ b/packages/database/prisma/migrations/20260612230000_add_imobiliaria_loteadora_specialist_category/migration.sql
@@ -1,0 +1,12 @@
+-- Add IMOBILIARIA and LOTEADORA to the SpecialistCategory enum.
+--
+-- These two "premium" partner categories were offered (and priced) in the
+-- public signup UI (/parceiros/cadastro) but were missing from the DB enum,
+-- so POST /specialists returned 400 "Dados inválidos" for exactly the
+-- flagship paid tier. Adding the values unblocks registration.
+--
+-- NOTE: production does not run `prisma migrate deploy` automatically, so this
+-- statement must also be applied manually to the Neon database before the
+-- feature works in production. It is idempotent (IF NOT EXISTS).
+ALTER TYPE "SpecialistCategory" ADD VALUE IF NOT EXISTS 'IMOBILIARIA';
+ALTER TYPE "SpecialistCategory" ADD VALUE IF NOT EXISTS 'LOTEADORA';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2203,6 +2203,8 @@ enum SpecialistCategory {
   ADVOGADO_IMOBILIARIO
   DESPACHANTE
   OUTRO
+  IMOBILIARIA
+  LOTEADORA
 }
 
 enum SpecialistStatus {


### PR DESCRIPTION
## Resumo

Segunda leva de launch-readiness: corrige o **bug duro do cadastro de especialista** (P0-B) e a **primeira melhoria de onboarding**.

### 1. `fix(p0-b)` — categorias Imobiliária/Loteadora aceitas
A UI `/parceiros/cadastro` oferecia e cobrava (tier premium R$ 350) as categorias **Imobiliária** e **Loteadora**, mas o enum `SpecialistCategory` (Prisma) e o Zod de `POST /specialists` **não as tinham** → registro retornava **400** exatamente no tier mais caro.
- Adicionadas `IMOBILIARIA` e `LOTEADORA` ao enum (`schema.prisma`) e ao Zod.
- Migration `ALTER TYPE ... ADD VALUE IF NOT EXISTS` (idempotente).

> ⚠️ **AÇÃO MANUAL NECESSÁRIA:** a produção **não roda `migrate deploy` automático**. Rode no banco (Neon) antes do deploy:
> ```sql
> ALTER TYPE "SpecialistCategory" ADD VALUE IF NOT EXISTS 'IMOBILIARIA';
> ALTER TYPE "SpecialistCategory" ADD VALUE IF NOT EXISTS 'LOTEADORA';
> ```

### 2. `fix(onboarding)` — redirect pós-verificação para o painel
Após confirmar o e-mail, o novo assinante era mandado para `/parceiros/planos` (que leva ao cadastro de **especialista** — fluxo errado para quem acabou de registrar uma conta/empresa). Agora vai direto para **`/dashboard`**.

## Verificação
- Build validado pelo **preview da Vercel** deste PR.
- Sem sobreposição de arquivos com o PR #161 (rebaseado na `main` atual).

## Próximo passo (não incluído)
- **Assistente de onboarding guiado** (checklist "primeiros passos" no dashboard) — UI maior, será PR dedicado.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_