### PR TITLE
feat(security): token de 1º acesso (substitui senha em texto puro)

### DIFF
--- a/apps/api/src/routes/auth/first-access.ts
+++ b/apps/api/src/routes/auth/first-access.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { randomBytes } from 'node:crypto'
+import argon2 from 'argon2'
+
+/**
+ * Fluxo de definição de senha por token (1º acesso / esqueci a senha),
+ * reusando o model PasswordReset — sem migração nova.
+ *
+ * Substitui o envio de senha em texto puro por e-mail/WhatsApp: agora o
+ * parceiro recebe um link com token e define a própria senha.
+ */
+
+/** Cria um token de definição de senha e retorna o token cru (vai no link). */
+export async function createPasswordSetupToken(prisma: any, email: string, ttlDays = 7): Promise<string> {
+  const token = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000)
+  await prisma.passwordReset.create({
+    data: { email: email.toLowerCase().trim(), token, expiresAt },
+  })
+  return token
+}
+
+export default async function firstAccessRoutes(app: FastifyInstance) {
+  // GET /definir-senha/validar?token= — valida o token (para a UX do frontend)
+  app.get('/definir-senha/validar', {
+    schema: { tags: ['auth'], summary: 'Valida um token de definição de senha' },
+  }, async (req, reply) => {
+    const token = String((req.query as any)?.token ?? '')
+    if (!token) return reply.send({ valid: false })
+    const pr = await app.prisma.passwordReset.findUnique({ where: { token } }).catch(() => null)
+    if (!pr || pr.usedAt || pr.expiresAt < new Date()) return reply.send({ valid: false })
+    return reply.send({ valid: true, email: pr.email })
+  })
+
+  // POST /definir-senha { token, password } — define a senha e queima o token
+  app.post('/definir-senha', {
+    schema: { tags: ['auth'], summary: 'Define a senha via token de 1º acesso' },
+  }, async (req, reply) => {
+    const body = z.object({
+      token: z.string().min(16),
+      password: z.string().min(8, 'A senha deve ter ao menos 8 caracteres'),
+    }).parse(req.body)
+
+    const pr = await app.prisma.passwordReset.findUnique({ where: { token: body.token } }).catch(() => null)
+    if (!pr || pr.usedAt || pr.expiresAt < new Date()) {
+      return reply.status(400).send({ error: 'TOKEN_INVALIDO', message: 'Link inválido ou expirado. Solicite um novo.' })
+    }
+
+    const user = await app.prisma.user.findFirst({ where: { email: pr.email } })
+    if (!user) return reply.status(404).send({ error: 'USER_NOT_FOUND', message: 'Usuário não encontrado.' })
+
+    const passwordHash = await argon2.hash(body.password, { type: argon2.argon2id })
+
+    // Define a senha, queima o token e derruba sessões antigas (refresh tokens).
+    await app.prisma.$transaction([
+      app.prisma.user.update({ where: { id: user.id }, data: { passwordHash } }),
+      app.prisma.passwordReset.update({ where: { id: pr.id }, data: { usedAt: new Date() } }),
+      app.prisma.refreshToken.deleteMany({ where: { userId: user.id } }),
+    ])
+
+    return reply.send({ success: true })
+  })
+}

--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -20,6 +20,7 @@ import type { FastifyInstance } from 'fastify'
 import { env } from '../../utils/env.js'
 import type { AsaasWebhookEvent } from '../../services/asaas.service.js'
 import { safeStringEqual } from '../../utils/crypto-safe.js'
+import { createPasswordSetupToken } from '../auth/first-access.js'
 
 export default async function saasWebhookRoutes(app: FastifyInstance) {
   const prisma = app.prisma as any
@@ -211,7 +212,14 @@ async function handleTenantEvent(
       // Envia credenciais ao parceiro (e-mail + WhatsApp em paralelo).
       // Tudo feito em try/catch independentes pra um canal falhar sem
       // travar a ativação.
-      if (tempPasswordPlain && customerEmail) {
+      if (customerEmail) {
+        // Em vez de enviar a senha em texto puro, geramos um token de 1º acesso
+        // e mandamos um link para o parceiro definir a própria senha.
+        const setupToken = await createPasswordSetupToken(prisma, customerEmail).catch(() => null)
+        const setupLink = setupToken
+          ? `https://agoraencontrei.com.br/primeiro-acesso?token=${setupToken}`
+          : 'https://agoraencontrei.com.br/login'
+
         try {
           const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
           if (isEmailConfigured()) {
@@ -225,10 +233,12 @@ async function handleTenantEvent(
                   <p style="margin:0 0 12px"><a href="https://agoraencontrei.com.br/login" style="color:#C9A84C">https://agoraencontrei.com.br/login</a></p>
                   <p style="margin:0 0 8px"><strong>Seu site:</strong></p>
                   <p style="margin:0 0 12px"><a href="${siteUrl}" style="color:#C9A84C">${siteUrl}</a></p>
-                  <p style="margin:0 0 8px"><strong>E-mail:</strong> ${customerEmail}</p>
-                  <p style="margin:0"><strong>Senha temporária:</strong> <code style="background:#f1f5f9;padding:2px 6px;border-radius:4px">${tempPasswordPlain}</code></p>
+                  <p style="margin:0 0 12px"><strong>E-mail:</strong> ${customerEmail}</p>
+                  <div style="text-align:center;margin:8px 0 4px">
+                    <a href="${setupLink}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:700;padding:12px 24px;border-radius:10px;text-decoration:none">Definir minha senha →</a>
+                  </div>
                 </div>
-                <p style="margin:16px 0;color:#475569">No primeiro acesso troque a senha em <em>Perfil → Segurança</em>.</p>
+                <p style="margin:16px 0;color:#475569">Clique no botão acima para criar sua senha de acesso. O link expira em 7 dias.</p>
                 <p style="margin:24px 0 0;font-size:13px;color:#64748b">Qualquer dúvida, responda este e-mail.</p>
               </div>`
             await sendEmail({
@@ -256,9 +266,9 @@ async function handleTenantEvent(
                 `🎉 *AgoraEncontrei — Pagamento confirmado!*\n\n` +
                 `Seu site está no ar:\n${siteUrl}\n\n` +
                 `*Acesso ao painel:*\nhttps://agoraencontrei.com.br/login\n\n` +
-                `*E-mail:* ${customerEmail}\n` +
-                `*Senha temporária:* ${tempPasswordPlain}\n\n` +
-                `Troque a senha no primeiro acesso (Perfil → Segurança).`
+                `*E-mail:* ${customerEmail}\n\n` +
+                `*Defina sua senha de acesso:*\n${setupLink}\n\n` +
+                `(o link expira em 7 dias)`
               await fetch(`https://graph.facebook.com/v19.0/${WHATSAPP_PHONE_ID}/messages`, {
                 method: 'POST',
                 headers: {
@@ -281,7 +291,7 @@ async function handleTenantEvent(
           }
         }
       } else {
-        app.log.warn(`[saas-webhook] Tenant ${subdomain} sem tempPasswordPlain — credenciais NÃO enviadas (provavelmente checkout antigo)`)
+        app.log.warn(`[saas-webhook] Tenant ${subdomain} sem customerEmail — link de 1º acesso NÃO enviado`)
       }
 
       app.log.info(`[saas-webhook] Tenant ${subdomain} ACTIVATED (plan: ${tenant.plan})`)

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -20,6 +20,7 @@ import compress from '@fastify/compress'
 // ── Routes ─────────────────────────────────────────────────────────────────
 import healthRoutes from './routes/health.js'
 import authRoutes from './routes/auth/index.js'
+import firstAccessRoutes from './routes/auth/first-access.js'
 import usersRoutes from './routes/users/index.js'
 import propertiesRoutes from './routes/properties/index.js'
 import leadsRoutes from './routes/leads/index.js'
@@ -723,6 +724,7 @@ async function bootstrap() {
   // ── Routes ──────────────────────────────────────────────────────────────
   await app.register(healthRoutes, { prefix: '/health' })
   await app.register(authRoutes,   { prefix: '/api/v1/auth' })
+  await app.register(firstAccessRoutes, { prefix: '/api/v1/auth' })
   await app.register(usersRoutes,  { prefix: '/api/v1/users' })
   await app.register(propertiesRoutes, { prefix: '/api/v1/properties' })
   await app.register(leadsRoutes,  { prefix: '/api/v1/leads' })

--- a/apps/web/src/app/(public)/primeiro-acesso/page.tsx
+++ b/apps/web/src/app/(public)/primeiro-acesso/page.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+const NAVY = '#1B2B5B'
+const GOLD = '#C9A84C'
+
+function PrimeiroAcessoInner() {
+  const params = useSearchParams()
+  const router = useRouter()
+  const token = params.get('token') ?? ''
+
+  const [checking, setChecking] = useState(true)
+  const [valid, setValid] = useState(false)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    if (!token) { setChecking(false); setValid(false); return }
+    fetch(`${API_URL}/api/v1/auth/definir-senha/validar?token=${encodeURIComponent(token)}`)
+      .then(r => r.ok ? r.json() : { valid: false })
+      .then(d => { setValid(!!d.valid); setEmail(d.email ?? '') })
+      .catch(() => setValid(false))
+      .finally(() => setChecking(false))
+  }, [token])
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (password.length < 8) { setError('A senha deve ter ao menos 8 caracteres.'); return }
+    if (password !== confirm) { setError('As senhas não conferem.'); return }
+    setSubmitting(true)
+    try {
+      const res = await fetch(`${API_URL}/api/v1/auth/definir-senha`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setError(data?.message ?? 'Não foi possível definir a senha. Tente novamente.')
+        return
+      }
+      setDone(true)
+      setTimeout(() => router.push('/login'), 2200)
+    } catch {
+      setError('Erro de conexão. Tente novamente.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const card = 'w-full max-w-md rounded-2xl bg-white p-8 shadow-xl'
+
+  return (
+    <div className="flex min-h-[80dvh] items-center justify-center px-4 py-12" style={{ backgroundColor: '#f8f6f1' }}>
+      {checking ? (
+        <div className={card}><p className="text-center text-gray-500">Validando seu link…</p></div>
+      ) : done ? (
+        <div className={card}>
+          <h1 className="mb-2 text-xl font-bold" style={{ color: NAVY }}>Senha criada! ✅</h1>
+          <p className="text-gray-600">Tudo certo. Redirecionando para o login…</p>
+        </div>
+      ) : !valid ? (
+        <div className={card}>
+          <h1 className="mb-2 text-xl font-bold" style={{ color: NAVY }}>Link inválido ou expirado</h1>
+          <p className="mb-5 text-gray-600">
+            Este link de primeiro acesso não é mais válido (pode já ter sido usado ou expirado).
+          </p>
+          <Link href="/login" className="font-semibold underline" style={{ color: NAVY }}>
+            Ir para o login
+          </Link>
+        </div>
+      ) : (
+        <form onSubmit={submit} className={card}>
+          <h1 className="mb-1 text-2xl font-bold" style={{ color: NAVY, fontFamily: 'Georgia, serif' }}>
+            Defina sua senha
+          </h1>
+          <p className="mb-6 text-sm text-gray-500">
+            {email ? <>Conta: <strong>{email}</strong></> : 'Crie a senha de acesso ao seu painel.'}
+          </p>
+
+          <label className="mb-1 block text-sm font-medium text-gray-700">Nova senha</label>
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            autoComplete="new-password"
+            className="mb-4 w-full rounded-xl border border-gray-300 px-4 py-3 outline-none focus:border-[#C9A84C]"
+            style={{ fontSize: '16px' }}
+            placeholder="Mínimo 8 caracteres"
+          />
+
+          <label className="mb-1 block text-sm font-medium text-gray-700">Confirmar senha</label>
+          <input
+            type="password"
+            value={confirm}
+            onChange={e => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            className="mb-5 w-full rounded-xl border border-gray-300 px-4 py-3 outline-none focus:border-[#C9A84C]"
+            style={{ fontSize: '16px' }}
+            placeholder="Repita a senha"
+          />
+
+          {error && <p className="mb-4 text-sm font-medium text-red-600">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-xl py-3 font-bold text-black transition hover:opacity-90 disabled:opacity-60"
+            style={{ backgroundColor: GOLD }}
+          >
+            {submitting ? 'Salvando…' : 'Criar senha e acessar'}
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}
+
+export default function PrimeiroAcessoPage() {
+  return (
+    <Suspense fallback={<div className="min-h-[80dvh]" />}>
+      <PrimeiroAcessoInner />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
## Resumo

**(3/3)** Substitui o envio de **senha em texto puro** (por e-mail/WhatsApp) por um **token de 1º acesso** — o parceiro recebe um link e define a própria senha. Reusa o model `PasswordReset` existente, **sem migração**.

### Mudanças
- **`routes/auth/first-access.ts`** (novo): `GET /api/v1/auth/definir-senha/validar?token=` + `POST /api/v1/auth/definir-senha` (`{token, password}` → argon2, queima o token, derruba refresh tokens) + helper `createPasswordSetupToken()`.
- **`server.ts`**: registra a rota sob `/api/v1/auth`.
- **`saas-webhook.ts`**: no e-mail e no WhatsApp de ativação, troca a "senha temporária" por um botão/link **`/primeiro-acesso?token=…`** (expira em 7 dias). O plaintext deixa de ser transmitido (e o `delete settings.tempPasswordPlain` já o removia do banco).
- **web `/primeiro-acesso`**: página que valida o token e define a senha (inputs 16px p/ iOS).

Bônus: o mesmo fluxo serve de **"esqueci minha senha"**.

## ⚠️ Requer teste E2E
Isto toca o **onboarding pago** e **auth** — pontos críticos que não dá pra testar daqui. **Validar no QA E2E** (criar tenant → pagar sandbox → receber link → definir senha → login) **antes de confiar no fluxo real**. Foi feito de forma aditiva e reversível (a rota nova não afeta os fluxos existentes; o webhook pode voltar ao plaintext se necessário).

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_