### PR TITLE
fix(csp): libera Web Worker (blob:) do MapLibre — pins do mapa não renderizavam

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -185,6 +185,11 @@ const nextConfig = {
             value: [
               "default-src 'self'",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://connect.facebook.net https://www.googletagmanager.com https://www.google-analytics.com https://maps.googleapis.com https://cdn.jsdelivr.net https://unpkg.com",
+              // MapLibre GL processa as fontes GeoJSON/clustering num Web Worker
+              // carregado via blob: — sem isto os pins do mapa não renderizam
+              // (worker-src cai em default-src 'self' e o blob é bloqueado).
+              "worker-src 'self' blob:",
+              "child-src 'self' blob:",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com",
               "font-src 'self' https://fonts.gstatic.com",
               "img-src 'self' data: blob: https: http:",


### PR DESCRIPTION
## Causa raiz (por que os pins nunca apareciam)
O mapa carregava os leilões (o seletor mostrava **"Leilão 2000"**), mas **nenhum pin renderizava** — desde o primeiro relato de "mapa não carrega as opções".

A **CSP** do site define `default-src 'self'` e **não tinha `worker-src`**. O MapLibre GL processa as fontes **GeoJSON com clustering dentro de um Web Worker carregado via `blob:`**. Sem `worker-src blob:`, a diretiva cai em `default-src 'self'` e o navegador **bloqueia o worker** → os tiles de satélite e o marcador "você está aqui" (DOM) aparecem, mas a camada de pins (GeoJSON) **nunca renderiza**. Por isso as correções anteriores (backfill de coordenadas, fitBounds, escopo por região) estavam certas, mas os pins continuavam invisíveis.

## Correção
Adiciona à CSP em `apps/web/next.config.mjs`:
```
worker-src 'self' blob:
child-src 'self' blob:
```
Mudança mínima e padrão para MapLibre + CSP. Não afeta outras políticas.

## Como testar (após deploy)
`agoraencontrei.com.br/leiloes` → os pins/clusters dourados de leilão devem aparecer no mapa (e, com localização permitida, centrados na sua região). Vale conferir o console (F12): não deve mais haver erro de CSP sobre *worker*/`blob:`.

https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY

---
_Generated by [Claude Code](https://claude.ai/code/session_0199PBNXuU5pmJv68nZnxtBY)_