### PR TITLE
feat(onboarding): checklist "Primeiros passos" no dashboard

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip, ResponsiveContainer, Legend,
 } from 'recharts'
 import AuctionMonitor from './AuctionMonitor'
+import { OnboardingChecklist } from '@/components/dashboard/OnboardingChecklist'
 import {
   Building2,
   UserCheck,
@@ -141,6 +142,9 @@ export default function DashboardPage() {
           Aqui está um resumo do seu negócio hoje
         </p>
       </div>
+
+      {/* Onboarding — primeiros passos (some quando concluído ou dispensado) */}
+      <OnboardingChecklist propertyCount={stats?.total ?? 0} />
 
       {/* Banner de status da IA */}
       {aiStatus && (

--- a/apps/web/src/components/dashboard/OnboardingChecklist.tsx
+++ b/apps/web/src/components/dashboard/OnboardingChecklist.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+/**
+ * OnboardingChecklist — "Primeiros passos" para novos assinantes.
+ *
+ * Mostra um cartão com 3-4 passos iniciais (personalizar marca, publicar o
+ * primeiro imóvel, conectar WhatsApp/IA, conhecer o CRM). O passo de imóvel
+ * é concluído automaticamente quando a conta já tem imóveis; os demais são
+ * marcados ao serem visitados. Some quando dispensado ou 100% concluído.
+ *
+ * Estado persistido em localStorage (sem backend), seguro contra SSR.
+ */
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  Sparkles, CheckCircle2, X, ArrowRight,
+  Palette, Building2, MessageCircle, Users,
+} from 'lucide-react'
+
+const DISMISS_KEY = 'ae_onboarding_dismissed'
+const VISITED_KEY = 'ae_onboarding_visited'
+
+type Step = {
+  id: string
+  label: string
+  desc: string
+  href: string
+  icon: React.ReactNode
+  auto?: boolean
+}
+
+export function OnboardingChecklist({ propertyCount = 0 }: { propertyCount?: number }) {
+  const [mounted, setMounted] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+  const [visited, setVisited] = useState<string[]>([])
+
+  useEffect(() => {
+    setMounted(true)
+    try {
+      setDismissed(localStorage.getItem(DISMISS_KEY) === '1')
+      const v = localStorage.getItem(VISITED_KEY)
+      if (v) setVisited(JSON.parse(v))
+    } catch {}
+  }, [])
+
+  const steps: Step[] = [
+    {
+      id: 'brand',
+      label: 'Personalize seu site',
+      desc: 'Cores, logo e identidade da sua marca',
+      href: '/dashboard/settings?tab=sistema&panel=cores',
+      icon: <Palette className="w-5 h-5" />,
+    },
+    {
+      id: 'property',
+      label: 'Publique seu primeiro imóvel',
+      desc: 'Cadastre e divulgue no marketplace',
+      href: '/dashboard/properties/new',
+      icon: <Building2 className="w-5 h-5" />,
+      auto: propertyCount > 0,
+    },
+    {
+      id: 'whatsapp',
+      label: 'Conecte WhatsApp e IA',
+      desc: 'Atendimento automático com o Tomás',
+      href: '/dashboard/settings?tab=integracoes',
+      icon: <MessageCircle className="w-5 h-5" />,
+    },
+    {
+      id: 'crm',
+      label: 'Conheça seu CRM',
+      desc: 'Acompanhe leads e negociações',
+      href: '/dashboard/leads',
+      icon: <Users className="w-5 h-5" />,
+    },
+  ]
+
+  const isDone = (s: Step) => !!s.auto || visited.includes(s.id)
+  const doneCount = steps.filter(isDone).length
+  const allDone = doneCount === steps.length
+
+  const markVisited = (id: string) => {
+    setVisited(prev => {
+      if (prev.includes(id)) return prev
+      const next = [...prev, id]
+      try { localStorage.setItem(VISITED_KEY, JSON.stringify(next)) } catch {}
+      return next
+    })
+  }
+
+  const dismiss = () => {
+    setDismissed(true)
+    try { localStorage.setItem(DISMISS_KEY, '1') } catch {}
+  }
+
+  // Evita mismatch SSR/CSR e oculta quando dispensado ou tudo concluído.
+  if (!mounted || dismissed || allDone) return null
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-[#C9A84C]/30 bg-gradient-to-br from-[#1B2B5B] to-[#0f1c3a] p-5 text-white">
+      <button
+        onClick={dismiss}
+        aria-label="Dispensar primeiros passos"
+        className="absolute right-3 top-3 text-white/50 transition-colors hover:text-white"
+      >
+        <X className="h-4 w-4" />
+      </button>
+
+      <div className="mb-1 flex items-center gap-2">
+        <Sparkles className="h-4 w-4 text-[#C9A84C]" />
+        <h2 className="text-lg font-bold">Primeiros passos</h2>
+      </div>
+      <p className="mb-4 text-sm text-white/60">
+        Conclua a configuração para aproveitar todo o sistema — {doneCount} de {steps.length} feitos.
+      </p>
+
+      <div className="mb-5 h-1.5 overflow-hidden rounded-full bg-white/10">
+        <div
+          className="h-full bg-[#C9A84C] transition-all duration-500"
+          style={{ width: `${(doneCount / steps.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {steps.map(s => {
+          const done = isDone(s)
+          return (
+            <Link
+              key={s.id}
+              href={s.href}
+              onClick={() => markVisited(s.id)}
+              className={`group flex items-center gap-3 rounded-xl border p-3 transition-all ${
+                done
+                  ? 'border-white/10 bg-white/5'
+                  : 'border-[#C9A84C]/30 bg-white/10 hover:border-[#C9A84C] hover:bg-white/15'
+              }`}
+            >
+              <div className={done ? 'text-[#C9A84C]' : 'text-white/80'}>
+                {done ? <CheckCircle2 className="h-5 w-5" /> : s.icon}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className={`text-sm font-semibold ${done ? 'text-white/50 line-through' : 'text-white'}`}>
+                  {s.label}
+                </p>
+                {!done && <p className="text-xs leading-snug text-white/50">{s.desc}</p>}
+              </div>
+              {!done && (
+                <ArrowRight className="h-4 w-4 flex-shrink-0 text-white/40 transition-colors group-hover:text-[#C9A84C]" />
+              )}
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Resumo

Implementa o **assistente de onboarding** — a peça que faltava para o novo assinante não cair "no escuro" ao entrar no painel.

### `feat(onboarding)` — checklist "Primeiros passos" no dashboard
Adiciona um cartão no topo do `/dashboard` com os passos iniciais:
1. **Personalize seu site** → `/dashboard/settings?tab=sistema&panel=cores`
2. **Publique seu primeiro imóvel** → `/dashboard/properties/new` *(auto-concluído quando a conta já tem imóveis, via `stats.total`)*
3. **Conecte WhatsApp e IA** → `/dashboard/settings?tab=integracoes`
4. **Conheça seu CRM** → `/dashboard/leads`

**Comportamento:**
- Barra de progresso (X de 4).
- Passos marcados ao serem visitados; o de imóvel completa sozinho.
- Dispensável (X) e **some quando 100% concluído**.
- Estado em `localStorage` (sem backend), seguro contra SSR (só renderiza após mount).

Combina com o redirect pós-verificação para `/dashboard` (PR #162) — agora o novo assinante chega ao painel **e** recebe orientação.

## Verificação
- Links apontam para rotas existentes do dashboard.
- Build validado pelo **preview da Vercel** deste PR.
- `React.ReactNode` sem import segue o padrão do repo.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_