### PR TITLE
refactor(planos): unifica nomes na fonte única (DB) + documenta

### DIFF
--- a/apps/api/src/services/bootstrap-plans.ts
+++ b/apps/api/src/services/bootstrap-plans.ts
@@ -34,7 +34,7 @@ interface PlanSeed {
 const DEFAULT_PLANS: PlanSeed[] = [
   {
     slug: 'lite',
-    name: 'Lite',
+    name: 'Simples',
     description: 'Site profissional + CRM básico para começar a vender online.',
     priceMonthly: 97,
     priceYearly: 970, // ~2 meses grátis
@@ -56,7 +56,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
   },
   {
     slug: 'pro',
-    name: 'Pro',
+    name: 'Premium',
     description: 'Para corretores e imobiliárias que querem escalar com IA e automação.',
     priceMonthly: 297,
     priceYearly: 2970, // ~2 meses grátis
@@ -67,7 +67,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
     themes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro', 'signature_estate'],
     modules: ['site_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes'],
     features: [
-      'Tudo do Lite',
+      'Tudo do Simples',
       'Até 200 imóveis publicados',
       'CRM avançado (deals, pipeline, automações)',
       'Tomás IA — 1000 conversas/mês + voz',
@@ -81,7 +81,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
   },
   {
     slug: 'enterprise',
-    name: 'Enterprise',
+    name: 'Super Premium',
     description: 'Domínio próprio, ilimitado e atendimento dedicado.',
     priceMonthly: 597,
     priceYearly: 5970,
@@ -92,7 +92,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
     themes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro', 'landscape_living', 'signature_estate'],
     modules: ['site_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos'],
     features: [
-      'Tudo do Pro',
+      'Tudo do Premium',
       'Imóveis e leads ilimitados',
       'Domínio próprio (.com.br)',
       'Split de pagamentos (Asaas)',
@@ -106,7 +106,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
   {
     slug: 'nivel-maximo',
     name: 'Nível Máximo',
-    description: 'Tudo do Enterprise + Editor de Vídeo IA com legendas automáticas, presets, transições e B-roll por IA.',
+    description: 'Tudo do Super Premium + Editor de Vídeo IA com legendas automáticas, presets, transições e B-roll por IA.',
     priceMonthly: 3500,
     priceYearly: 35000,
     maxProperties: -1,
@@ -116,7 +116,7 @@ const DEFAULT_PLANS: PlanSeed[] = [
     themes: ['urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro', 'landscape_living', 'signature_estate'],
     modules: ['site_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos', 'video_editor'],
     features: [
-      'Tudo do Enterprise',
+      'Tudo do Super Premium',
       'Editor de Vídeo IA — 50 renders/dia',
       'Legendas automáticas PT-BR (palavra-a-palavra)',
       'Presets para imobiliário, social, e-commerce, tutorial',

--- a/apps/web/src/lib/site-factory/plan-registry.ts
+++ b/apps/web/src/lib/site-factory/plan-registry.ts
@@ -1,7 +1,16 @@
 /**
- * Site Factory — Plan Registry
+ * Site Factory — Plan Registry (ESPELHO ESTÁTICO)
  *
- * Defines available plans and which modules each plan unlocks.
+ * ⚠️ FONTE DE VERDADE = banco de dados (`PlanDefinition`, semeado por
+ * `apps/api/src/services/bootstrap-plans.ts`). O checkout (`/saas/checkout`) e
+ * a página `/parceiros/planos` (via `DynamicPlans` + catálogo público) leem
+ * os planos/preços DIRETO do banco.
+ *
+ * Este arquivo é um ESPELHO ESTÁTICO, usado só em contextos renderizados em
+ * build/sem fetch: `/sistema`, `/pitch` e a ferramenta interna site-factory.
+ * Mantenha nomes e preços IDÊNTICOS ao seed do banco:
+ *   lite → "Simples" (R$ 97) · pro → "Premium" (R$ 297) · enterprise → "Super Premium" (R$ 597)
+ * Ao mudar um plano, edite o seed (fonte) e reflita aqui.
  */
 
 export type PlanKey = 'LITE' | 'PRO' | 'ENTERPRISE'


### PR DESCRIPTION
## Resumo

Unifica as definições de plano numa **fonte de verdade única (o banco)** e elimina a divergência de nomes.

### O problema
Havia 3 lugares com dados de plano e os **nomes divergiam**:
| slug | DB/checkout (antes) | páginas /sistema e /pitch |
|------|---------------------|---------------------------|
| lite | "Lite" | **"Simples"** |
| pro | "Pro" | **"Premium"** |
| enterprise | "Enterprise" | **"Super Premium"** |

Ou seja, um cliente via **nomes diferentes** em `/parceiros/planos` (lê do DB) vs `/sistema`. Os preços já batiam (R$ 97/297/597).

### A solução (baixo risco)
- **`bootstrap-plans.ts`** (seed do DB = **fonte de verdade**, lida pelo checkout e pelo `DynamicPlans`): nomes alinhados aos nomes públicos (**Simples / Premium / Super Premium**) + os "Tudo do X" das features. O checkout casa por **slug**, então mudar o `name` é seguro; ícones do `DynamicPlans` também são por slug.
- **`plan-registry.ts`** (web): documentado como **espelho estático** do banco (usado só em `/sistema`, `/pitch` e na ferramenta interna), com a regra de manter sincronizado. Os valores já batiam.

**Resultado:** `/parceiros/planos`, `/sistema` e `/pitch` passam a exibir **exatamente os mesmos nomes e preços**, e fica claro que o **banco** é a fonte canônica.

### Follow-up opcional (não incluído por segurança)
Fazer `/sistema` e `/pitch` consumirem o catálogo público (DB) em runtime em vez do espelho estático — eliminaria o espelho de vez, mas restila páginas que não dá pra testar daqui. Fica registrado.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_