### PR TITLE
fix(leilões): mapa enquadra os pins na 1ª carga (fitBounds)

### DIFF
--- a/apps/web/src/app/(public)/imoveis/MapSearch.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearch.tsx
@@ -155,6 +155,7 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
   const drawingPointsRef = useRef<[number, number][]>([])
   const drawingRef = useRef(false)
   const tempMarkersRef = useRef<MapLibreMarker[]>([])
+  const didFitAuctionsRef = useRef(false)
 
   const [clusters, setClusters] = useState<(Cluster & { resolvedLat: number; resolvedLng: number })[]>(() => {
     if (!initialClusters) return []
@@ -633,6 +634,31 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
       }))
 
     source.setData({ type: 'FeatureCollection', features })
+
+    // Enquadra o mapa nos leilões na PRIMEIRA carga. Sem isto o mapa fica preso
+    // em Franca/zoom 14 e os pins (geocodificados por bairro/cidade Brasil
+    // afora) ficam fora da vista — parecia que "não carregava as opções".
+    if (features.length > 0 && !didFitAuctionsRef.current && mapInstance.current) {
+      didFitAuctionsRef.current = true
+      let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity
+      for (const f of features) {
+        const [lng, lat] = f.geometry.coordinates
+        if (lng < minLng) minLng = lng
+        if (lng > maxLng) maxLng = lng
+        if (lat < minLat) minLat = lat
+        if (lat > maxLat) maxLat = lat
+      }
+      try {
+        if (minLng === maxLng && minLat === maxLat) {
+          mapInstance.current.easeTo({ center: [minLng, minLat], zoom: 12, duration: 600 })
+        } else {
+          mapInstance.current.fitBounds(
+            [[minLng, minLat], [maxLng, maxLat]],
+            { padding: 60, maxZoom: 13, duration: 600 },
+          )
+        }
+      } catch { /* fitBounds pode falhar com bounds degenerados — ignora */ }
+    }
   }, [filteredAuctions, isLoaded])
 
   // Render owner-direct green pins using MapLibre Markers


### PR DESCRIPTION
## 🐛 Bug: mapa de leilões "não carrega as opções"

No seu print, o mapa abre num **satélite de área rural, sem pins**, mesmo com o badge "Leilão 120".

### Causa
O endpoint `/api/v1/auctions/map` retorna **apenas leilões com coordenada** (`latitude/longitude not null`) — então os 120 **têm** coords. O problema é que o mapa **abre fixo em Franca, zoom 14, e nunca dá `fitBounds`** nos leilões. Como os pins estão geocodificados por bairro/cidade **Brasil afora** (job de geocodificação), eles ficam **fora da vista** → parece mapa vazio.

### Correção
Na **primeira carga** com pins, o mapa calcula os bounds das features e dá `fitBounds` (padding 60, `maxZoom` 13). Enquadra **só uma vez** (`didFitAuctionsRef`) para não atrapalhar o pan/zoom/filtro do usuário depois.

Coordenadas no MapLibre já estavam corretas (`[lng, lat]`); o que faltava era o enquadramento.

## Notas
- Toca `MapSearch.tsx` (mesmo arquivo do #175 "mapa só-leilões"), em **linhas diferentes** → mergeiam limpo. Aplica aos dois mapas (imóveis e leilões).
- Não testável visualmente daqui (precisa do MapLibre no browser); preview da Vercel valida o build.
- Se mesmo assim aparecerem **poucos** pins, é porque poucos leilões foram geocodificados ainda — o job #171 faz o backfill gradual.

https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw

---
_Generated by [Claude Code](https://claude.ai/code/session_018zk9KAHFo3Hbgg9iQUTjvw)_