### PR TITLE
docs: plano de vendas (playbook mestre)

### DIFF
--- a/docs/PLANO-DE-VENDAS.md
+++ b/docs/PLANO-DE-VENDAS.md
@@ -1,0 +1,250 @@
+# 🎯 Plano de Vendas — AgoraEncontrei
+
+> **Documento mestre de vendas.** Inventário completo de ferramentas, análise de
+> concorrentes, proposta de valor, quebra de objeções, justificativa de preço e
+> scripts de abordagem. É a fonte de conteúdo da página pública de vendas e do
+> pitch deck.
+>
+> ⚠️ Os números de concorrentes (preços/recursos) refletem o mercado conhecido
+> até 2026 e devem ser **reconfirmados antes de uso público** — o mercado muda.
+
+---
+
+## 1. Posicionamento em uma frase
+
+> **O AgoraEncontrei é o único sistema imobiliário que junta, num lugar só, um
+> vendedor com Inteligência Artificial que atende 24/7, um site próprio no ar em
+> 24h, CRM completo, inteligência de leilões com cálculo de ROI, financeiro
+> (boletos/repasses) e marketing automático — tudo nativo para o Brasil.**
+
+Não é "mais um CRM". É a **central de operação e aquisição** da imobiliária moderna —
+substitui de 5 a 7 ferramentas por uma só, mais barata que a soma das partes.
+
+---
+
+## 2. A dor de quem vende imóvel hoje
+
+O corretor / imobiliária típico vive **espalhado em 6 ferramentas que não conversam**:
+
+| Dor | Realidade hoje |
+|-----|----------------|
+| 🐌 Lead esfria | Responde lead horas depois → concorrente fechou antes |
+| 🧩 Ferramentas soltas | CRM num lugar, site noutro, portal noutro, planilha de financeiro… |
+| 💸 Custo somado | Paga CRM + site + ferramenta de IA + gestão financeira separadamente |
+| 🌙 Fora do horário | Lead chega 22h no WhatsApp e ninguém responde |
+| 🔍 Leilão é caixa-preta | Sabe que tem oportunidade mas não calcula ROI/risco |
+| 📉 Sem previsibilidade | Não sabe de onde vem o lead nem o que converte |
+
+**O AgoraEncontrei mata as 6 dores de uma vez.**
+
+---
+
+## 3. Inventário COMPLETO de ferramentas (o que está incluído)
+
+Organizado por área. Cada item tem o **benefício de venda** (o que dizer ao cliente).
+
+### 🤖 Tomás — Vendedor com IA (o diferencial nº 1)
+- Atende e **qualifica leads 24/7** no WhatsApp e no site (intenção, orçamento, bairro, urgência).
+- Já **envia imóveis compatíveis** automaticamente e marca visita.
+- Segue a **"regra dos 2 minutos"**: manda o imóvel primeiro, segura o checkout, cria desejo antes de oferecer.
+- Entende **voz** (o cliente fala, ele transcreve e responde).
+- **Venda:** "Seu plantão nunca dorme. Enquanto você está em uma visita, o Tomás fecha o próximo."
+
+### 🌐 Site próprio + Marketplace
+- **Site profissional no ar em 24h**, com seu domínio próprio e **white-label** (sem "powered by").
+- 5 temas premium (urbano, clássico, luxo, etc.).
+- Aparece também no **marketplace AgoraEncontrei** (tráfego compartilhado).
+- **Tour virtual**, **visita por vídeo** e **mapa interativo por região** (satélite).
+- **Venda:** "Site de imobiliária grande, no ar amanhã, sem desenvolvedor."
+
+### 📊 CRM completo
+- Leads, contatos, negócios (funil), atividades, comissões, financiamentos.
+- **Lead scoring** (prioriza quem está quente).
+- **Funil de aquisição** com automações (preview → checkout) e follow-up automático.
+- **Venda:** "Nada de lead perdido em planilha. Cada contato tem dono, etapa e próximo passo."
+
+### 🔨 Inteligência de Leilões (ninguém mais tem)
+- Busca unificada em **Caixa, Santander, BB, Bradesco e leiloeiros** (judiciais e extrajudiciais).
+- **Calculadora de ROI**: ITBI, registro, advogado, desocupação, reforma → lucro e payback.
+- **Score de oportunidade** e selo "💎 Pérola" para descontos > 40%.
+- **Alertas** por e-mail/WhatsApp de novas oportunidades.
+- **Venda:** "Transforme leilão em renda recorrente para você e seus clientes investidores."
+
+### 📣 Marketing & SEO automático
+- **SEO programático**: gera páginas por bairro/cidade automaticamente (Google traz lead orgânico).
+- **Blog** integrado, **posts sociais** automáticos, campanhas de marketing.
+- **Venda:** "Apareça no Google em centenas de buscas sem escrever nada."
+
+### 🎨 IA Visual & Vídeo
+- Edição de fotos, **marca d'água**, otimização de imagens (Cloudinary).
+- Geração/edição de vídeo dos imóveis.
+- **Venda:** "Fotos e vídeos de revista sem contratar fotógrafo/editor."
+
+### 🔗 Sincronização com Portais
+- Publica nos portais: **ZAP, VivaReal, OLX, Facebook Marketplace** (adapters prontos).
+- **Venda:** "Cadastra uma vez, aparece em todo lugar."
+
+### 💰 LemosBank — Financeiro
+- **Boletos, cobranças, repasses, rescisões, histórico** (integração Asaas).
+- Notas fiscais, contratos e **assinatura digital** (Clicksign).
+- **Venda:** "Cobre, repasse e assine contrato sem sair do sistema."
+
+### ⚙️ Automações & WhatsApp
+- Motor de **automação por regras** (gatilho → ação).
+- **WhatsApp Cloud API** oficial (Meta) para atendimento e disparos.
+- **Venda:** "O sistema trabalha sozinho enquanto você dorme."
+
+### 🧰 Ainda incluso
+- Avaliação de imóveis (engine), rental yield, taxas BCB.
+- Inbox unificada, notificações, documentos, jurídico, auditoria.
+- Multi-tenant, multiusuário, controle de acesso por papel.
+
+---
+
+## 4. Os 6 diferenciais que NINGUÉM junta
+
+1. **Vendedor com IA (Tomás)** que atende 24/7 — não é chatbot de FAQ, é qualificação + envio de imóvel + agendamento.
+2. **Inteligência de leilões com ROI** — exclusivo no mercado de CRM imobiliário.
+3. **Site próprio em 24h + marketplace** — presença dupla (seu site + nosso tráfego).
+4. **Tudo-em-um real** — CRM + site + portais + financeiro + marketing + IA num login só.
+5. **Nativo Brasil** — Caixa, Asaas (boleto/PIX), Clicksign, WhatsApp oficial, NF.
+6. **Preço de entrada agressivo** — começa em **R$ 97/mês**, com tudo de IA já a partir de **R$ 297/mês**.
+
+---
+
+## 5. Análise de concorrentes
+
+> ⚠️ Reconfirmar preços/recursos antes de uso público.
+
+| Concorrente | O que é forte | O que NÃO tem (onde ganhamos) |
+|-------------|---------------|-------------------------------|
+| **Jetimob** | Site + CRM + integração de portais; popular em imobiliárias | Sem vendedor com IA real; sem inteligência de leilões; sem financeiro próprio |
+| **Vista / Kenlo (ex-Ingaia)** | CRM robusto, grande base, integrações | Caro/corporativo; sem IA de atendimento 24/7 nem leilões; implantação lenta |
+| **Tecimob** | Sites + CRM baratos para corretor autônomo | Foco em site; sem IA, sem leilões, sem financeiro completo |
+| **Imobzi** | Gestão (CRM + locação + financeiro + site) | Sem vendedor com IA; sem inteligência de leilões; sem marketplace |
+| **Universal Software / Superlógica** | Fortes em administração de locação/financeiro | Não são plataforma de aquisição/venda com IA nem leilões |
+| **RD Station / HubSpot** | CRM/marketing genérico poderoso | Não é imobiliário; sem site de imóveis, portais, leilões ou financeiro do setor |
+| **Loft / QuintoAndar** | Marketplaces com tráfego | São concorrentes de atenção, não dão ao corretor um sistema próprio |
+
+**Conclusão de venda:** os concorrentes resolvem **uma fatia** (ou site, ou CRM, ou
+financeiro). O AgoraEncontrei resolve **a operação inteira** — e é o **único** com
+IA de atendimento + inteligência de leilões.
+
+---
+
+## 6. Comparativo "nós vs eles" (tabela de fechamento)
+
+| Recurso | AgoraEncontrei | CRM tradicional | Construtor de site |
+|---------|:--------------:|:---------------:|:------------------:|
+| Vendedor com IA 24/7 (Tomás) | ✅ | ❌ | ❌ |
+| Inteligência de leilões + ROI | ✅ | ❌ | ❌ |
+| Site próprio em 24h + white-label | ✅ | parcial | ✅ |
+| Marketplace com tráfego | ✅ | ❌ | ❌ |
+| Sincronização de portais | ✅ | ✅ | parcial |
+| Financeiro (boleto/repasse/NF) | ✅ | parcial | ❌ |
+| SEO programático | ✅ | ❌ | parcial |
+| IA visual de foto/vídeo | ✅ | ❌ | ❌ |
+| Assinatura digital de contrato | ✅ | parcial | ❌ |
+| **Preço de entrada** | **R$ 97–297/mês** | R$ 150–400/mês | R$ 80–200/mês |
+
+---
+
+## 7. Proposta de valor — a conta que faz dizer "sim"
+
+**Stack equivalente, comprado separado, custaria por mês:**
+
+| Ferramenta avulsa | Custo médio/mês |
+|-------------------|----------------:|
+| CRM imobiliário | R$ 200–400 |
+| Construtor de site | R$ 100–200 |
+| Ferramenta de IA / chatbot | R$ 150–300 |
+| Sincronização de portais | R$ 100+ |
+| Gestão financeira/cobrança | R$ 150+ |
+| SEO / marketing | R$ 200+ |
+| **Total avulso** | **≈ R$ 900–1.350/mês** |
+
+**No AgoraEncontrei Premium: R$ 297/mês.** → **Economia de R$ 600+ por mês** e
+tudo integrado. *Um único imóvel vendido a mais no ano paga anos de assinatura.*
+
+---
+
+## 8. Planos e justificativa de preço
+
+### Planos SaaS (sistema completo)
+| Plano | Preço | Para quem | Destaques |
+|-------|------:|-----------|-----------|
+| **Simples** | R$ 97/mês | Corretor autônomo | Site em 24h, 50 imóveis, WhatsApp, subdomínio |
+| **Premium** ⭐ | R$ 297/mês | Imobiliária em crescimento | **+ Tomás IA, CRM, SEO, tour, proposta, mapa, blog, analytics, 500 imóveis** |
+| **Super Premium** | R$ 597/mês | Quem quer dominar a região | + domínio próprio, white-label, vídeo, ROI Calculator, imóveis ilimitados, suporte prioritário |
+
+### Diretório de Especialistas (perfil público + ferramentas)
+| Plano | Preço | Inclui |
+|-------|------:|--------|
+| **Prime** | R$ 197/mês | Perfil verificado, topo das buscas, calculadora ROI, alertas, analytics |
+| **VIP** | R$ 497/mês | Tudo do Prime + sentinela territorial, relatório mensal em PDF, suporte prioritário |
+
+**Ancoragem:** apresente sempre o **Premium (R$ 297)** como o recomendado — é onde
+está a IA. O Simples vira "porta de entrada" e o Super Premium faz o Premium parecer barato.
+
+---
+
+## 9. Quebra de objeções
+
+| Objeção | Resposta de venda |
+|---------|-------------------|
+| *"Está caro."* | "Caro é pagar CRM + site + IA + financeiro separados (R$ 900+). Aqui é R$ 297 com tudo. Um imóvel a mais no ano já pagou." |
+| *"Já tenho um sistema."* | "Ótimo — qual deles atende seu lead às 22h e calcula ROI de leilão? Fazemos a migração pra você. Nenhum concorrente tem IA + leilões." |
+| *"Não confio em IA atendendo."* | "O Tomás qualifica e te entrega o lead quente — você assume quando quiser. Ele só garante que ninguém fica sem resposta." |
+| *"Sou autônomo, é demais pra mim."* | "Começa no Simples por R$ 97 ou no perfil Prime por R$ 197. Cresce quando quiser." |
+| *"E os portais (ZAP/VivaReal)?"* | "Sincroniza automático. Cadastra uma vez, aparece em todos." |
+| *"Vou ter trabalho pra montar."* | "Seu site fica no ar em 24h e a gente faz o onboarding com você." |
+| *"E se não gostar?"* | "Sem fidelidade. Você fica porque funciona, não porque está preso." |
+
+---
+
+## 10. Scripts de abordagem
+
+### WhatsApp (primeiro contato)
+> Olá, [nome]! Aqui é [seu nome], do AgoraEncontrei. Vi que você atua com imóveis
+> em [cidade/bairro]. Posso te mostrar em 5 min como ter um **vendedor com IA que
+> atende seus leads 24/7** + um **site profissional no ar em 24h**, por menos do
+> que você gasta hoje em ferramentas separadas? Quando fica bom uma demo rápida?
+
+### Ligação (abertura)
+> "[Nome], uma pergunta direta: quando um cliente te chama no WhatsApp às 22h, quem
+> responde? … Pois é. O AgoraEncontrei responde, qualifica e já manda o imóvel certo —
+> sozinho. Te mostro funcionando em 5 minutos?"
+
+### Demo (roteiro de 5 minutos)
+1. Mostre o **Tomás** atendendo um lead e mandando imóvel (efeito "uau").
+2. Mostre o **site no ar** + marketplace.
+3. Mostre a **calculadora de leilão** com ROI (diferencial).
+4. Mostre o **CRM/funil** com o lead já lá dentro.
+5. Feche com a **conta do item 7** (economia) e o plano Premium.
+
+### Sequência de follow-up
+- **D+0:** demo + proposta. → **D+1:** "Te mando o acesso de teste?" → **D+3:** caso de uso/prova social → **D+7:** oferta com bônus de implantação → **D+14:** última chamada.
+
+---
+
+## 11. Oferta irresistível (fechamento)
+
+Empacote para o "sim" imediato:
+- ✅ **Site no ar em 24h** + onboarding assistido (feito junto).
+- ✅ **Sem fidelidade** — cancela quando quiser.
+- ✅ **Migração assistida** do sistema atual.
+- ✅ **Tomás IA incluso** já no Premium.
+- 🎁 **Bônus de lançamento** (sugestão): 1º mês com desconto / setup grátis / X destaques no marketplace.
+
+> **Frase de fechamento:** "Você pode continuar pagando caro por ferramentas soltas
+> e perdendo lead às 22h… ou ter tudo num lugar, com um vendedor de IA trabalhando
+> por você, por R$ 297. Começamos hoje?"
+
+---
+
+## 12. Próximas peças (derivadas deste documento)
+- [ ] **Página de vendas pública** no site (visual, impressionante) — em produção.
+- [ ] **Pitch deck** (slides para reunião/WhatsApp) — em produção.
+- [ ] Reconfirmar dados de concorrentes e definir o bônus de lançamento oficial.
+
+_Última revisão: 2026-06._


### PR DESCRIPTION
## Resumo

Peça **1 de 3** do material de vendas: o **playbook mestre** (`docs/PLANO-DE-VENDAS.md`) — fonte de conteúdo da página pública e do pitch deck que virão a seguir.

**Conteúdo:**
- Posicionamento em uma frase + dores do cliente.
- **Inventário completo de ferramentas** (Tomás IA, site/marketplace, CRM, inteligência de leilões com ROI, marketing/SEO, IA visual/vídeo, portais, LemosBank/financeiro, automações/WhatsApp) — cada uma com o benefício de venda.
- **6 diferenciais** que ninguém junta.
- **Análise de concorrentes** (Jetimob, Vista/Kenlo, Tecimob, Imobzi, Universal/Superlógica, RD/HubSpot, Loft/QuintoAndar) + comparativo "nós vs eles".
- **Proposta de valor** (conta de economia: stack avulso ~R$900 vs R$297).
- **Planos e justificativa de preço** com **dados reais do sistema** (Simples R$97 / Premium R$297 / Super Premium R$597; diretório Prime R$197 / VIP R$497).
- **Quebra de objeções**, **scripts** (WhatsApp/ligação/demo/follow-up) e **oferta de fechamento**.

> ⚠️ Os números de concorrentes devem ser reconfirmados antes de uso público (anotado no doc).

## Próximas peças (em produção)
- [ ] Página de vendas pública no site
- [ ] Pitch deck (slides)

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_