### PR TITLE
test: roteiro de QA E2E + script de smoke-test

### DIFF
--- a/docs/QA-E2E.md
+++ b/docs/QA-E2E.md
@@ -1,0 +1,75 @@
+# ✅ Roteiro de Teste Ponta a Ponta (E2E) — AgoraEncontrei
+
+> Checklist para conferir **tudo** que foi entregue, após promover a produção.
+> Marque cada item. O `scripts/smoke-e2e.sh` automatiza a parte pública (rode-o
+> primeiro). Cada seção referencia o PR que entregou a feature.
+
+**Pré-requisito:** produção promovida na Vercel + segredos no Railway + webhooks
+no Asaas + SQL do enum no Neon (ver `docs/GO-LIVE.md`).
+
+```bash
+# Smoke automático primeiro:
+WEB_URL=https://www.agoraencontrei.com.br \
+API_URL=https://api.agoraencontrei.com.br \
+./scripts/smoke-e2e.sh
+```
+
+---
+
+## A. Vitrine pública  *(PR #160)*
+- [ ] `/` carrega com a **home reordenada** (Leilões → Quiz → Parceiro; badge "Mais de 25 anos…").
+- [ ] Sem `<meta keywords>` gigante no `<head>` (View Source).
+- [ ] `/imoveis`, `/leiloes`, `/avaliacao`, `/anunciar` abrem (200).
+- [ ] `/politica-privacidade`, `/termos-uso`, `/contato`, `/sobre` abrem.
+- [ ] Banner de cookies aparece; GA/Pixel só disparam após consentimento (DevTools → Network).
+
+## B. Material de vendas  *(PRs #166–#169)*
+- [ ] **Navbar** mostra **"💼 Para Imobiliárias"** (desktop e mobile) → leva a `/sistema`.
+- [ ] `/sistema`: hero, **banner "Oferta de Fundador"**, 9 ferramentas (só **Leilões** com selo EXCLUSIVO — Tomás **não**), comparativo, conta de economia, planos reais (R$97/297/597), FAQ, CTA.
+- [ ] `/pitch`: 9 slides em scroll-snap; slide do Tomás diz "Seu plantão nunca dorme" (não "exclusivo"); slide de leilões diz "Ninguém mais tem".
+- [ ] Docs revisados: `PLANO-DE-VENDAS.md` e `ANALISE-CONCORRENTES.md` coerentes (leilões = diferencial nº 1).
+
+## C. Leilões — performance + mapa  *(PRs #165, #171)*
+- [ ] `/leiloes` carrega a lista **rápido** (não trava ~12s esperando feeds).
+- [ ] Logo após o hero aparece o **mapa por região** (satélite, com pins).
+- [ ] Pins de leilão aparecem **espalhados por bairro** (após o job de geocodificação rodar algumas vezes — ver seção H).
+- [ ] Filtros, botão 💎 Pérola, calculadora de ROI e criação de alerta funcionam.
+
+## D. Onboarding  *(PRs #162, #163)*
+- [ ] Registrar nova conta → verificar e-mail → **cai em `/dashboard`** (não em cadastro de especialista).
+- [ ] No dashboard aparece o **checklist "Primeiros passos"** (4 passos; dispensável; some quando concluído).
+- [ ] Cadastro de especialista como **Imobiliária** ou **Loteadora** **não dá mais 400** *(requer o SQL do enum aplicado no Neon)*.
+
+## E. Fluxo de assinatura (pagamento) — o mais crítico  *(PRs #161, #162)*
+- [ ] `/parceiros/planos` mostra a **landing de planos** (não redireciona p/ cadastro).
+- [ ] Escolher plano → checkout → gera cobrança Asaas (PIX/boleto/cartão).
+- [ ] Pagar (sandbox) → **webhook ativa o tenant** → credenciais chegam por **e-mail/WhatsApp**.
+- [ ] **Não há mais "sucesso falso"**: se o Asaas não estiver configurado, o checkout mostra erro honesto (não tela de sucesso).
+- [ ] Login com as credenciais → acessa o dashboard.
+- [ ] `{subdomínio}.agoraencontrei.com.br` → site do cliente no ar.
+
+## F. SaaS / Tenant  *(PRs #170, #172)*
+- [ ] **Domínio próprio:** `POST /api/v1/tenants/:id/domain` (como dono ou SUPER_ADMIN) registra na Vercel e retorna instruções de DNS *(requer `VERCEL_TOKEN`/`VERCEL_PROJECT_ID`)*.
+- [ ] **Permissão:** o mesmo endpoint com usuário **de outro tenant** → **403**.
+- [ ] **Expiração de trial:** um tenant com `planStatus=TRIAL` e `trialEndsAt` no passado é **suspenso** automaticamente (após o job rodar) → `planStatus=SUSPENDED`, site fora do ar.
+- [ ] Pagar reativa o tenant (webhook → `ACTIVE`).
+
+## G. Segurança  *(PRs #161, #172, #173)*
+- [ ] **Webhook fail-closed:** `POST /api/v1/webhooks/asaas` **sem** o header `asaas-access-token` → **401** (com `ASAAS_WEBHOOK_SECRET` setado). *(O smoke-test verifica isso.)*
+- [ ] **Idempotência:** reenviar o mesmo evento de pagamento não ativa/credita duas vezes.
+- [ ] **Sentry (opcional):** após `pnpm --filter @agoraencontrei/api add @sentry/node` + `SENTRY_DSN`, um erro 500 aparece no painel do Sentry. Sem isso, o app funciona normal (no-op).
+
+## H. Jobs agendados (backend)  *(PRs #170, #171)*
+> Rodam a cada ~30 min via `scheduled.jobs.ts`. Confira nos **logs do Railway**:
+- [ ] `[scheduled] trial-expiration: suspended N expired trials` (quando houver trials vencidos).
+- [ ] `[scheduled] auction-geocode-bairro: geocoded N/M auctions` (backfill das coordenadas dos leilões).
+- [ ] Demais jobs sem erro (boleto, follow-ups, lembretes de visita, etc.).
+
+---
+
+## Como reportar um problema
+Para cada ✗, anote: **passo**, **o que esperava**, **o que veio** (status/print) e a
+**URL/rota**. Se for backend, inclua o trecho de log do Railway. Assim eu corrijo
+direcionado, sem precisar reproduzir do zero.
+
+_Última revisão: 2026-06._

--- a/scripts/smoke-e2e.sh
+++ b/scripts/smoke-e2e.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Smoke E2E — verifica rapidamente as superfícies públicas após um deploy.
+# Não substitui o roteiro manual (docs/QA-E2E.md) — é o "está tudo de pé?".
+#
+# Uso:
+#   WEB_URL=https://www.agoraencontrei.com.br \
+#   API_URL=https://api.agoraencontrei.com.br \
+#   ./scripts/smoke-e2e.sh
+#
+# Sai com código != 0 se qualquer verificação CRÍTICA falhar (bom para CI).
+set -u
+
+WEB_URL="${WEB_URL:-https://www.agoraencontrei.com.br}"
+API_URL="${API_URL:-https://api.agoraencontrei.com.br}"
+TIMEOUT="${TIMEOUT:-25}"
+
+pass=0; fail=0; warn=0
+TMP="$(mktemp)"; trap 'rm -f "$TMP"' EXIT
+
+# check <nome> <url> <status_esperado> [grep_opcional] [critico=1]
+check() {
+  local name="$1" url="$2" expect="$3" needle="${4:-}" critical="${5:-1}"
+  local status
+  status="$(curl -sS -m "$TIMEOUT" -o "$TMP" -w '%{http_code}' "$url" 2>/dev/null || echo 000)"
+  local ok=1
+  [ "$status" = "$expect" ] || ok=0
+  if [ "$ok" = 1 ] && [ -n "$needle" ]; then grep -qi -- "$needle" "$TMP" || ok=0; fi
+  if [ "$ok" = 1 ]; then
+    printf '  ✓ %-34s %s\n' "$name" "($status)"; pass=$((pass+1))
+  elif [ "$critical" = 1 ]; then
+    printf '  ✗ %-34s esperado %s, veio %s%s\n' "$name" "$expect" "$status" "${needle:+ (faltou \"$needle\")}"; fail=$((fail+1))
+  else
+    printf '  ⚠ %-34s esperado %s, veio %s (não-crítico)\n' "$name" "$expect" "$status"; warn=$((warn+1))
+  fi
+}
+
+# check_post <nome> <url> <status_esperado> <json> [critico=1]
+check_post() {
+  local name="$1" url="$2" expect="$3" data="$4" critical="${5:-1}"
+  local status
+  status="$(curl -sS -m "$TIMEOUT" -o /dev/null -w '%{http_code}' \
+    -X POST "$url" -H 'Content-Type: application/json' -d "$data" 2>/dev/null || echo 000)"
+  if [ "$status" = "$expect" ]; then
+    printf '  ✓ %-34s %s\n' "$name" "($status)"; pass=$((pass+1))
+  elif [ "$critical" = 1 ]; then
+    printf '  ✗ %-34s esperado %s, veio %s\n' "$name" "$expect" "$status"; fail=$((fail+1))
+  else
+    printf '  ⚠ %-34s esperado %s, veio %s (não-crítico)\n' "$name" "$expect" "$status"; warn=$((warn+1))
+  fi
+}
+
+echo "🌐 Vitrine pública — $WEB_URL"
+check "home"                  "$WEB_URL/"                       200
+check "/imoveis"              "$WEB_URL/imoveis"                200
+check "/leiloes"             "$WEB_URL/leiloes"                200
+check "/sistema (vendas)"     "$WEB_URL/sistema"                200 "Fundador"   0
+check "/pitch (deck)"         "$WEB_URL/pitch"                  200             0
+check "/parceiros/planos"     "$WEB_URL/parceiros/planos"       200
+check "/seja-parceiro"        "$WEB_URL/seja-parceiro"          200
+check "/politica-privacidade" "$WEB_URL/politica-privacidade"   200
+check "/termos-uso"           "$WEB_URL/termos-uso"             200
+check "/contato"              "$WEB_URL/contato"                200
+
+echo ""
+echo "🔌 API — $API_URL"
+check "health"                "$API_URL/health"                 200             "" 0
+check "auctions (lista)"      "$API_URL/api/v1/auctions"        200
+check "auctions/map (pins)"   "$API_URL/api/v1/auctions/map"    200             "" 0
+check "auctions/stats"        "$API_URL/api/v1/auctions/stats"  200             "" 0
+
+echo ""
+echo "🔒 Segurança"
+# Webhook SaaS sem o header asaas-access-token DEVE recusar (401) quando o
+# ASAAS_WEBHOOK_SECRET está setado em produção (fail-closed). 200 aqui = alerta.
+check_post "webhook SaaS sem segredo → 401" "$API_URL/api/v1/webhooks/asaas" 401 \
+  '{"event":"PAYMENT_CONFIRMED","payment":{"id":"smoke-test"}}' 0
+
+echo ""
+echo "──────────────────────────────────────────────"
+echo "Resultado: ✓ $pass   ✗ $fail   ⚠ $warn"
+[ "$fail" -eq 0 ] && echo "✅ Smoke OK (verificações críticas passaram)" || echo "❌ Smoke FALHOU — revise os ✗ acima"
+exit "$fail"


### PR DESCRIPTION
## Resumo

Prepara o terreno para **testarmos tudo de ponta a ponta** depois do deploy.

**Entrega:**
- **`docs/QA-E2E.md`** — checklist E2E cobrindo **todas** as features entregues nesta jornada, organizado por área e **mapeado por PR**: vitrine pública, material de vendas, leilões (perf + mapa/scatter), onboarding, fluxo de assinatura/pagamento, SaaS/tenant (domínio + trial), segurança (webhook fail-closed, auth de domínio, Sentry) e jobs agendados.
- **`scripts/smoke-e2e.sh`** — smoke-test automático das superfícies públicas (web + API), incluindo a verificação do **webhook fail-closed (espera 401 sem segredo)**. Configurável por `WEB_URL`/`API_URL`; sai com código ≠ 0 se algo crítico falhar (serve em CI). Sintaxe validada (`bash -n`).

```bash
WEB_URL=https://www.agoraencontrei.com.br \
API_URL=https://api.agoraencontrei.com.br \
./scripts/smoke-e2e.sh
```

## Fluxo sugerido para o teste
1. Promover produção + setar segredos/SQL (`docs/GO-LIVE.md`).
2. Rodar `scripts/smoke-e2e.sh` (pega o que está de pé).
3. Seguir o `docs/QA-E2E.md` manualmente para os fluxos com login/pagamento.
4. Me mandar os ✗ com passo/esperado/veio — corrijo direcionado.

Doc + script apenas — não altera o app.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_