### PR TITLE
fix(leilões): escopa mapa e listagem na região do visitante (geolocalização)

### DIFF
--- a/apps/web/src/app/(public)/imoveis/MapSearch.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearch.tsx
@@ -125,6 +125,7 @@ interface Props {
   auctionsOnly?: boolean // quando true, mostra só pins de leilão (esconde imóveis da plataforma)
   userLat?: number // localização do visitante (passada pelo pai p/ evitar 2º prompt)
   userLng?: number
+  userCity?: string // cidade do visitante — escopa os pins de leilão à região
 }
 
 // Nominatim cache in module scope
@@ -151,7 +152,7 @@ async function geocodeNeighborhood(neighborhood: string, city: string): Promise<
   return null
 }
 
-export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters, auctionsOnly, userLat, userLng }: Props) {
+export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initialBedrooms, initialClusters, auctionsOnly, userLat, userLng, userCity }: Props) {
   const mapRef = useRef<HTMLDivElement>(null)
   const mapInstance = useRef<MapLibreMap | null>(null)
   const markersRef = useRef<MapLibreMarker[]>([])
@@ -338,12 +339,15 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
       .catch(() => {})
   }, [])
 
-  // Load auction pins — bypass Railway, read directly from Supabase
+  // Load auction pins — bypass Railway, read directly from Supabase.
+  // Com a cidade do visitante (userCity), escopa os pins à região dele; sem
+  // ela, cai no estado padrão (SP). Refaz a busca quando a cidade resolve.
   useEffect(() => {
     async function loadAuctions() {
+      const scope = userCity ? `city=${encodeURIComponent(userCity)}` : 'state=SP'
       // Try API first
       try {
-        const res = await fetch(`${API_URL}/api/v1/auctions/map?state=SP&limit=2000`)
+        const res = await fetch(`${API_URL}/api/v1/auctions/map?${scope}&limit=2000`)
         if (res.ok) {
           const data = await res.json()
           if (data.data?.length > 0) { setAuctions(data.data); return }
@@ -368,8 +372,9 @@ export function MapSearch({ initialPurpose, initialCity, initialMaxPrice, initia
         }
       } catch {}
     }
+    didFitAuctionsRef.current = false // novo conjunto → permite reenquadrar
     loadAuctions()
-  }, [])
+  }, [userCity])
 
   // Sincroniza com a localização vinda do pai (quando passada via props).
   useEffect(() => {

--- a/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
+++ b/apps/web/src/app/(public)/imoveis/MapSearchWrapper.tsx
@@ -11,6 +11,7 @@ interface Props {
   auctionsOnly?: boolean
   userLat?: number
   userLng?: number
+  userCity?: string
 }
 
 export default function MapSearchWrapper(props: Props) {

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -417,13 +417,23 @@ export default function LeiloesClient() {
   // na cidade/UF de quem acessa (ex.: quem está em Franca/SP vê Franca/SP primeiro).
   const [userLoc, setUserLoc] = useState<UserGeo | null>(null)
   const [userRegion, setUserRegion] = useState<UserRegion | null>(null)
+  const autoRegionAppliedRef = useRef(false)
   useEffect(() => {
     let cancelled = false
     getUserGeo().then(async geo => {
       if (!geo || cancelled) return
       setUserLoc(geo)
       const region = await reverseGeocodeRegion(geo.lat, geo.lng)
-      if (region && !cancelled) setUserRegion(region)
+      if (!region || cancelled) return
+      setUserRegion(region)
+      // Com 16k+ leilões, ordenar a página no client não traz a região do
+      // visitante do meio da lista. Então aplica a cidade dele como filtro
+      // (no servidor) na 1ª vez — abre já mostrando os leilões da região.
+      if (region.city && !autoRegionAppliedRef.current) {
+        autoRegionAppliedRef.current = true
+        setCity(prev => prev || region.city)
+        setPage(1)
+      }
     })
     return () => { cancelled = true }
   }, [])
@@ -740,14 +750,24 @@ export default function LeiloesClient() {
             Explore os leilões no mapa via satélite — navegue por bairro antes de ver a lista abaixo.
           </p>
         </div>
-        <LeiloesMapa auctionsOnly userLat={userLoc?.lat} userLng={userLoc?.lng} />
+        <LeiloesMapa auctionsOnly userLat={userLoc?.lat} userLng={userLoc?.lng} userCity={userRegion?.city} />
       </section>
 
       {/* Toolbar */}
       <div className="sticky top-16 z-20 bg-white border-b shadow-sm">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="flex items-center gap-2 text-sm text-gray-500 flex-wrap">
             <span className="font-semibold text-gray-800">{total.toLocaleString('pt-BR')}</span> leilões encontrados
+            {userRegion?.city && city && city.toLowerCase() === userRegion.city.toLowerCase() && (
+              <span className="inline-flex items-center gap-1.5 text-xs">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-semibold" style={{ backgroundColor: '#eef2ff', color: '#1B2B5B' }}>
+                  📍 {userRegion.city}{userRegion.state ? `/${userRegion.state}` : ''} (sua região)
+                </span>
+                <button onClick={() => { setCity(''); setPage(1) }} className="underline text-gray-500 hover:text-gray-700">
+                  ver todos
+                </button>
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <button


### PR DESCRIPTION
Correção do que você reportou: ao abrir `/leilões` em Franca/SP, **o mapa não trazia os pins de Franca** e a **lista vinha com 16.597 itens genéricos "Santander /SP"** em vez de Franca primeiro.

## Causa
A base de leilões cresceu para **16.597 registros**. A API pagina ordenada por data, então minha ordenação client-side só reordenava os ~20 itens da página — os de Franca nunca subiam do meio da lista. O mapa também abria com escopo estadual amplo.

## Correção (escopo por região no servidor)
- **`LeiloesClient`**: ao resolver a geolocalização (reverse-geocode → cidade/UF), aplica a **cidade do visitante como filtro no servidor** uma vez — abre já mostrando os leilões da região. Badge **"📍 {cidade}/{UF} (sua região)"** com link **"ver todos"** para limpar o filtro.
- **`MapSearch`**: aceita `userCity` e busca os pins de `/auctions/map?city={cidade}` (escopo na região), refazendo a busca quando a cidade resolve e reenquadrando nos pins próximos.
- **`MapSearchWrapper`**: repassa `userCity`.

Validado na API: `/auctions?city=Franca` → 13 leilões de Franca; `/auctions/map?city=Franca` → pins de Franca. Sem geolocalização/permissão, mantém o comportamento anterior (estado SP / Franca-first).

## Como testar (navegador real)
`agoraencontrei.com.br/leiloes` → permitir localização → mapa abre na sua região **com os pins** e a lista mostra os leilões da **sua cidade** primeiro, com o badge "sua região / ver todos".

> Obs.: se em Franca os pins ainda não aparecerem após este deploy, me avise o que o console do navegador mostra na chamada de `/auctions/map` — aí investigo um eventual erro de runtime do mapa.

https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY

---
_Generated by [Claude Code](https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY)_