### PR TITLE
feat(mapa/leilões): abre na localização do visitante e prioriza a região

### DIFF
--- a/apps/web/src/app/(public)/imoveis/MapSearch.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearch.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { X, PenLine, Trash2, Search, MapPin, BedDouble, Maximize } from 'lucide-react'
 import type { Map as MapLibreMap, Marker as MapLibreMarker } from 'maplibre-gl'
+import { getUserGeo, haversineKm, type UserGeo } from '@/lib/geolocation'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://oenbzvxcsgyzqjtlovdq.supabase.co'
@@ -122,6 +123,8 @@ interface Props {
   initialBedrooms?: string
   initialClusters?: Cluster[] // SSR pre-fetched clusters for immediate display
   auctionsOnly?: boolean // quando true, mostra só pins de leilão (esconde imóveis da plataforma)
+  userLat?: number // localização do visitante (passada pelo pai p/ evitar 2º prompt)
+  userLng?: number
 }
 
 // Nominatim cache in module scope
@@ -148,7 +151,7 @@ async function geocodeNeighborhood(neighborhood: string, city: string): Promise<
   return null
 }
 
-export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters, auctionsOnly }: Props) {
+export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters, auctionsOnly, userLat, userLng }: Props) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstance = useRef<MapLibreMap | null>(null)
   const markersRef = useRef<MapLibreMarker[]>([])
@@ -157,6 +160,15 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
   const drawingRef = useRef(false)
   const tempMarkersRef = useRef<MapLibreMarker[]>([])
   const didFitAuctionsRef = useRef(false)
+
+  // Localização do visitante (ao vivo). Inicia com o que o pai passou (se houver)
+  // e tenta obter do navegador caso ainda não tenha. Serve para abrir o mapa já
+  // na região de quem acessa e priorizar os leilões/imóveis mais próximos.
+  const [userLoc, setUserLoc] = useState<UserGeo | null>(
+    typeof userLat === 'number' && typeof userLng === 'number' ? { lat: userLat, lng: userLng } : null,
+  )
+  const userMarkerRef = useRef<MapLibreMarker | null>(null)
+  const didCenterOnUserRef = useRef(false)
 
   const [clusters, setClusters] = useState<(Cluster & { resolvedLat: number; resolvedLng: number })[]>(() => {
     if (!initialClusters) return []
@@ -358,6 +370,45 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
     }
     loadAuctions()
   }, [])
+
+  // Sincroniza com a localização vinda do pai (quando passada via props).
+  useEffect(() => {
+    if (typeof userLat === 'number' && typeof userLng === 'number') {
+      setUserLoc(prev => (prev && prev.lat === userLat && prev.lng === userLng ? prev : { lat: userLat, lng: userLng }))
+    }
+  }, [userLat, userLng])
+
+  // Pede a localização do visitante ao abrir o mapa (se o pai ainda não passou).
+  // Sem isto o mapa abre preso em Franca; com isto abre na região de quem acessa.
+  useEffect(() => {
+    if (userLoc) return
+    let cancelled = false
+    getUserGeo().then(geo => { if (geo && !cancelled) setUserLoc(geo) })
+    return () => { cancelled = true }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Centraliza o mapa na localização do visitante (1x) e fixa um marcador
+  // "você está aqui". Impede o fit-all dos leilões de sobrescrever a vista.
+  useEffect(() => {
+    const map = mapInstance.current
+    if (!userLoc || !isLoaded || !map || didCenterOnUserRef.current) return
+    didCenterOnUserRef.current = true
+    // Voo imediato p/ a região do visitante. O enquadramento fino nos leilões
+    // mais próximos é feito quando os pins chegam (effect de auctions abaixo).
+    try {
+      map.flyTo({ center: [userLoc.lng, userLoc.lat], zoom: 11, duration: 800 })
+    } catch {}
+    import('maplibre-gl').then(mod => {
+      const maplibregl = mod.default || mod
+      try { userMarkerRef.current?.remove() } catch {}
+      const el = document.createElement('div')
+      el.title = 'Você está aqui'
+      el.style.cssText = 'width:18px;height:18px;border-radius:50%;background:#2563eb;border:3px solid #fff;box-shadow:0 0 0 4px rgba(37,99,235,0.25),0 2px 6px rgba(0,0,0,0.3);'
+      userMarkerRef.current = new maplibregl.Marker({ element: el })
+        .setLngLat([userLoc.lng, userLoc.lat])
+        .addTo(map)
+    }).catch(() => {})
+  }, [userLoc, isLoaded])
 
   // Fallback: geocodifica leilões que vieram sem latitude/longitude.
   // Os scrapers nem sempre preenchem coordenadas, então sem isto esses
@@ -671,6 +722,35 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
     // afora) ficam fora da vista — parecia que "não carregava as opções".
     if (features.length > 0 && !didFitAuctionsRef.current && mapInstance.current) {
       didFitAuctionsRef.current = true
+
+      // Com a localização do visitante: enquadra ELE + os leilões mais próximos
+      // (até 12, dentro de ~300km) — abre já na região de quem acessa. Sem
+      // localização: enquadra todos os pins (comportamento anterior).
+      if (userLoc) {
+        const near = features
+          .map(f => ({ f, d: haversineKm(userLoc, { lat: f.geometry.coordinates[1], lng: f.geometry.coordinates[0] }) }))
+          .sort((a, b) => a.d - b.d)
+          .filter(x => x.d <= 300)
+          .slice(0, 12)
+        const pts = near.map(x => x.f.geometry.coordinates as [number, number])
+        pts.push([userLoc.lng, userLoc.lat])
+        let nMinLng = Infinity, nMinLat = Infinity, nMaxLng = -Infinity, nMaxLat = -Infinity
+        for (const [lng, lat] of pts) {
+          if (lng < nMinLng) nMinLng = lng
+          if (lng > nMaxLng) nMaxLng = lng
+          if (lat < nMinLat) nMinLat = lat
+          if (lat > nMaxLat) nMaxLat = lat
+        }
+        try {
+          if (pts.length <= 1 || (nMinLng === nMaxLng && nMinLat === nMaxLat)) {
+            mapInstance.current.easeTo({ center: [userLoc.lng, userLoc.lat], zoom: 11, duration: 600 })
+          } else {
+            mapInstance.current.fitBounds([[nMinLng, nMinLat], [nMaxLng, nMaxLat]], { padding: 70, maxZoom: 13, duration: 600 })
+          }
+        } catch { /* ignora bounds degenerados */ }
+        return
+      }
+
       let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity
       for (const f of features) {
         const [lng, lat] = f.geometry.coordinates

--- a/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
@@ -9,6 +9,8 @@ interface Props {
   initialBedrooms?: string
   initialClusters?: any[]
   auctionsOnly?: boolean
+  userLat?: number
+  userLng?: number
 }
 
 export default function MapSearchWrapper(props: Props) {

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { getUserGeo, reverseGeocodeRegion, type UserGeo, type UserRegion } from '@/lib/geolocation'
 import { Search, MapPin, Filter, Calculator, Bell, TrendingUp, ChevronDown, X, ArrowRight, Building, Home, Map as MapIcon, Star, Clock, DollarSign, BarChart3, AlertTriangle, Loader2, CheckCircle, ExternalLink } from 'lucide-react'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
@@ -179,10 +180,24 @@ function parseMoneyValue(v: unknown): number | null {
   return null
 }
 
-// Franca-first geographic priority
-function cityPriority(city: string | null, state: string | null): number {
+// Prioridade geográfica. Com a localização do visitante (userRegion), prioriza
+// a cidade/UF de quem acessa; sem ela, cai no padrão Franca-first.
+function cityPriority(
+  city: string | null,
+  state: string | null,
+  userRegion?: { city: string; state: string } | null,
+): number {
   const c = (city || '').toUpperCase()
   const s = (state || '').toUpperCase()
+
+  if (userRegion?.city) {
+    const uc = userRegion.city.toUpperCase()
+    const us = (userRegion.state || '').toUpperCase()
+    if (c && (c.includes(uc) || uc.includes(c))) return 0 // mesma cidade do visitante
+    if (us && s === us) return 1                            // mesmo estado
+    return 2
+  }
+
   if (c.includes('FRANCA')) return 0
   if (c.includes('BATATAIS') || c.includes('PATROCINIO') || c.includes('CRISTAIS') || c.includes('RESTINGA')) return 1
   if (c.includes('RIBEIRAO') || c.includes('RIBEIRÃO')) return 2
@@ -398,6 +413,21 @@ export default function LeiloesClient() {
   // View mode
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
 
+  // Localização do visitante (ao vivo): centraliza o mapa e prioriza a listagem
+  // na cidade/UF de quem acessa (ex.: quem está em Franca/SP vê Franca/SP primeiro).
+  const [userLoc, setUserLoc] = useState<UserGeo | null>(null)
+  const [userRegion, setUserRegion] = useState<UserRegion | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    getUserGeo().then(async geo => {
+      if (!geo || cancelled) return
+      setUserLoc(geo)
+      const region = await reverseGeocodeRegion(geo.lat, geo.lng)
+      if (region && !cancelled) setUserRegion(region)
+    })
+    return () => { cancelled = true }
+  }, [])
+
   const fetchAuctions = useCallback(async () => {
     setLoading(true)
     try {
@@ -444,8 +474,8 @@ export default function LeiloesClient() {
           const internalItems = (data.data || []) as Auction[]
           if (internalItems.length > 0) {
             internalItems.sort((a: Auction, b: Auction) => {
-              const geoA = cityPriority(a.city, a.state)
-              const geoB = cityPriority(b.city, b.state)
+              const geoA = cityPriority(a.city, a.state, userRegion)
+              const geoB = cityPriority(b.city, b.state, userRegion)
               return geoA - geoB
             })
             setAuctions(internalItems)
@@ -490,11 +520,11 @@ export default function LeiloesClient() {
         maxPrice,
       })
 
-      // FRANCA-FIRST: Always prioritize by geographic relevance, then by selected sort
+      // Prioriza pela região do visitante (ou Franca-first sem localização),
+      // depois pela ordenação escolhida.
       const sortedItems = [...filteredItems].sort((a, b) => {
-        // Primary: Geographic priority (Franca=0, neighbors=1, Ribeirão=2, SP=3, others=5)
-        const geoA = cityPriority(a.city, a.state)
-        const geoB = cityPriority(b.city, b.state)
+        const geoA = cityPriority(a.city, a.state, userRegion)
+        const geoB = cityPriority(b.city, b.state, userRegion)
         if (geoA !== geoB) return geoA - geoB
 
         // Secondary: User-selected sort
@@ -548,7 +578,7 @@ export default function LeiloesClient() {
       setTotalPages(1)
     }
     setLoading(false)
-  }, [page, search, city, state, source, propertyType, minDiscount, maxPrice, sortBy, sortOrder])
+  }, [page, search, city, state, source, propertyType, minDiscount, maxPrice, sortBy, sortOrder, userRegion])
 
   useEffect(() => { fetchAuctions() }, [fetchAuctions])
 
@@ -710,7 +740,7 @@ export default function LeiloesClient() {
             Explore os leilões no mapa via satélite — navegue por bairro antes de ver a lista abaixo.
           </p>
         </div>
-        <LeiloesMapa auctionsOnly />
+        <LeiloesMapa auctionsOnly userLat={userLoc?.lat} userLng={userLoc?.lng} />
       </section>
 
       {/* Toolbar */}

--- a/apps/web/src/lib/geolocation.ts
+++ b/apps/web/src/lib/geolocation.ts
@@ -1,0 +1,64 @@
+// Geolocalização do visitante (client-side).
+// Usado para abrir os mapas (/imoveis e /leilões) já centrados na região de
+// quem acessa e priorizar os imóveis/leilões mais próximos.
+
+export interface UserGeo {
+  lat: number
+  lng: number
+}
+
+export interface UserRegion {
+  city: string
+  state: string // UF (ex.: "SP"), quando identificável
+}
+
+// Pede a posição atual ao navegador. Resolve null se indisponível, negado ou
+// em timeout — nunca rejeita, para o chamador tratar como "sem localização".
+export function getUserGeo(opts?: PositionOptions): Promise<UserGeo | null> {
+  return new Promise((resolve) => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      resolve(null)
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => resolve(null),
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 5 * 60 * 1000, ...opts },
+    )
+  })
+}
+
+// Distância em km entre dois pontos (Haversine).
+export function haversineKm(a: UserGeo, b: UserGeo): number {
+  const R = 6371
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180
+  const lat1 = (a.lat * Math.PI) / 180
+  const lat2 = (b.lat * Math.PI) / 180
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2)
+  return 2 * R * Math.asin(Math.sqrt(h))
+}
+
+// Coordenada → cidade/UF via Nominatim (reverse). Best-effort: null em falha.
+export async function reverseGeocodeRegion(lat: number, lng: number): Promise<UserRegion | null> {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json&zoom=10&accept-language=pt-BR`,
+      { headers: { Accept: 'application/json' } },
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const a = data?.address ?? {}
+    const city: string =
+      a.city || a.town || a.municipality || a.village || a.city_district || a.county || ''
+    // Nominatim devolve o código ISO (ex.: "BR-SP") — extrai a UF.
+    const iso: string = a['ISO3166-2-lvl4'] || ''
+    const state = iso.includes('-') ? iso.split('-')[1] : ''
+    if (!city) return null
+    return { city, state }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## O que faz
Ao abrir o **mapa** (home/`/imoveis` e `/leilões`) ou a **página de leilões**, pede a **localização atual** do visitante e já mostra primeiro a região dele — ex.: quem está em **Franca/SP** abre vendo Franca/SP, no mapa e na listagem.

## Mudanças
- **`lib/geolocation.ts`** (novo): `getUserGeo` (via `navigator.geolocation`, best-effort, nunca rejeita), `haversineKm` (distância) e `reverseGeocodeRegion` (coordenada → cidade/UF via Nominatim).
- **`MapSearch.tsx`** (componente único dos dois mapas): solicita a posição ao abrir, **centraliza no visitante** com marcador "você está aqui" e **enquadra os leilões mais próximos** (até 12, raio ~300 km). Sem permissão/indisponível, mantém o comportamento atual (fit nos pins / Franca).
- **`LeiloesClient.tsx`**: ordena a **listagem** pela cidade/UF do visitante (`cityPriority` dinâmico; Franca-first continua como fallback) e passa as coordenadas ao mapa (evita 2º prompt de permissão).
- **`MapSearchWrapper.tsx`**: repassa as novas props `userLat`/`userLng`.

## Comportamento
- Permissão **concedida** → mapa abre na região do visitante + listagem de leilões prioriza a cidade/UF dele.
- Permissão **negada / indisponível / HTTP** → fallback atual (Franca-first), sem quebrar nada.

## Observações
- Geolocalização exige **HTTPS** e **permissão do usuário** — só dá para validar de verdade no **Preview da Vercel num navegador real** (não tem como testar neste ambiente).
- Escopo: cobre os dois **mapas** + a **listagem de leilões**. A listagem SSR de `/imoveis` (venda/aluguel) segue Franca-first — o estoque de venda/aluguel é concentrado em Franca, então não apliquei filtro automático por geolocalização lá (evita listas vazias para quem acessa de fora). Posso adicionar um aviso "perto de você" lá se quiser.

> Sugiro testar no Preview (permitir localização) antes de mergear.

https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY

---
_Generated by [Claude Code](https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY)_