### PR TITLE
feat(saas): expiração automática de trial

### DIFF
--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -1098,4 +1098,60 @@ export async function runScheduledJobs(app: FastifyInstance) {
   } catch (err) {
     app.log.error({ err }, '[scheduled] whatsapp-bot-nudge failed')
   }
+
+  // ── 13. Expiração de trial: tenants em TRIAL com trialEndsAt vencido ─────
+  // Sem este job, um trial nunca expira sozinho — o tenant fica usando o
+  // sistema de graça pra sempre. Suspende o Tenant + Company juntos (mesma
+  // transação) e registra auditoria. A reativação acontece no webhook de
+  // pagamento (PAYMENT_CONFIRMED volta pra ACTIVE).
+  try {
+    const expiredTrials = await app.prisma.tenant.findMany({
+      where: {
+        planStatus: 'TRIAL',
+        trialEndsAt: { not: null, lt: now },
+      },
+      select: { id: true, subdomain: true, companyId: true, settings: true },
+      orderBy: { trialEndsAt: 'asc' },
+      take: 200,
+    })
+
+    let suspended = 0
+    for (const tenant of expiredTrials) {
+      await app.prisma.$transaction(async (tx: any) => {
+        await tx.tenant.update({
+          where: { id: tenant.id },
+          data: {
+            planStatus: 'SUSPENDED',
+            isActive: false,
+            suspendedAt: now,
+            settings: { ...((tenant.settings as any) || {}), trialExpiredAt: now.toISOString() },
+          },
+        })
+        if (tenant.companyId) {
+          await tx.company.update({
+            where: { id: tenant.companyId },
+            data: { isActive: false },
+          }).catch(() => null)
+        }
+      })
+
+      await app.prisma.auditLog.create({
+        data: {
+          companyId: tenant.companyId || 'platform',
+          action: 'tenant.trial.expired' as any,
+          resource: 'tenant',
+          resourceId: tenant.id,
+          payload: { subdomain: tenant.subdomain, expiredAt: now.toISOString() } as any,
+        },
+      }).catch(() => {})
+
+      suspended++
+    }
+
+    if (suspended > 0) {
+      app.log.info(`[scheduled] trial-expiration: suspended ${suspended} expired trials`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] trial-expiration failed')
+  }
 }


### PR DESCRIPTION
## Resumo

**(A) Roadmap — expiração automática de trial.**

O `Tenant` tem `planStatus` (TRIAL/ACTIVE/…) e `trialEndsAt`, mas **não havia job** que expirasse o trial — um tenant em trial usava o sistema **de graça indefinidamente**.

Adiciona o **job #13** em `scheduled.jobs.ts` (que já roda a cada 30 min):
- Busca tenants `planStatus = 'TRIAL'` com `trialEndsAt < now` (limit 200, mais antigos primeiro).
- Suspende **Tenant + Company na mesma transação** (`planStatus='SUSPENDED'`, `isActive=false`, `suspendedAt`), grava `trialExpiredAt` no settings e registra **auditoria** (`tenant.trial.expired`).
- A **reativação** continua acontecendo no webhook de pagamento (`PAYMENT_CONFIRMED → ACTIVE`).

Segue exatamente o padrão dos outros 12 jobs do arquivo (try/catch isolado, `take` limitado, log condicional). Arquivo é `@ts-nocheck`.

## Verificação
- Não testável localmente (sem DB), mas é lógica auto-contida espelhando os jobs existentes e os campos usados pelo webhook de ativação.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_