### PR TITLE
fix(web): unifica fallback de API (consistência) — ⚠️ ver nota de diagnóstico

### DIFF
--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -11,7 +11,7 @@ import { MapPin, Home, Search, ChevronRight } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
 
 // Mapeamento de cluster-slug para metadados
 const CLUSTER_META: Record<string, { title: string; h1: string; desc: string; schema: string; icon: string }> = {

--- a/apps/web/src/app/(public)/investor/InvestorDashboardClient.tsx
+++ b/apps/web/src/app/(public)/investor/InvestorDashboardClient.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/lib/financial-engine'
 import { fetchMacroRates, getCachedRates, formatRate } from '@/lib/bcb-rates'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/(public)/leilao-imoveis-franca-sp/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis-franca-sp/page.tsx
@@ -69,7 +69,7 @@ function getPropertyIcon(type: string) {
   }
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.agoraencontrei.com.br'
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
 
 // ── Main Component ────────────────────────────────────────────────────────────
 export default function LeilaoPage() {

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -332,7 +332,7 @@ export default function LeiloesClient() {
     setLeadSubmitting(true)
     setLeadError('')
     try {
-      const API = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.agoraencontrei.com.br'
+      const API = process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
       const res = await fetch(`${API}/api/v1/public/leads`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
@@ -14,7 +14,7 @@ import { SEO_CATEGORIAS_MAP, type SeoCategoria } from '@/data/seo-categorias'
 import { UNIQUE_CITIES } from '@/data/seo-cities'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://www.agoraencontrei.com.br'
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
 
 export const revalidate = 86400
 

--- a/apps/web/src/app/api/health-check/route.ts
+++ b/apps/web/src/app/api/health-check/route.ts
@@ -5,7 +5,7 @@
  */
 import { NextResponse } from 'next/server'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
 
 export async function GET() {
   const checks: Record<string, { status: string; latency?: number }> = {}

--- a/apps/web/src/components/CalculadoraROI.tsx
+++ b/apps/web/src/components/CalculadoraROI.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Calculator, TrendingUp, AlertTriangle, MessageCircle, BarChart3, ShieldCheck, ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
 
 interface Props {
   valorAvaliado: number

--- a/apps/web/src/lib/city-resolver.ts
+++ b/apps/web/src/lib/city-resolver.ts
@@ -8,7 +8,7 @@
  */
 import { IBGE_CITY_BY_SLUG, type IbgeCityData } from '@/data/seo-ibge-cities-expanded'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.agoraencontrei.com.br'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
 
 export interface ResolvedCity {
   slug: string


### PR DESCRIPTION
## Resumo

Unifica o **fallback de `NEXT_PUBLIC_API_URL`** no frontend. Havia uma divergência real: **8 arquivos** usavam `https://api.agoraencontrei.com.br` como default e **10** usavam `https://api-production-669c.up.railway.app`. Esta PR torna os 8 consistentes com a maioria (Railway).

## ⚠️ Correção de diagnóstico (importante — leia antes de mergear)
Eu havia afirmado que `api.agoraencontrei.com.br` estava "com TLS quebrado (503)". **Isso NÃO está confirmado.** O 503 veio do **proxy de egresso do meu ambiente de execução** (o certificado servido era emitido por `Anthropic — Egress Gateway`, e ambos os hosts resolviam para o IP do proxy). Ou seja, pode ser **artefato do sandbox**, não uma falha real de produção.

**Implicações:**
- Se `api.agoraencontrei.com.br` **funciona** em produção (verifique de um navegador/máquina externa), então o canônico ideal talvez seja **ele** (domínio estável), e não a URL do Railway (que é mais efêmera). Nesse caso, prefira **flipar** esta PR para unificar em `api.agoraencontrei.com.br`.
- De qualquer forma, **o que realmente importa é setar `NEXT_PUBLIC_API_URL`** na Vercel — aí o fallback nem é usado. A inconsistência dos 8 vs 10 é que justifica a PR (higiene), independente de qual domínio.

## Recomendação
1. Verifique `https://api.agoraencontrei.com.br/health` de fora do meu ambiente.
2. Se funciona → me avise que eu **flipo** a unificação para esse domínio (mais estável).
3. Se está mesmo quebrado → esta PR já resolve + corrija o cert no Railway.

Mudança em si é de baixo risco (só altera o valor de fallback). O 403 em `/api/v1/auctions` continua sendo anti-bot intencional (não é bug).

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw