### PR TITLE
fix(checkout): check-subdomain público — desbloqueia assinatura (estava sempre "Indisponível")

### DIFF
--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -20,6 +20,7 @@ import {
   createCharge,
   type AsaasBillingType,
 } from '../../services/asaas.service.js'
+import { isSubdomainAvailable } from '../../services/tenant.service.js'
 
 /**
  * Gera senha temporária legível (ex: "Onda7-Mar9-Lua") — fácil de copiar
@@ -34,6 +35,22 @@ function generateTempPassword(): string {
 
 export default async function saasBillingRoutes(app: FastifyInstance) {
   const prisma = app.prisma as any
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // GET /check-subdomain — disponibilidade do subdomínio (PÚBLICO)
+  // O checkout é público; a versão em /tenants exige auth e por isso o checkout
+  // recebia 401 e marcava TODO subdomínio como indisponível (botão travado).
+  // Retorna shape PLANO { available, reason } — o front lê direto.
+  // ═══════════════════════════════════════════════════════════════════════════
+  app.get('/check-subdomain', async (req, reply) => {
+    const sd = String((req.query as any)?.subdomain ?? '').trim()
+    if (!sd) return reply.status(400).send({ available: false, reason: 'Informe um subdomínio.' })
+    const result = await isSubdomainAvailable(prisma, sd).catch(() => ({
+      available: false,
+      reason: 'Não foi possível verificar agora. Tente novamente.',
+    }))
+    return reply.send(result)
+  })
 
   // ═══════════════════════════════════════════════════════════════════════════
   // POST /checkout — Create subscription for a plan

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -124,7 +124,7 @@ export function DynamicPlans() {
     const t = setTimeout(async () => {
       try {
         const r = await fetch(
-          `${API_URL}/api/v1/tenants/check-subdomain?subdomain=${encodeURIComponent(sd)}`,
+          `${API_URL}/api/v1/billing/saas/check-subdomain?subdomain=${encodeURIComponent(sd)}`,
         )
         const d = await r.json()
         if (d.available) setSubdomainStatus({ state: 'available' })


### PR DESCRIPTION
## 🚨 Bug crítico (encontrado no seu teste de assinatura)

Você relatou "**falha na hora de escolher o domínio**" — todo subdomínio aparecia **"Indisponível. Tente outro nome."** e o botão de assinar não liberava.

### Causa raiz
O checkout (público) chamava `GET /api/v1/tenants/check-subdomain`, mas o **router de `tenants` exige autenticação** (`app.addHook('preHandler', app.authenticate)`). Resultado: requisição pública → **401** → `d.available` vira `undefined` → o front cai no `else` e marca **qualquer** subdomínio como "Indisponível" → o botão "Assinar" fica **sempre desabilitado**. **Ninguém conseguia assinar.**

### Correção
- **API:** novo endpoint **público** `GET /api/v1/billing/saas/check-subdomain` (no router de billing/saas, que já é público), retornando shape **plano** `{ available, reason }` via `isSubdomainAvailable` (valida reservados + já-em-uso) com fallback amigável em erro.
- **Web:** `DynamicPlans` passa a chamar o endpoint público.

Agora a checagem funciona: nome livre → "✓ está livre" e botão habilita; nome em uso/reservado → motivo correto.

## Notas para o seu teste
- Se **"tomaslemos"** continuar como indisponível **após este deploy**, é porque uma tentativa anterior **já criou esse tenant** (o checkout cria Company+Tenant+User em TRIAL antes do pagamento). Use outro subdomínio, ex.: `lemosimoveis`.
- Pelo mesmo motivo, o **e-mail** `tomaslemosbr@gmail.com` pode dar `EMAIL_IN_USE` (conta criada em teste anterior) — use outro e-mail ou faça login/recupere senha. Posso adicionar uma limpeza de tenants TRIAL órfãos (checkout abandonado) se quiser.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_