### PR TITLE
fix(leilões): mapa da página de leilões mostra só leilões

### DIFF
--- a/apps/web/src/app/(public)/imoveis/MapSearch.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearch.tsx
@@ -121,6 +121,7 @@ interface Props {
   initialMaxPrice?: string
   initialBedrooms?: string
   initialClusters?: Cluster[] // SSR pre-fetched clusters for immediate display
+  auctionsOnly?: boolean // quando true, mostra só pins de leilão (esconde imóveis da plataforma)
 }
 
 // Nominatim cache in module scope
@@ -147,7 +148,7 @@ async function geocodeNeighborhood(neighborhood: string, city: string): Promise<
   return null
 }
 
-export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters }: Props) {
+export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters, auctionsOnly }: Props) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstance = useRef<MapLibreMap | null>(null)
   const markersRef = useRef<MapLibreMarker[]>([])
@@ -251,6 +252,8 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
 
   // Load clusters from API
   useEffect(() => {
+    // Modo "só leilões" (página de leilões): não carrega imóveis da plataforma.
+    if (auctionsOnly) return
     async function loadClusters(bbox?: { swLat: number; swLng: number; neLat: number; neLng: number }) {
       try {
         const params = new URLSearchParams()
@@ -314,6 +317,8 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
   }, [initialPurpose]) // eslint-disable-line react-hooks/exhaustive-deps
   // Load owner-direct (green pins) properties from free-listing endpoint
   useEffect(() => {
+    // Modo "só leilões": não mostra os pins verdes de imóveis dos proprietários.
+    if (auctionsOnly) return
     fetch(`${API_URL}/api/v1/public/free-listing/map-pins`)
       .then(r => r.ok ? r.json() : [])
       .then((data: OwnerDirectPin[]) => setOwnerDirectPins(Array.isArray(data) ? data : []))
@@ -1046,6 +1051,8 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
 
         {/* Layer Toggles */}
         <div className="ml-auto flex items-center gap-1.5 pointer-events-auto">
+          {/* Toggle de imóveis à venda — escondido no modo só-leilões */}
+          {!auctionsOnly && (
           <button
             onClick={() => setShowSaleLayer(v => !v)}
             className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold shadow-lg transition-all ${
@@ -1057,6 +1064,7 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
             <span className={`w-2.5 h-2.5 rounded-full ${showSaleLayer ? 'bg-blue-400' : 'bg-gray-300'}`} />
             🏠 Venda
           </button>
+          )}
           <button
             onClick={() => setShowAuctionLayer(v => !v)}
             className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold shadow-lg transition-all ${

--- a/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
@@ -8,6 +8,7 @@ interface Props {
   initialMaxPrice?: string
   initialBedrooms?: string
   initialClusters?: any[]
+  auctionsOnly?: boolean
 }
 
 export default function MapSearchWrapper(props: Props) {

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -700,17 +700,17 @@ export default function LeiloesClient() {
         </div>
       </section>
 
-      {/* MAPA POR REGIÃO — satélite, com leilões e imóveis por bairro */}
+      {/* MAPA POR REGIÃO — satélite, só com os leilões (sem imóveis da plataforma) */}
       <section className="max-w-7xl mx-auto px-4 pt-6">
         <div className="mb-3">
           <h2 className="text-xl font-bold text-[#1B2B5B]" style={{ fontFamily: 'Georgia, serif' }}>
-            Mapa de oportunidades por região
+            Mapa de leilões por região
           </h2>
           <p className="text-sm text-gray-500">
-            Explore leilões e imóveis no mapa via satélite — navegue por bairro antes de ver a lista abaixo.
+            Explore os leilões no mapa via satélite — navegue por bairro antes de ver a lista abaixo.
           </p>
         </div>
-        <LeiloesMapa />
+        <LeiloesMapa auctionsOnly />
       </section>
 
       {/* Toolbar */}


### PR DESCRIPTION
## Resumo

Corrige o mapa da **página de leilões** para mostrar **apenas os leilões**, não os imóveis comuns anunciados na plataforma. O mapa da home/`/imoveis` continua mostrando **todos** os imóveis.

## O que mudou
Adiciona a prop **`auctionsOnly`** ao `MapSearch`. Quando ativa:
- **Desliga** o carregamento de imóveis da plataforma: clusters azuis (`/api/v1/public/map-clusters`) e pins verdes de proprietários (`/api/v1/public/free-listing/map-pins`).
- **Esconde** o toggle de camada "🏠 Venda" (que controlaria pins que não existem).
- **Mantém** os pins de leilão (`/api/v1/auctions/map`).

A flag é propagada por `MapSearchWrapper` e ativada no embed da `LeiloesClient` (`<LeiloesMapa auctionsOnly />`). O `/imoveis?view=map` **não** passa a flag → segue mostrando tudo (imóveis + leilões), inalterado.

## Verificação
- Build validado pelo **preview da Vercel** deste PR. (Não dá pra testar o render do mapa daqui, mas a mudança é só gatear fetches/UI por uma flag; o caminho dos leilões é o mesmo já em produção.)

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_