### PR TITLE
feat(saas): libera checkouts abandonados (subdomínio + e-mail)

### DIFF
--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -1208,4 +1208,61 @@ export async function runScheduledJobs(app: FastifyInstance) {
   } catch (err) {
     app.log.error({ err }, '[scheduled] trial-expiration failed')
   }
+
+  // ── 14. Libera checkouts abandonados (nunca ativados) — 1x/dia (04h UTC) ──
+  // Tenant criado no checkout mas que NUNCA pagou (activatedAt null) e cujo
+  // trial venceu há 7+ dias: libera o subdomínio e o e-mail (tombstone), para
+  // que o nome possa ser reusado. NÃO deleta (evita risco de FK/perda); só
+  // renomeia + marca CANCELLED. Paga-se com activatedAt != null => protegido.
+  if (now.getUTCHours() === 4 && now.getUTCMinutes() < 30) {
+    try {
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+      const orphans = await app.prisma.tenant.findMany({
+        where: {
+          activatedAt: null,
+          planStatus: { in: ['TRIAL', 'PENDING_PAYMENT', 'SUSPENDED'] },
+          trialEndsAt: { not: null, lt: sevenDaysAgo },
+        },
+        select: { id: true, subdomain: true, ownerId: true, settings: true },
+        take: 20,
+      })
+
+      let released = 0
+      for (const t of orphans) {
+        const tag = t.id.slice(-6)
+        try {
+          await app.prisma.$transaction(async (tx: any) => {
+            await tx.tenant.update({
+              where: { id: t.id },
+              data: {
+                subdomain: `${t.subdomain}-exp-${tag}`.slice(0, 50),
+                planStatus: 'CANCELLED',
+                isActive: false,
+                settings: { ...((t.settings as any) || {}), releasedAt: now.toISOString(), originalSubdomain: t.subdomain },
+              },
+            })
+            if (t.ownerId) {
+              const owner = await tx.user.findUnique({ where: { id: t.ownerId }, select: { email: true } }).catch(() => null)
+              if (owner?.email && !owner.email.includes('+exp-')) {
+                const [local, domain] = owner.email.split('@')
+                await tx.user.update({
+                  where: { id: t.ownerId },
+                  data: { email: `${local}+exp-${tag}@${domain || 'expired.local'}` },
+                }).catch(() => null)
+              }
+            }
+          })
+          released++
+        } catch (e) {
+          app.log.warn({ e, tenantId: t.id }, '[scheduled] orphan-release skip')
+        }
+      }
+
+      if (released > 0) {
+        app.log.info(`[scheduled] orphan-checkout-release: liberou ${released} subdomínios/e-mails abandonados`)
+      }
+    } catch (err) {
+      app.log.error({ err }, '[scheduled] orphan-checkout-release failed')
+    }
+  }
 }


### PR DESCRIPTION
## Resumo

Complemento ao fluxo de assinatura: libera automaticamente **checkouts abandonados** (que ocupavam subdomínio + e-mail), como o `tomaslemos` dos seus testes.

**Job #14** (1x/dia, 04h UTC) em `scheduled.jobs.ts`:
- Pega tenants **nunca ativados** (`activatedAt = null`) com `planStatus` em TRIAL/PENDING_PAYMENT/SUSPENDED e `trialEndsAt` vencido há **7+ dias**.
- **Libera** (tombstone): renomeia o subdomínio para `{sub}-exp-{id}` e o e-mail do dono para `{local}+exp-{id}@…`, marca `CANCELLED`/`isActive=false`. O nome original volta a ficar livre.
- **Não deleta** (evita risco de FK/perda de dados). **Clientes pagantes são protegidos** (`activatedAt != null` nunca entra no filtro).

> Para liberar o `tomaslemos` **agora** (sem esperar 7 dias), dá pra renomear pelo painel admin/Prisma Studio — ou só usar outro subdomínio no teste.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_