### PR TITLE
feat(api): monitoramento de erros opcional via Sentry

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import Fastify from 'fastify'
 import { ZodError } from 'zod'
 import { env, logEnvWarnings } from './utils/env.js'
+import { initSentry, captureError } from './utils/sentry.js'
 
 // ── v2026.04.01 ────────────────────────────────────────────────────────────
 // ── Plugins ────────────────────────────────────────────────────────────────
@@ -686,6 +687,9 @@ async function runMigrations(prisma: any) {
 }
 
 async function bootstrap() {
+  // Monitoramento de erros — no-op se SENTRY_DSN ausente ou @sentry/node não instalado.
+  await initSentry(app)
+
   // ── Core Plugins ────────────────────────────────────────────────────────
   await app.register(corsPlugin)
   await app.register(helmetPlugin)
@@ -922,8 +926,9 @@ async function bootstrap() {
         message: error.message,
       })
     }
-    app.log.error(error)
     const statusCode = error?.statusCode ?? 500
+    if (statusCode >= 500) captureError(error)
+    app.log.error(error)
     reply.status(statusCode).send({
       error: error?.code ?? 'INTERNAL_ERROR',
       message: env.NODE_ENV === 'production' && statusCode === 500

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -95,6 +95,12 @@ const envSchema = z.object({
   VERCEL_TOKEN: z.string().optional(),
   VERCEL_PROJECT_ID: z.string().optional(),
 
+  // Sentry — monitoramento de erros (opcional). Só ativa quando esta DSN está
+  // setada E o pacote @sentry/node está instalado (carregado via dynamic
+  // import — ver utils/sentry.ts).
+  SENTRY_DSN: z.string().optional(),
+  SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
+
   // Clicksign — digital signatures
   CLICKSIGN_ACCESS_TOKEN: z.string().optional(),
   CLICKSIGN_BASE_URL: z.string().optional(),

--- a/apps/api/src/utils/sentry.ts
+++ b/apps/api/src/utils/sentry.ts
@@ -1,0 +1,51 @@
+/**
+ * Sentry — monitoramento de erros (opcional e tolerante a ausência).
+ *
+ * Projetado para NÃO ser um risco de deploy:
+ *  - O pacote `@sentry/node` é carregado por **dynamic import** dentro de
+ *    try/catch. Se ele não estiver instalado, o boot segue normal (no-op) —
+ *    nada de import estático que derrubaria o `node dist/server.js`.
+ *  - Só inicializa quando `SENTRY_DSN` está setada.
+ *
+ * Para ATIVAR em produção:
+ *   1) pnpm --filter @agoraencontrei/api add @sentry/node
+ *   2) setar SENTRY_DSN (e, opcional, SENTRY_TRACES_SAMPLE_RATE) no Railway
+ */
+
+import { env } from './env.js'
+
+let sentry: any = null
+
+export async function initSentry(app: { log: { info: (m: string) => void; warn: (m: string) => void } }) {
+  if (!env.SENTRY_DSN) return
+
+  try {
+    // @ts-ignore — dependência opcional; instalada sob demanda (ver doc acima).
+    const Sentry = await import('@sentry/node')
+    Sentry.init({
+      dsn: env.SENTRY_DSN,
+      environment: env.NODE_ENV,
+      tracesSampleRate: Number(env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1') || 0,
+    })
+    sentry = Sentry
+    app.log.info('[sentry] monitoramento de erros ativo')
+  } catch {
+    app.log.warn('[sentry] SENTRY_DSN setada, mas @sentry/node não está instalado — rode `pnpm --filter @agoraencontrei/api add @sentry/node`')
+  }
+}
+
+/** Envia uma exceção ao Sentry, se ativo. Nunca lança. */
+export function captureError(err: unknown, context?: Record<string, unknown>) {
+  if (!sentry) return
+  try {
+    if (context) sentry.captureException?.(err, { extra: context })
+    else sentry.captureException?.(err)
+  } catch {
+    /* monitoramento nunca pode derrubar o request */
+  }
+}
+
+/** Indica se o Sentry foi inicializado com sucesso. */
+export function isSentryActive(): boolean {
+  return sentry != null
+}


### PR DESCRIPTION
## Resumo

**(A) Roadmap — monitoramento de erros (Sentry).**

Integra o Sentry **sem risco de deploy**. O desafio: adicionar `@sentry/node` como dependência exigiria atualizar o `pnpm-lock.yaml`, e um lockfile inconsistente **derruba o build/deploy**.

A solução: o pacote é carregado por **dynamic import dentro de try/catch** (`utils/sentry.ts`). O app **builda e sobe normalmente mesmo sem o pacote instalado** (no-op). Ativa só quando `SENTRY_DSN` está setada **e** o pacote foi adicionado.

**Mudanças:**
- `env.ts`: `SENTRY_DSN` + `SENTRY_TRACES_SAMPLE_RATE` (opcionais).
- `utils/sentry.ts` (novo): `initSentry` (carregamento seguro) + `captureError`.
- `server.ts`: `initSentry(app)` no bootstrap + `captureError(error)` no error handler (apenas erros ≥ 500).

## Para ATIVAR em produção (1 vez)
```bash
pnpm --filter @agoraencontrei/api add @sentry/node
```
+ setar `SENTRY_DSN` (e opcional `SENTRY_TRACES_SAMPLE_RATE`) no Railway.

> Optei por **não** mexer no `pnpm-lock.yaml` neste PR justamente para não arriscar o deploy — a ativação fica como um passo único e deliberado, quando você quiser ligar.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_