### PR TITLE
fix(security): webhook de especialistas — fail-closed + recupera externalReference

### DIFF
--- a/apps/api/src/routes/specialists/payments.ts
+++ b/apps/api/src/routes/specialists/payments.ts
@@ -9,6 +9,7 @@ import type { FastifyInstance } from 'fastify'
 import { prisma } from '../../lib/prisma.js'
 import { env } from '../../utils/env.js'
 import { findOrCreateCustomer } from '../../services/asaas.service.js'
+import { safeStringEqual } from '../../utils/crypto-safe.js'
 
 const ASAAS_BASE_URL = env.ASAAS_BASE_URL ?? 'https://www.asaas.com/api/v3'
 const ASAAS_API_KEY  = env.ASAAS_API_KEY  ?? ''
@@ -233,6 +234,15 @@ export async function specialistPaymentRoutes(app: FastifyInstance) {
   app.post('/webhook', {
     config: { rawBody: true },
   }, async (req, reply) => {
+    // Fail-closed: valida o segredo do Asaas (mesmo padrão do webhook SaaS).
+    // Sem isso, qualquer um poderia POSTar aqui e ativar um plano de
+    // especialista sem ter pago.
+    const webhookToken = (req.headers['asaas-access-token'] as string) || ''
+    if (env.ASAAS_WEBHOOK_SECRET && !safeStringEqual(webhookToken, env.ASAAS_WEBHOOK_SECRET)) {
+      app.log.warn('[specialist-webhook] token inválido — recusado')
+      return reply.status(401).send({ error: 'UNAUTHORIZED' })
+    }
+
     const event = req.body as {
       event: string
       payment?: { externalReference?: string; status?: string; subscription?: string }


### PR DESCRIPTION
## Resumo

Duas correções no webhook de pagamentos de **especialistas** (`POST /api/v1/specialists/payments/webhook`), incorporando a parte útil e limpa do antigo PR #92:

### 1. Fail-closed (segurança)
O endpoint **não validava** o segredo do Asaas — qualquer um poderia forjar um POST e **ativar um plano PRIME/VIP sem pagar** (ou cancelar planos de terceiros). Agora rejeita **401** quando `ASAAS_WEBHOOK_SECRET` está setado e o header `asaas-access-token` não confere (comparação em tempo constante via `safeStringEqual`). Mesmo padrão do webhook SaaS (#161).

### 2. Recupera `externalReference` via `subscriptionId` (correção de plano errado)
Eventos `PAYMENT_*` do Asaas às vezes chegam **só com `subscriptionId`**, sem `externalReference`. O código antigo então defaultava para **PRIME** — ativando o plano errado para um assinante **VIP**. Agora:
- Consulta a assinatura no Asaas (`GET /subscriptions/{id}`) para recuperar a referência `specialist:{id}:{plano}`.
- O fallback no banco passa a usar o **plano atual** do especialista, em vez de PRIME.

> Substitui a necessidade de mergear o #92 inteiro (que reintroduz scraper antigo + SEO já superada). Resta avaliar à parte só o fallback CSV da Caixa do #92 — ver `docs/DEPENDENCIAS.md` (#177).

## Verificação
- Não testável aqui (sem runtime Asaas), mas espelha o padrão do #161 e o `scripts/smoke-e2e.sh` valida o fail-closed (POST sem segredo → 401) após o deploy.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw