### PR TITLE
fix(build): destrava deploy de produção quebrado pelo TypeScript 6

### DIFF
--- a/packages/tomas-knowledge/tsconfig.json
+++ b/packages/tomas-knowledge/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Produção fora do ar — build quebrado pelo TypeScript 6

O grupo de updates do Dependabot (mergeado em `0797f39`) incluiu **`typescript 5.9.3 → 6.0.3`**. No TS6, `moduleResolution: "node"` (node10) virou **erro fatal TS5107**, que estoura no build do pacote `packages/tomas-knowledge` (rodado no install command da Vercel e como dependência de workspace no Railway). Resultado: **todos os deploys de produção desde então falharam** (Vercel + Railway), incluindo o #191 e o #192 (CORS/voz).

## Correção
Adiciona `"ignoreDeprecations": "6.0"` em `packages/tomas-knowledge/tsconfig.json` — a saída exata sugerida pela própria mensagem do TS6. É a mesma correção já validada (build exit 0) e que subiu verde em Preview.

Confirmei que **só o `tomas-knowledge`** usa o `moduleResolution` deprecado e builda via `tsc`; os apps `api`/`web` não usam essa opção, então passam no TS6. Mudança mínima e cirúrgica (1 linha).

> Urgente: a API e o site fazem auto-deploy do `main`. Sem isto, o fix de CORS/voz (#192) e os demais não chegam a produção.

https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY

---
_Generated by [Claude Code](https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY)_