### PR TITLE
feat: módulos de locação do sistema legado IMOBILI (rateio, contas a pagar, rescisão, acordos, conciliação, notificações, permissões, IPTU)

### DIFF
--- a/.claude/skills/sistema-imobiliario-locacao/SKILL.md
+++ b/.claude/skills/sistema-imobiliario-locacao/SKILL.md
@@ -93,5 +93,22 @@ contas a pagar, comissões, notas fiscais).
 - Papéis de acesso rígidos demais (RBAC sem granularidade por módulo).
 - Não guardar histórico de reajustes e de baixas (perde rastreabilidade fiscal).
 
+## Implementações de referência (neste repositório)
+Padrões já implementados e testados — reaproveite a abordagem ao construir sistemas novos:
+- **Rateio de repasse**: `apps/api/src/services/repasse.service.ts` (`scheduleRepasseWithSplit`)
+  + modelo `RepasseBeneficiary`. Reconciliação de centavos: o último beneficiário absorve o resto.
+- **Motor de rescisão**: `apps/api/src/services/rescission.service.ts` (`calculateRescission`) —
+  função PURA, fácil de testar; proporcional por dias + multa proporcional ao período restante.
+- **Acordos/parcelas**: `apps/api/src/services/agreement.service.ts` (`generateInstallmentPlan`) —
+  clamp de fim de mês + centavos na última parcela.
+- **Conciliação bancária**: `apps/api/src/services/reconciliation.service.ts` — parsers CSV/CNAB400
+  e `matchEntries` (por nosso número, depois valor+data, sem reusar candidato).
+- **Permissões por módulo**: `apps/api/src/utils/permissions.ts` (`requirePermission`, opt-in).
+- **Testes**: `apps/api/test/*.test.ts` com `node:test` via `tsx` (sem libs extras).
+
+> Lição-chave: extraia a regra de negócio numa **função pura** (sem I/O) e teste a matemática
+> isoladamente — dinheiro deve fechar em centavos sempre (aloque em inteiros de centavos e
+> deixe o último item absorver o resto).
+
 ---
 **Referência de mapeamento detalhada:** `docs/SISTEMA-UNILOC-MAPEAMENTO.md`.

--- a/.claude/skills/sistema-imobiliario-locacao/SKILL.md
+++ b/.claude/skills/sistema-imobiliario-locacao/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: sistema-imobiliario-locacao
+description: >-
+  Conhecimento de domínio para construir sistemas, sites ou programas de
+  imobiliária — especialmente administração de carteira de LOCAÇÃO (property
+  management) no mercado brasileiro. Use sempre que for projetar, modelar dados
+  ou planejar funcionalidades de: CRM imobiliário, gestão de aluguéis,
+  contratos, repasses a proprietários, cobrança/boletos, IPTU, rescisão,
+  financeiro de imobiliária. Baseado em sistema legado (IMOBILI/UNILOC)
+  comprovado por ~25 anos de operação real. NÃO contém dados pessoais.
+---
+
+# Sistema Imobiliário de Locação — Checklist de Domínio
+
+Conhecimento destilado de um sistema desktop de administração de locação em uso real por
+~25 anos (IMOBILI/UNILOC, Visual FoxPro). Use como **checklist de funcionalidades** ao
+construir qualquer sistema/site/programa imobiliário, para não esquecer regras de negócio
+que só aparecem na operação do dia a dia.
+
+## Quando usar
+- Modelar banco de dados de imobiliária (locação, vendas, financeiro).
+- Planejar telas/módulos de um CRM ou ERP imobiliário.
+- Decidir o escopo de um MVP de gestão de aluguéis.
+- Avaliar lacunas de um sistema imobiliário existente.
+
+## O ciclo completo da locação (não pule etapas)
+```
+Cadastro → Contrato → Cobrança mensal → Recebimento/Baixa →
+Repasse ao proprietário → (Reajuste anual) → Rescisão/Acordo
+```
+Em paralelo, sempre existe o **financeiro interno da imobiliária** (caixa, banco,
+contas a pagar, comissões, notas fiscais).
+
+## Entidades essenciais (modelo de dados mínimo)
+- **Proprietário (locador)** + dados bancários para repasse.
+- **Co-proprietários / favorecidos** com **rateio por percentual** (1 imóvel → N donos).
+- **Inquilino** e **Fiador** (suportar 2 fiadores; cônjuge e representantes legais PJ).
+- **Imóvel** com % de propriedade, IPTU, água, luz, garagem (vaga pode ser unidade própria).
+- **Contrato** ligando locador+imóvel+inquilino+garantia.
+- **Lançamento de aluguel** (mensal) + **lançamentos diversos** (avulsos).
+- **Boleto/Invoice**, **Repasse**, **Transação de caixa**, **Movimento bancário**.
+
+## Regras de negócio que costumam ser esquecidas
+1. **Rateio de repasse**: um imóvel pode ter vários donos/favorecidos com % distintos.
+   O repasse não é 1:1 — modele uma tabela de participantes.
+2. **Reajuste anual por índice** (IGPM/IPCA): guardar índice, data-base, mês de reajuste,
+   data do último e do próximo reajuste, e histórico de índices por data.
+3. **Garantia locatícia** tem 4 tipos: fiador, caução, seguro fiança, título de
+   capitalização — cada um com regras próprias.
+4. **IRRF retido** no repasse de pessoa física (tabela progressiva mensal de IR).
+5. **Multa + juros de mora**: multa percentual fixa + juros por dia ou por mês; defina
+   se cálculo é em dias corridos ou úteis (precisa de tabela de feriados).
+6. **IPTU parcelado** (carnê): lançar por imóvel/ano, ratear parcelas ao inquilino.
+7. **Encargos inclusos**: marcar se água/luz/condomínio/IPTU já estão no aluguel.
+8. **Vistoria de entrada e de saída** (data + laudo) — essencial para rescisão.
+9. **Rescisão = apuração de saldo**: aluguel proporcional + IPTU pro-rata + multa
+   rescisória + bonificação + devolução de caução. Faça um motor de cálculo, não campos soltos.
+10. **Acordos/renegociação**: débitos atrasados viram novo cronograma de parcelas
+    vinculado aos lançamentos originais.
+11. **Cobrança bancária**: emissão de boleto e **baixa por arquivo CNAB de retorno**
+    (ou webhook do gateway). Sempre prever conciliação caixa × banco.
+12. **Notificação formal/extrajudicial**: tipo, assunto, situação e data de resolução
+    (régua: cobrança amigável → notificação → jurídico).
+
+## Financeiro interno da imobiliária (não esquecer)
+- **Caixa** com plano de contas (grupos), débito/crédito.
+- **Contas a pagar** (despesas) com favorecido, vencimento, status, documento.
+- **Controle de cheques** (a pagar / pré-datados) com situação.
+- **Comissões** da imobiliária e da equipe.
+- **Notas fiscais de serviço** (NFS-e) sobre a taxa de administração.
+- **Conciliação bancária** por conta.
+
+## Operacional / sistema
+- **Permissões granulares por módulo** (não só papéis fixos): imobiliárias têm muitos
+  perfis (corretor, financeiro, jurídico, diretoria) com acessos finos.
+- **Parametrização central**: taxas padrão, dados bancários, e-mail/SMTP, NF, logos.
+- **Sequenciadores** de nº de boleto/recibo/edital.
+- **Modelos de documento** (contrato, notificação, recibo) com mesclagem de campos.
+- **Lembretes/agenda** operacional vinculados a contrato/imóvel/cliente.
+- **Auditoria**: registrar usuário e data de criação/alteração em tudo (`userCad`,
+  `dataCad`, `userAtua`, `dataAtua`).
+
+## Mercado brasileiro — especificidades
+- Documentos: CPF/CNPJ (CIC/CGC), RG, IE, CRECI da imobiliária.
+- Bancos: boleto (CNAB 240/400), PIX, e gateways (ex.: Asaas) para split/repasse.
+- Índices oficiais via BCB (IGPM, IPCA, taxas).
+- Retenções fiscais: IRRF, PIS/COFINS/CSLL, ISS sobre a taxa de administração.
+
+## Anti-padrões a evitar
+- Tratar repasse como 1 proprietário por imóvel (quebra em co-propriedade).
+- Esquecer rescisão como cálculo (vira planilha manual paralela).
+- Não ter contas a pagar/cheques (financeiro fica só "a receber").
+- Papéis de acesso rígidos demais (RBAC sem granularidade por módulo).
+- Não guardar histórico de reajustes e de baixas (perde rastreabilidade fiscal).
+
+---
+**Referência de mapeamento detalhada:** `docs/SISTEMA-UNILOC-MAPEAMENTO.md`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --project tsconfig.build.json || true",
     "start": "node dist/server.js",
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/*.test.ts",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {

--- a/apps/api/scripts/backfill-repasse-beneficiaries.ts
+++ b/apps/api/scripts/backfill-repasse-beneficiaries.ts
@@ -1,0 +1,92 @@
+/**
+ * backfill-repasse-beneficiaries.ts
+ *
+ * Popula RepasseBeneficiary (rateio de repasse) a partir dos dados JÁ
+ * existentes no AgoraEncontrei: para cada contrato ativo cujo imóvel tem
+ * MAIS DE UM proprietário (PropertyOwner com percentual), cria um beneficiário
+ * por proprietário com o respectivo %.
+ *
+ * Seguro por padrão:
+ *   • Dry-run por padrão — só imprime o que faria. Use --apply para gravar.
+ *   • Idempotente — pula contratos que já têm beneficiários cadastrados.
+ *   • Escopo por empresa — exige --company <companyId>.
+ *   • Só grava se a soma dos percentuais do imóvel for ~100%.
+ *
+ * Uso:
+ *   npx tsx scripts/backfill-repasse-beneficiaries.ts --company <id>            (dry-run)
+ *   npx tsx scripts/backfill-repasse-beneficiaries.ts --company <id> --apply    (grava)
+ */
+
+import 'dotenv/config'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 ? process.argv[i + 1] : undefined
+}
+const APPLY = process.argv.includes('--apply')
+const COMPANY_ID = arg('company')
+
+async function main() {
+  if (!COMPANY_ID) {
+    console.error('ERRO: informe --company <companyId>')
+    process.exit(1)
+  }
+  console.log(`[backfill-rateio] empresa=${COMPANY_ID} modo=${APPLY ? 'APLICAR' : 'DRY-RUN'}`)
+
+  // Contratos ativos com imóvel vinculado.
+  const contracts = await prisma.contract.findMany({
+    where: { companyId: COMPANY_ID, propertyId: { not: null } },
+    select: { id: true, propertyId: true, landlordName: true },
+  })
+
+  let created = 0, skippedExisting = 0, skippedSingle = 0, skippedSum = 0
+
+  for (const c of contracts) {
+    // Já tem rateio? pula (idempotente).
+    const existing = await (prisma as any).repasseBeneficiary.count({ where: { contractId: c.id } })
+    if (existing > 0) { skippedExisting++; continue }
+
+    const owners = await prisma.propertyOwner.findMany({
+      where: { propertyId: c.propertyId! },
+      include: { contact: { select: { name: true } } },
+    })
+    // Só interessa rateio quando há 2+ proprietários.
+    if (owners.length < 2) { skippedSingle++; continue }
+
+    const sum = owners.reduce((s, o) => s + Number(o.percentage), 0)
+    if (Math.abs(sum - 100) > 0.01) {
+      skippedSum++
+      console.warn(`  ! contrato ${c.id}: % do imóvel soma ${sum.toFixed(2)} (≠100) — pulado`)
+      continue
+    }
+
+    const rows = owners.map((o) => ({
+      companyId: COMPANY_ID!,
+      contractId: c.id,
+      clientId: null as string | null, // PropertyOwner liga a Contact, não Client — destino fica no fallback
+      name: o.contact?.name ?? 'Proprietário',
+      percentage: Number(o.percentage),
+      role: 'OWNER',
+    }))
+
+    console.log(`  + contrato ${c.id}: ${rows.length} beneficiários (${rows.map(r => `${r.name} ${r.percentage}%`).join(', ')})`)
+    if (APPLY) {
+      await (prisma as any).repasseBeneficiary.createMany({ data: rows })
+    }
+    created += rows.length
+  }
+
+  console.log(`\n[backfill-rateio] resumo:`)
+  console.log(`  beneficiários ${APPLY ? 'criados' : 'a criar'}: ${created}`)
+  console.log(`  contratos pulados (já tinham rateio): ${skippedExisting}`)
+  console.log(`  contratos pulados (imóvel com 1 dono): ${skippedSingle}`)
+  console.log(`  contratos pulados (% ≠ 100): ${skippedSum}`)
+  if (!APPLY) console.log(`\n  DRY-RUN — nada foi gravado. Rode novamente com --apply para aplicar.`)
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1) })
+  .finally(() => prisma.$disconnect())

--- a/apps/api/src/routes/agreements/index.ts
+++ b/apps/api/src/routes/agreements/index.ts
@@ -1,0 +1,186 @@
+/**
+ * Agreements Routes — Acordos / Renegociação de dívida
+ *
+ *   POST /api/v1/agreements                       — cria acordo + gera parcelas
+ *   POST /api/v1/agreements/preview               — pré-visualiza o cronograma
+ *   GET  /api/v1/agreements                        — lista (filtros: status, contractId)
+ *   GET  /api/v1/agreements/:id                    — acordo + parcelas
+ *   POST /api/v1/agreements/:id/installments/:n/pay — paga uma parcela
+ *   POST /api/v1/agreements/:id/cancel             — cancela acordo
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { generateInstallmentPlan } from '../../services/agreement.service.js'
+
+const createSchema = z.object({
+  contractId: z.string().optional(),
+  tenantName: z.string().optional(),
+  originalDebt: z.number().positive(),
+  discountValue: z.number().min(0).default(0),
+  agreedValue: z.number().positive(),
+  installments: z.number().int().min(1).max(120),
+  firstDueDate: z.string(),
+  intervalMonths: z.number().int().min(1).max(12).optional(),
+  notes: z.string().optional(),
+})
+
+export default async function agreementsRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  // POST /preview — pré-visualiza o cronograma sem salvar
+  app.post('/preview', {
+    schema: { tags: ['agreements'], summary: 'Preview installment plan' },
+  }, async (req, reply) => {
+    const b = z.object({
+      agreedValue: z.number().positive(),
+      installments: z.number().int().min(1).max(120),
+      firstDueDate: z.string(),
+      intervalMonths: z.number().int().min(1).max(12).optional(),
+    }).parse(req.body)
+    const plan = generateInstallmentPlan({
+      agreedValue: b.agreedValue,
+      installments: b.installments,
+      firstDueDate: new Date(b.firstDueDate),
+      intervalMonths: b.intervalMonths,
+    })
+    return reply.send({ success: true, data: plan })
+  })
+
+  // POST / — cria acordo e gera as parcelas
+  app.post('/', {
+    schema: { tags: ['agreements'], summary: 'Create agreement with schedule' },
+  }, async (req, reply) => {
+    const b = createSchema.parse(req.body)
+
+    if (b.contractId) {
+      const contract = await app.prisma.contract.findFirst({
+        where: { id: b.contractId, companyId: req.user.cid },
+        select: { id: true },
+      })
+      if (!contract) return reply.status(404).send({ error: 'CONTRACT_NOT_FOUND' })
+    }
+
+    const plan = generateInstallmentPlan({
+      agreedValue: b.agreedValue,
+      installments: b.installments,
+      firstDueDate: new Date(b.firstDueDate),
+      intervalMonths: b.intervalMonths,
+    })
+
+    const created = await db().agreement.create({
+      data: {
+        companyId: req.user.cid,
+        contractId: b.contractId ?? null,
+        tenantName: b.tenantName ?? null,
+        originalDebt: b.originalDebt,
+        discountValue: b.discountValue,
+        agreedValue: b.agreedValue,
+        installments: b.installments,
+        firstDueDate: new Date(b.firstDueDate),
+        status: 'ACTIVE',
+        notes: b.notes ?? null,
+        createdBy: req.user.sub ?? null,
+        schedule: {
+          create: plan.map((p) => ({
+            number: p.number,
+            dueDate: new Date(p.dueDate),
+            amount: p.amount,
+          })),
+        },
+      },
+      include: { schedule: { orderBy: { number: 'asc' } } },
+    })
+    return reply.status(201).send({ success: true, data: created })
+  })
+
+  // GET / — lista acordos
+  app.get('/', {
+    schema: { tags: ['agreements'], summary: 'List agreements' },
+  }, async (req, reply) => {
+    const q = req.query as any
+    const where: any = { companyId: req.user.cid }
+    if (q.status) where.status = q.status
+    if (q.contractId) where.contractId = q.contractId
+    const rows = await db().agreement.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      include: { schedule: { orderBy: { number: 'asc' } } },
+      take: 200,
+    })
+    return reply.send({ success: true, data: rows })
+  })
+
+  // GET /:id — acordo + parcelas
+  app.get('/:id', {
+    schema: { tags: ['agreements'], summary: 'Get agreement with schedule' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const row = await db().agreement.findFirst({
+      where: { id, companyId: req.user.cid },
+      include: { schedule: { orderBy: { number: 'asc' } } },
+    })
+    if (!row) return reply.status(404).send({ error: 'NOT_FOUND' })
+    return reply.send({ success: true, data: row })
+  })
+
+  // POST /:id/installments/:number/pay — paga uma parcela; fecha o acordo se todas pagas
+  app.post('/:id/installments/:number/pay', {
+    schema: { tags: ['agreements'], summary: 'Pay an installment' },
+  }, async (req, reply) => {
+    const { id, number } = req.params as { id: string; number: string }
+    const num = parseInt(number)
+
+    const agreement = await db().agreement.findFirst({
+      where: { id, companyId: req.user.cid },
+      select: { id: true, status: true },
+    })
+    if (!agreement) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (agreement.status === 'CANCELLED') return reply.status(409).send({ error: 'CANCELLED' })
+
+    const installment = await db().agreementInstallment.findFirst({
+      where: { agreementId: id, number: num },
+    })
+    if (!installment) return reply.status(404).send({ error: 'INSTALLMENT_NOT_FOUND' })
+
+    const body = z.object({
+      paidAt: z.string().optional(),
+      paidAmount: z.number().positive().optional(),
+    }).parse(req.body ?? {})
+
+    await db().agreementInstallment.update({
+      where: { id: installment.id },
+      data: {
+        status: 'PAID',
+        paidAt: body.paidAt ? new Date(body.paidAt) : new Date(),
+        paidAmount: body.paidAmount ?? installment.amount,
+      },
+    })
+
+    // Se todas as parcelas estiverem pagas, marca o acordo como cumprido.
+    const pendingCount = await db().agreementInstallment.count({
+      where: { agreementId: id, status: { not: 'PAID' } },
+    })
+    if (pendingCount === 0) {
+      await db().agreement.update({ where: { id }, data: { status: 'FULFILLED' } })
+    }
+
+    const updated = await db().agreement.findFirst({
+      where: { id },
+      include: { schedule: { orderBy: { number: 'asc' } } },
+    })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // POST /:id/cancel — cancela o acordo
+  app.post('/:id/cancel', {
+    schema: { tags: ['agreements'], summary: 'Cancel agreement' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const agreement = await db().agreement.findFirst({ where: { id, companyId: req.user.cid }, select: { id: true } })
+    if (!agreement) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().agreement.update({ where: { id }, data: { status: 'CANCELLED' } })
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/agreements/index.ts
+++ b/apps/api/src/routes/agreements/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { requirePermission } from '../../utils/permissions.js'
 import { z } from 'zod'
 import { generateInstallmentPlan } from '../../services/agreement.service.js'
 
@@ -27,10 +28,12 @@ const createSchema = z.object({
 
 export default async function agreementsRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  const canView = requirePermission('agreements', 'view')
+  const canEdit = requirePermission('agreements', 'edit')
   const db = () => app.prisma as any
 
   // POST /preview — pré-visualiza o cronograma sem salvar
-  app.post('/preview', {
+  app.post('/preview', { preHandler: canEdit,
     schema: { tags: ['agreements'], summary: 'Preview installment plan' },
   }, async (req, reply) => {
     const b = z.object({
@@ -49,7 +52,7 @@ export default async function agreementsRoutes(app: FastifyInstance) {
   })
 
   // POST / — cria acordo e gera as parcelas
-  app.post('/', {
+  app.post('/', { preHandler: canEdit,
     schema: { tags: ['agreements'], summary: 'Create agreement with schedule' },
   }, async (req, reply) => {
     const b = createSchema.parse(req.body)
@@ -96,7 +99,7 @@ export default async function agreementsRoutes(app: FastifyInstance) {
   })
 
   // GET / — lista acordos
-  app.get('/', {
+  app.get('/', { preHandler: canView,
     schema: { tags: ['agreements'], summary: 'List agreements' },
   }, async (req, reply) => {
     const q = req.query as any
@@ -113,7 +116,7 @@ export default async function agreementsRoutes(app: FastifyInstance) {
   })
 
   // GET /:id — acordo + parcelas
-  app.get('/:id', {
+  app.get('/:id', { preHandler: canView,
     schema: { tags: ['agreements'], summary: 'Get agreement with schedule' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
@@ -126,7 +129,7 @@ export default async function agreementsRoutes(app: FastifyInstance) {
   })
 
   // POST /:id/installments/:number/pay — paga uma parcela; fecha o acordo se todas pagas
-  app.post('/:id/installments/:number/pay', {
+  app.post('/:id/installments/:number/pay', { preHandler: canEdit,
     schema: { tags: ['agreements'], summary: 'Pay an installment' },
   }, async (req, reply) => {
     const { id, number } = req.params as { id: string; number: string }
@@ -174,7 +177,7 @@ export default async function agreementsRoutes(app: FastifyInstance) {
   })
 
   // POST /:id/cancel — cancela o acordo
-  app.post('/:id/cancel', {
+  app.post('/:id/cancel', { preHandler: canEdit,
     schema: { tags: ['agreements'], summary: 'Cancel agreement' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }

--- a/apps/api/src/routes/finance/webhook.ts
+++ b/apps/api/src/routes/finance/webhook.ts
@@ -14,7 +14,7 @@
 import type { FastifyInstance } from 'fastify'
 import { env } from '../../utils/env.js'
 import type { AsaasWebhookEvent } from '../../services/asaas.service.js'
-import { scheduleRepasse } from '../../services/repasse.service.js'
+import { scheduleRepasseWithSplit } from '../../services/repasse.service.js'
 import { safeStringEqual } from '../../utils/crypto-safe.js'
 import { notify } from '../../services/notification.service.js'
 import { dispatchWebhooks } from '../../services/outgoing-webhook.service.js'
@@ -225,12 +225,16 @@ export default async function asaasWebhookRoutes(app: FastifyInstance) {
                   : undefined
                 const fixedDay = contractFixedDay ?? tenantFixedDay
 
-                await scheduleRepasse(app.prisma as any, {
+                // Rateia entre os beneficiários do contrato (RepasseBeneficiary).
+                // Sem beneficiários cadastrados, cai em 1 repasse de 100% para
+                // contract.landlordId (comportamento histórico preservado).
+                await scheduleRepasseWithSplit(app.prisma as any, {
                   tenantId: tenant?.id || undefined,
                   companyId: contract.companyId,
                   contractId: rental.contractId ?? undefined,
                   rentalId,
-                  landlordId: contract.landlordId,
+                  fallbackLandlordId: contract.landlordId,
+                  fallbackLandlordName: contract.landlordName ?? undefined,
                   grossValue: payment.value,
                   commissionPercent,
                   delayDays,

--- a/apps/api/src/routes/iptu/index.ts
+++ b/apps/api/src/routes/iptu/index.ts
@@ -11,15 +11,18 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { requirePermission } from '../../utils/permissions.js'
 import { z } from 'zod'
 import { generateInstallmentPlan } from '../../services/agreement.service.js'
 
 export default async function iptuRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  const canView = requirePermission('iptu', 'view')
+  const canEdit = requirePermission('iptu', 'edit')
   const db = () => app.prisma as any
 
   // POST / — cria carnê e gera parcelas
-  app.post('/', { schema: { tags: ['iptu'], summary: 'Create IPTU carnê with installments' } }, async (req, reply) => {
+  app.post('/', { preHandler: canEdit, schema: { tags: ['iptu'], summary: 'Create IPTU carnê with installments' } }, async (req, reply) => {
     const b = z.object({
       propertyId: z.string().optional(),
       contractId: z.string().optional(),
@@ -58,7 +61,7 @@ export default async function iptuRoutes(app: FastifyInstance) {
   })
 
   // GET / — lista carnês
-  app.get('/', { schema: { tags: ['iptu'], summary: 'List IPTU carnês' } }, async (req, reply) => {
+  app.get('/', { preHandler: canView, schema: { tags: ['iptu'], summary: 'List IPTU carnês' } }, async (req, reply) => {
     const q = req.query as any
     const where: any = { companyId: req.user.cid }
     if (q.propertyId) where.propertyId = q.propertyId
@@ -69,7 +72,7 @@ export default async function iptuRoutes(app: FastifyInstance) {
   })
 
   // GET /:id — carnê + parcelas
-  app.get('/:id', { schema: { tags: ['iptu'], summary: 'Get IPTU carnê' } }, async (req, reply) => {
+  app.get('/:id', { preHandler: canView, schema: { tags: ['iptu'], summary: 'Get IPTU carnê' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const row = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, include: { schedule: { orderBy: { number: 'asc' } } } })
     if (!row) return reply.status(404).send({ error: 'NOT_FOUND' })
@@ -77,7 +80,7 @@ export default async function iptuRoutes(app: FastifyInstance) {
   })
 
   // POST /:id/installments/:number/pay
-  app.post('/:id/installments/:number/pay', { schema: { tags: ['iptu'], summary: 'Pay IPTU installment' } }, async (req, reply) => {
+  app.post('/:id/installments/:number/pay', { preHandler: canEdit, schema: { tags: ['iptu'], summary: 'Pay IPTU installment' } }, async (req, reply) => {
     const { id, number } = req.params as { id: string; number: string }
     const carne = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, select: { id: true, status: true } })
     if (!carne) return reply.status(404).send({ error: 'NOT_FOUND' })
@@ -96,7 +99,7 @@ export default async function iptuRoutes(app: FastifyInstance) {
   })
 
   // POST /:id/cancel
-  app.post('/:id/cancel', { schema: { tags: ['iptu'], summary: 'Cancel IPTU carnê' } }, async (req, reply) => {
+  app.post('/:id/cancel', { preHandler: canEdit, schema: { tags: ['iptu'], summary: 'Cancel IPTU carnê' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const carne = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, select: { id: true } })
     if (!carne) return reply.status(404).send({ error: 'NOT_FOUND' })

--- a/apps/api/src/routes/iptu/index.ts
+++ b/apps/api/src/routes/iptu/index.ts
@@ -1,0 +1,106 @@
+/**
+ * IPTU Carnê Routes — Carnê de IPTU parcelado (Uniloc iptu/lanciptu)
+ *
+ *   POST /api/v1/iptu                          — cria carnê + gera parcelas
+ *   GET  /api/v1/iptu                           — lista (filtros: propertyId, year, status)
+ *   GET  /api/v1/iptu/:id                        — carnê + parcelas
+ *   POST /api/v1/iptu/:id/installments/:n/pay    — paga uma parcela (fecha o carnê se todas pagas)
+ *   POST /api/v1/iptu/:id/cancel                 — cancela carnê
+ *
+ * O cronograma de parcelas reaproveita `generateInstallmentPlan` (acordos).
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { generateInstallmentPlan } from '../../services/agreement.service.js'
+
+export default async function iptuRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  // POST / — cria carnê e gera parcelas
+  app.post('/', { schema: { tags: ['iptu'], summary: 'Create IPTU carnê with installments' } }, async (req, reply) => {
+    const b = z.object({
+      propertyId: z.string().optional(),
+      contractId: z.string().optional(),
+      year: z.number().int().min(2000).max(2100),
+      iptuCode: z.string().optional(),
+      totalAmount: z.number().positive(),
+      installments: z.number().int().min(1).max(24),
+      firstDueDate: z.string(),
+      chargeToTenant: z.boolean().default(true),
+      notes: z.string().optional(),
+    }).parse(req.body)
+
+    const plan = generateInstallmentPlan({
+      agreedValue: b.totalAmount,
+      installments: b.installments,
+      firstDueDate: new Date(b.firstDueDate),
+    })
+
+    const created = await db().iptuCarne.create({
+      data: {
+        companyId: req.user.cid,
+        propertyId: b.propertyId ?? null,
+        contractId: b.contractId ?? null,
+        year: b.year,
+        iptuCode: b.iptuCode ?? null,
+        totalAmount: b.totalAmount,
+        installments: b.installments,
+        chargeToTenant: b.chargeToTenant,
+        notes: b.notes ?? null,
+        createdBy: req.user.sub ?? null,
+        schedule: { create: plan.map((p) => ({ number: p.number, dueDate: new Date(p.dueDate), amount: p.amount })) },
+      },
+      include: { schedule: { orderBy: { number: 'asc' } } },
+    })
+    return reply.status(201).send({ success: true, data: created })
+  })
+
+  // GET / — lista carnês
+  app.get('/', { schema: { tags: ['iptu'], summary: 'List IPTU carnês' } }, async (req, reply) => {
+    const q = req.query as any
+    const where: any = { companyId: req.user.cid }
+    if (q.propertyId) where.propertyId = q.propertyId
+    if (q.year) where.year = parseInt(q.year)
+    if (q.status) where.status = q.status
+    const rows = await db().iptuCarne.findMany({ where, orderBy: [{ year: 'desc' }, { createdAt: 'desc' }], include: { schedule: { orderBy: { number: 'asc' } } }, take: 200 })
+    return reply.send({ success: true, data: rows })
+  })
+
+  // GET /:id — carnê + parcelas
+  app.get('/:id', { schema: { tags: ['iptu'], summary: 'Get IPTU carnê' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const row = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, include: { schedule: { orderBy: { number: 'asc' } } } })
+    if (!row) return reply.status(404).send({ error: 'NOT_FOUND' })
+    return reply.send({ success: true, data: row })
+  })
+
+  // POST /:id/installments/:number/pay
+  app.post('/:id/installments/:number/pay', { schema: { tags: ['iptu'], summary: 'Pay IPTU installment' } }, async (req, reply) => {
+    const { id, number } = req.params as { id: string; number: string }
+    const carne = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, select: { id: true, status: true } })
+    if (!carne) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (carne.status === 'CANCELLED') return reply.status(409).send({ error: 'CANCELLED' })
+
+    const inst = await db().iptuInstallment.findFirst({ where: { carneId: id, number: parseInt(number) } })
+    if (!inst) return reply.status(404).send({ error: 'INSTALLMENT_NOT_FOUND' })
+
+    await db().iptuInstallment.update({ where: { id: inst.id }, data: { status: 'PAID', paidAt: new Date() } })
+
+    const pending = await db().iptuInstallment.count({ where: { carneId: id, status: { not: 'PAID' } } })
+    if (pending === 0) await db().iptuCarne.update({ where: { id }, data: { status: 'SETTLED' } })
+
+    const updated = await db().iptuCarne.findFirst({ where: { id }, include: { schedule: { orderBy: { number: 'asc' } } } })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // POST /:id/cancel
+  app.post('/:id/cancel', { schema: { tags: ['iptu'], summary: 'Cancel IPTU carnê' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const carne = await db().iptuCarne.findFirst({ where: { id, companyId: req.user.cid }, select: { id: true } })
+    if (!carne) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().iptuCarne.update({ where: { id }, data: { status: 'CANCELLED' } })
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/notices/index.ts
+++ b/apps/api/src/routes/notices/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { requirePermission } from '../../utils/permissions.js'
 import { z } from 'zod'
 
 const TYPES = ['AVISO_COBRANCA', 'EXTRAJUDICIAL', 'DESPEJO', 'REAJUSTE', 'RENOVACAO', 'OUTRO'] as const
@@ -17,9 +18,11 @@ const RECIPIENTS = ['TENANT', 'LANDLORD', 'OTHER'] as const
 
 export default async function noticesRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  const canView = requirePermission('notices', 'view')
+  const canEdit = requirePermission('notices', 'edit')
   const db = () => app.prisma as any
 
-  app.get('/', { schema: { tags: ['notices'], summary: 'List formal notices' } }, async (req, reply) => {
+  app.get('/', { preHandler: canView, schema: { tags: ['notices'], summary: 'List formal notices' } }, async (req, reply) => {
     const q = req.query as any
     const where: any = { companyId: req.user.cid }
     if (q.status) where.status = q.status
@@ -29,7 +32,7 @@ export default async function noticesRoutes(app: FastifyInstance) {
     return reply.send({ success: true, data: rows })
   })
 
-  app.post('/', { schema: { tags: ['notices'], summary: 'Create formal notice' } }, async (req, reply) => {
+  app.post('/', { preHandler: canEdit, schema: { tags: ['notices'], summary: 'Create formal notice' } }, async (req, reply) => {
     const b = z.object({
       contractId: z.string().optional(),
       recipient: z.enum(RECIPIENTS).default('TENANT'),
@@ -61,7 +64,7 @@ export default async function noticesRoutes(app: FastifyInstance) {
     return reply.status(201).send({ success: true, data: created })
   })
 
-  app.patch('/:id', { schema: { tags: ['notices'], summary: 'Update formal notice' } }, async (req, reply) => {
+  app.patch('/:id', { preHandler: canEdit, schema: { tags: ['notices'], summary: 'Update formal notice' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
     if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
@@ -83,7 +86,7 @@ export default async function noticesRoutes(app: FastifyInstance) {
     return reply.send({ success: true, data: updated })
   })
 
-  app.post('/:id/send', { schema: { tags: ['notices'], summary: 'Mark notice as sent' } }, async (req, reply) => {
+  app.post('/:id/send', { preHandler: canEdit, schema: { tags: ['notices'], summary: 'Mark notice as sent' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
     if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
@@ -91,7 +94,7 @@ export default async function noticesRoutes(app: FastifyInstance) {
     return reply.send({ success: true, data: updated })
   })
 
-  app.post('/:id/resolve', { schema: { tags: ['notices'], summary: 'Resolve notice' } }, async (req, reply) => {
+  app.post('/:id/resolve', { preHandler: canEdit, schema: { tags: ['notices'], summary: 'Resolve notice' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
     if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
@@ -99,7 +102,7 @@ export default async function noticesRoutes(app: FastifyInstance) {
     return reply.send({ success: true, data: updated })
   })
 
-  app.delete('/:id', { schema: { tags: ['notices'], summary: 'Cancel notice' } }, async (req, reply) => {
+  app.delete('/:id', { preHandler: canEdit, schema: { tags: ['notices'], summary: 'Cancel notice' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
     if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })

--- a/apps/api/src/routes/notices/index.ts
+++ b/apps/api/src/routes/notices/index.ts
@@ -1,0 +1,109 @@
+/**
+ * Formal Notices Routes — Notificações formais/extrajudiciais (Uniloc notifics)
+ *
+ *   GET    /api/v1/notices                 — lista (filtros: status, type, contractId)
+ *   POST   /api/v1/notices                 — cria notificação
+ *   PATCH  /api/v1/notices/:id             — atualiza
+ *   POST   /api/v1/notices/:id/send        — marca como enviada
+ *   POST   /api/v1/notices/:id/resolve     — marca como resolvida
+ *   DELETE /api/v1/notices/:id             — cancela
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+
+const TYPES = ['AVISO_COBRANCA', 'EXTRAJUDICIAL', 'DESPEJO', 'REAJUSTE', 'RENOVACAO', 'OUTRO'] as const
+const RECIPIENTS = ['TENANT', 'LANDLORD', 'OTHER'] as const
+
+export default async function noticesRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  app.get('/', { schema: { tags: ['notices'], summary: 'List formal notices' } }, async (req, reply) => {
+    const q = req.query as any
+    const where: any = { companyId: req.user.cid }
+    if (q.status) where.status = q.status
+    if (q.type) where.type = q.type
+    if (q.contractId) where.contractId = q.contractId
+    const rows = await db().formalNotice.findMany({ where, orderBy: { noticeDate: 'desc' }, take: 200 })
+    return reply.send({ success: true, data: rows })
+  })
+
+  app.post('/', { schema: { tags: ['notices'], summary: 'Create formal notice' } }, async (req, reply) => {
+    const b = z.object({
+      contractId: z.string().optional(),
+      recipient: z.enum(RECIPIENTS).default('TENANT'),
+      recipientName: z.string().optional(),
+      type: z.enum(TYPES),
+      subject: z.string().min(1),
+      body: z.string().optional(),
+      noticeDate: z.string().optional(),
+    }).parse(req.body)
+
+    if (b.contractId) {
+      const c = await app.prisma.contract.findFirst({ where: { id: b.contractId, companyId: req.user.cid }, select: { id: true } })
+      if (!c) return reply.status(404).send({ error: 'CONTRACT_NOT_FOUND' })
+    }
+
+    const created = await db().formalNotice.create({
+      data: {
+        companyId: req.user.cid,
+        contractId: b.contractId ?? null,
+        recipient: b.recipient,
+        recipientName: b.recipientName ?? null,
+        type: b.type,
+        subject: b.subject,
+        body: b.body ?? null,
+        noticeDate: b.noticeDate ? new Date(b.noticeDate) : new Date(),
+        operator: req.user.sub ?? null,
+      },
+    })
+    return reply.status(201).send({ success: true, data: created })
+  })
+
+  app.patch('/:id', { schema: { tags: ['notices'], summary: 'Update formal notice' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const b = z.object({
+      subject: z.string().min(1).optional(),
+      body: z.string().optional(),
+      type: z.enum(TYPES).optional(),
+      recipientName: z.string().optional(),
+    }).parse(req.body)
+    const updated = await db().formalNotice.update({
+      where: { id },
+      data: {
+        ...(b.subject !== undefined ? { subject: b.subject } : {}),
+        ...(b.body !== undefined ? { body: b.body } : {}),
+        ...(b.type !== undefined ? { type: b.type } : {}),
+        ...(b.recipientName !== undefined ? { recipientName: b.recipientName } : {}),
+      },
+    })
+    return reply.send({ success: true, data: updated })
+  })
+
+  app.post('/:id/send', { schema: { tags: ['notices'], summary: 'Mark notice as sent' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().formalNotice.update({ where: { id }, data: { status: 'SENT' } })
+    return reply.send({ success: true, data: updated })
+  })
+
+  app.post('/:id/resolve', { schema: { tags: ['notices'], summary: 'Resolve notice' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().formalNotice.update({ where: { id }, data: { status: 'RESOLVED', resolvedAt: new Date() } })
+    return reply.send({ success: true, data: updated })
+  })
+
+  app.delete('/:id', { schema: { tags: ['notices'], summary: 'Cancel notice' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().formalNotice.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().formalNotice.update({ where: { id }, data: { status: 'CANCELLED' } })
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/payables/index.ts
+++ b/apps/api/src/routes/payables/index.ts
@@ -20,19 +20,24 @@
 
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
+import { requirePermission } from '../../utils/permissions.js'
 
 const PAYABLE_STATUS = ['PENDING', 'PAID', 'CANCELLED'] as const
 const CHECK_STATUS = ['PENDING', 'CLEARED', 'CANCELLED'] as const
 
 export default async function payablesRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  // Enforcement de permissão por módulo: leitura exige 'view', escrita 'edit'.
+  // Opt-in: usuários sem permissões cadastradas continuam liberados.
+  const canView = requirePermission('payables', 'view')
+  const canEdit = requirePermission('payables', 'edit')
   const db = () => app.prisma as any
 
   // ── Contas a Pagar ────────────────────────────────────────────────────────
 
   // GET / — lista contas a pagar
   app.get('/', {
-    schema: { tags: ['payables'], summary: 'List accounts payable' },
+    preHandler: canView, schema: { tags: ['payables'], summary: 'List accounts payable' },
   }, async (req, reply) => {
     const q = req.query as any
     const where: any = { companyId: req.user.cid }
@@ -61,7 +66,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // GET /summary — totais por status
   app.get('/summary', {
-    schema: { tags: ['payables'], summary: 'Accounts payable summary' },
+    preHandler: canView, schema: { tags: ['payables'], summary: 'Accounts payable summary' },
   }, async (req, reply) => {
     const companyId = req.user.cid
     const now = new Date()
@@ -91,7 +96,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // POST / — cria conta a pagar
   app.post('/', {
-    schema: { tags: ['payables'], summary: 'Create account payable' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Create account payable' },
   }, async (req, reply) => {
     const body = z.object({
       description: z.string().min(1),
@@ -129,7 +134,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // PATCH /:id — atualiza campos editáveis
   app.patch('/:id', {
-    schema: { tags: ['payables'], summary: 'Update account payable' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Update account payable' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
@@ -164,7 +169,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // POST /:id/pay — marca como paga
   app.post('/:id/pay', {
-    schema: { tags: ['payables'], summary: 'Mark account payable as paid' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Mark account payable as paid' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
@@ -191,7 +196,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // DELETE /:id — cancela (não apaga, mantém histórico)
   app.delete('/:id', {
-    schema: { tags: ['payables'], summary: 'Cancel account payable' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Cancel account payable' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
@@ -204,7 +209,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // GET /checks — lista cheques
   app.get('/checks', {
-    schema: { tags: ['payables'], summary: 'List bank checks' },
+    preHandler: canView, schema: { tags: ['payables'], summary: 'List bank checks' },
   }, async (req, reply) => {
     const q = req.query as any
     const where: any = { companyId: req.user.cid }
@@ -215,7 +220,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // POST /checks — cria cheque (opcionalmente vinculado a uma conta a pagar)
   app.post('/checks', {
-    schema: { tags: ['payables'], summary: 'Create bank check' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Create bank check' },
   }, async (req, reply) => {
     const body = z.object({
       checkNumber: z.string().min(1),
@@ -257,7 +262,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // POST /checks/:id/clear — compensa cheque
   app.post('/checks/:id/clear', {
-    schema: { tags: ['payables'], summary: 'Clear bank check' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Clear bank check' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().bankCheck.findFirst({ where: { id, companyId: req.user.cid } })
@@ -271,7 +276,7 @@ export default async function payablesRoutes(app: FastifyInstance) {
 
   // POST /checks/:id/cancel — cancela cheque
   app.post('/checks/:id/cancel', {
-    schema: { tags: ['payables'], summary: 'Cancel bank check' },
+    preHandler: canEdit, schema: { tags: ['payables'], summary: 'Cancel bank check' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const existing = await db().bankCheck.findFirst({ where: { id, companyId: req.user.cid } })

--- a/apps/api/src/routes/payables/index.ts
+++ b/apps/api/src/routes/payables/index.ts
@@ -1,0 +1,282 @@
+/**
+ * Payables Routes — Contas a Pagar + Cheques
+ *
+ * Financeiro interno da imobiliária (equivalente Uniloc cadespe/cp_cheqs).
+ *
+ * Contas a pagar:
+ *   GET    /api/v1/payables                 — lista (filtros: status, vencidas, período)
+ *   GET    /api/v1/payables/summary         — totais por status
+ *   POST   /api/v1/payables                 — cria conta a pagar
+ *   PATCH  /api/v1/payables/:id             — atualiza
+ *   POST   /api/v1/payables/:id/pay         — marca como paga
+ *   DELETE /api/v1/payables/:id             — cancela (status CANCELLED)
+ *
+ * Cheques:
+ *   GET    /api/v1/payables/checks          — lista cheques
+ *   POST   /api/v1/payables/checks          — cria cheque
+ *   POST   /api/v1/payables/checks/:id/clear — compensa cheque
+ *   POST   /api/v1/payables/checks/:id/cancel — cancela cheque
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+
+const PAYABLE_STATUS = ['PENDING', 'PAID', 'CANCELLED'] as const
+const CHECK_STATUS = ['PENDING', 'CLEARED', 'CANCELLED'] as const
+
+export default async function payablesRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  // ── Contas a Pagar ────────────────────────────────────────────────────────
+
+  // GET / — lista contas a pagar
+  app.get('/', {
+    schema: { tags: ['payables'], summary: 'List accounts payable' },
+  }, async (req, reply) => {
+    const q = req.query as any
+    const where: any = { companyId: req.user.cid }
+    if (q.status && (PAYABLE_STATUS as readonly string[]).includes(q.status)) where.status = q.status
+    if (q.overdue === 'true') {
+      where.status = 'PENDING'
+      where.dueDate = { lt: new Date() }
+    }
+    if (q.from || q.to) {
+      where.dueDate = {
+        ...(where.dueDate ?? {}),
+        ...(q.from ? { gte: new Date(q.from) } : {}),
+        ...(q.to ? { lte: new Date(q.to) } : {}),
+      }
+    }
+    const page = Math.max(1, parseInt(q.page ?? '1'))
+    const limit = Math.min(200, Math.max(1, parseInt(q.limit ?? '50')))
+    const [items, total] = await Promise.all([
+      db().accountPayable.findMany({
+        where, orderBy: { dueDate: 'asc' }, skip: (page - 1) * limit, take: limit,
+      }),
+      db().accountPayable.count({ where }),
+    ])
+    return reply.send({ success: true, data: { items, total, page, limit } })
+  })
+
+  // GET /summary — totais por status
+  app.get('/summary', {
+    schema: { tags: ['payables'], summary: 'Accounts payable summary' },
+  }, async (req, reply) => {
+    const companyId = req.user.cid
+    const now = new Date()
+    const grouped = await db().accountPayable.groupBy({
+      by: ['status'],
+      where: { companyId },
+      _sum: { amount: true },
+      _count: { _all: true },
+    })
+    const overdue = await db().accountPayable.aggregate({
+      where: { companyId, status: 'PENDING', dueDate: { lt: now } },
+      _sum: { amount: true },
+      _count: { _all: true },
+    })
+    return reply.send({
+      success: true,
+      data: {
+        byStatus: grouped.map((g: any) => ({
+          status: g.status,
+          total: Number(g._sum.amount ?? 0),
+          count: g._count._all,
+        })),
+        overdue: { total: Number(overdue._sum.amount ?? 0), count: overdue._count._all },
+      },
+    })
+  })
+
+  // POST / — cria conta a pagar
+  app.post('/', {
+    schema: { tags: ['payables'], summary: 'Create account payable' },
+  }, async (req, reply) => {
+    const body = z.object({
+      description: z.string().min(1),
+      payeeName: z.string().min(1),
+      payeeId: z.string().optional(),
+      category: z.string().optional(),
+      documentNumber: z.string().optional(),
+      amount: z.number().positive(),
+      dueDate: z.string(),
+      paymentMethod: z.string().optional(),
+      contractId: z.string().optional(),
+      propertyId: z.string().optional(),
+      notes: z.string().optional(),
+    }).parse(req.body)
+
+    const created = await db().accountPayable.create({
+      data: {
+        companyId: req.user.cid,
+        description: body.description,
+        payeeName: body.payeeName,
+        payeeId: body.payeeId ?? null,
+        category: body.category ?? null,
+        documentNumber: body.documentNumber ?? null,
+        amount: body.amount,
+        dueDate: new Date(body.dueDate),
+        paymentMethod: body.paymentMethod ?? null,
+        contractId: body.contractId ?? null,
+        propertyId: body.propertyId ?? null,
+        notes: body.notes ?? null,
+        createdBy: req.user.sub ?? null,
+      },
+    })
+    return reply.status(201).send({ success: true, data: created })
+  })
+
+  // PATCH /:id — atualiza campos editáveis
+  app.patch('/:id', {
+    schema: { tags: ['payables'], summary: 'Update account payable' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const body = z.object({
+      description: z.string().min(1).optional(),
+      payeeName: z.string().min(1).optional(),
+      category: z.string().optional(),
+      documentNumber: z.string().optional(),
+      amount: z.number().positive().optional(),
+      dueDate: z.string().optional(),
+      paymentMethod: z.string().optional(),
+      notes: z.string().optional(),
+    }).parse(req.body)
+
+    const updated = await db().accountPayable.update({
+      where: { id },
+      data: {
+        ...(body.description !== undefined ? { description: body.description } : {}),
+        ...(body.payeeName !== undefined ? { payeeName: body.payeeName } : {}),
+        ...(body.category !== undefined ? { category: body.category } : {}),
+        ...(body.documentNumber !== undefined ? { documentNumber: body.documentNumber } : {}),
+        ...(body.amount !== undefined ? { amount: body.amount } : {}),
+        ...(body.dueDate !== undefined ? { dueDate: new Date(body.dueDate) } : {}),
+        ...(body.paymentMethod !== undefined ? { paymentMethod: body.paymentMethod } : {}),
+        ...(body.notes !== undefined ? { notes: body.notes } : {}),
+      },
+    })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // POST /:id/pay — marca como paga
+  app.post('/:id/pay', {
+    schema: { tags: ['payables'], summary: 'Mark account payable as paid' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (existing.status === 'CANCELLED') return reply.status(409).send({ error: 'CANCELLED' })
+
+    const body = z.object({
+      paidAt: z.string().optional(),
+      paymentDoc: z.string().optional(),
+      paymentMethod: z.string().optional(),
+    }).parse(req.body ?? {})
+
+    const updated = await db().accountPayable.update({
+      where: { id },
+      data: {
+        status: 'PAID',
+        paidAt: body.paidAt ? new Date(body.paidAt) : new Date(),
+        ...(body.paymentDoc !== undefined ? { paymentDoc: body.paymentDoc } : {}),
+        ...(body.paymentMethod !== undefined ? { paymentMethod: body.paymentMethod } : {}),
+      },
+    })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // DELETE /:id — cancela (não apaga, mantém histórico)
+  app.delete('/:id', {
+    schema: { tags: ['payables'], summary: 'Cancel account payable' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().accountPayable.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().accountPayable.update({ where: { id }, data: { status: 'CANCELLED' } })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // ── Cheques ────────────────────────────────────────────────────────────────
+
+  // GET /checks — lista cheques
+  app.get('/checks', {
+    schema: { tags: ['payables'], summary: 'List bank checks' },
+  }, async (req, reply) => {
+    const q = req.query as any
+    const where: any = { companyId: req.user.cid }
+    if (q.status && (CHECK_STATUS as readonly string[]).includes(q.status)) where.status = q.status
+    const checks = await db().bankCheck.findMany({ where, orderBy: { dueDate: 'asc' }, take: 200 })
+    return reply.send({ success: true, data: checks })
+  })
+
+  // POST /checks — cria cheque (opcionalmente vinculado a uma conta a pagar)
+  app.post('/checks', {
+    schema: { tags: ['payables'], summary: 'Create bank check' },
+  }, async (req, reply) => {
+    const body = z.object({
+      checkNumber: z.string().min(1),
+      amount: z.number().positive(),
+      bankCode: z.string().optional(),
+      payeeName: z.string().optional(),
+      category: z.string().optional(),
+      issueDate: z.string().optional(),
+      dueDate: z.string().optional(),
+      accountPayableId: z.string().optional(),
+      notes: z.string().optional(),
+    }).parse(req.body)
+
+    // Se vinculado a conta a pagar, garante que pertence à mesma empresa.
+    if (body.accountPayableId) {
+      const ap = await db().accountPayable.findFirst({
+        where: { id: body.accountPayableId, companyId: req.user.cid },
+        select: { id: true },
+      })
+      if (!ap) return reply.status(404).send({ error: 'ACCOUNT_PAYABLE_NOT_FOUND' })
+    }
+
+    const created = await db().bankCheck.create({
+      data: {
+        companyId: req.user.cid,
+        checkNumber: body.checkNumber,
+        amount: body.amount,
+        bankCode: body.bankCode ?? null,
+        payeeName: body.payeeName ?? null,
+        category: body.category ?? null,
+        issueDate: body.issueDate ? new Date(body.issueDate) : null,
+        dueDate: body.dueDate ? new Date(body.dueDate) : null,
+        accountPayableId: body.accountPayableId ?? null,
+        notes: body.notes ?? null,
+      },
+    })
+    return reply.status(201).send({ success: true, data: created })
+  })
+
+  // POST /checks/:id/clear — compensa cheque
+  app.post('/checks/:id/clear', {
+    schema: { tags: ['payables'], summary: 'Clear bank check' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().bankCheck.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (existing.status === 'CANCELLED') return reply.status(409).send({ error: 'CANCELLED' })
+    const updated = await db().bankCheck.update({
+      where: { id }, data: { status: 'CLEARED', clearedAt: new Date() },
+    })
+    return reply.send({ success: true, data: updated })
+  })
+
+  // POST /checks/:id/cancel — cancela cheque
+  app.post('/checks/:id/cancel', {
+    schema: { tags: ['payables'], summary: 'Cancel bank check' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().bankCheck.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().bankCheck.update({ where: { id }, data: { status: 'CANCELLED' } })
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/permissions/index.ts
+++ b/apps/api/src/routes/permissions/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Permissions Routes — Permissões granulares por módulo (Uniloc U_MODULO*)
+ *
+ *   GET  /api/v1/permissions/users/:userId  — permissões de um usuário
+ *   PUT  /api/v1/permissions/users/:userId  — substitui as permissões do usuário
+ *   GET  /api/v1/permissions/modules         — módulos disponíveis
+ *
+ * Apenas ADMIN/SUPER_ADMIN podem gerenciar permissões.
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+
+/** Módulos conhecidos do sistema (para a UI de permissões). */
+export const MODULES = [
+  'properties', 'contracts', 'clients', 'leads', 'finance', 'payables',
+  'repasse', 'rescission', 'agreements', 'reconciliation', 'notices',
+  'reports', 'settings', 'users',
+] as const
+
+export default async function permissionsRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  function isAdmin(role: string) {
+    return role === 'SUPER_ADMIN' || role === 'ADMIN'
+  }
+
+  // GET /modules — lista de módulos conhecidos
+  app.get('/modules', { schema: { tags: ['permissions'], summary: 'List known modules' } }, async (_req, reply) => {
+    return reply.send({ success: true, data: MODULES })
+  })
+
+  // GET /users/:userId — permissões do usuário (escopo da empresa)
+  app.get('/users/:userId', { schema: { tags: ['permissions'], summary: 'Get user permissions' } }, async (req, reply) => {
+    if (!isAdmin(req.user.role)) return reply.status(403).send({ error: 'FORBIDDEN' })
+    const { userId } = req.params as { userId: string }
+    const user = await app.prisma.user.findFirst({ where: { id: userId, companyId: req.user.cid }, select: { id: true } })
+    if (!user) return reply.status(404).send({ error: 'USER_NOT_FOUND' })
+    const perms = await db().userModulePermission.findMany({ where: { userId, companyId: req.user.cid } })
+    return reply.send({ success: true, data: perms })
+  })
+
+  // PUT /users/:userId — substitui o conjunto de permissões do usuário
+  app.put('/users/:userId', { schema: { tags: ['permissions'], summary: 'Replace user permissions' } }, async (req, reply) => {
+    if (!isAdmin(req.user.role)) return reply.status(403).send({ error: 'FORBIDDEN' })
+    const { userId } = req.params as { userId: string }
+    const user = await app.prisma.user.findFirst({ where: { id: userId, companyId: req.user.cid }, select: { id: true } })
+    if (!user) return reply.status(404).send({ error: 'USER_NOT_FOUND' })
+
+    const b = z.object({
+      permissions: z.array(z.object({
+        module: z.string().min(1),
+        canView: z.boolean().default(true),
+        canEdit: z.boolean().default(false),
+        canDelete: z.boolean().default(false),
+      })),
+    }).parse(req.body)
+
+    const saved = await app.prisma.$transaction(async (tx: any) => {
+      await tx.userModulePermission.deleteMany({ where: { userId, companyId: req.user.cid } })
+      if (b.permissions.length === 0) return []
+      await tx.userModulePermission.createMany({
+        data: b.permissions.map((p) => ({
+          companyId: req.user.cid,
+          userId,
+          module: p.module,
+          canView: p.canView,
+          canEdit: p.canEdit,
+          canDelete: p.canDelete,
+        })),
+      })
+      return tx.userModulePermission.findMany({ where: { userId, companyId: req.user.cid } })
+    })
+    return reply.send({ success: true, data: saved })
+  })
+}

--- a/apps/api/src/routes/permissions/index.ts
+++ b/apps/api/src/routes/permissions/index.ts
@@ -14,7 +14,7 @@ import { z } from 'zod'
 /** Módulos conhecidos do sistema (para a UI de permissões). */
 export const MODULES = [
   'properties', 'contracts', 'clients', 'leads', 'finance', 'payables',
-  'repasse', 'rescission', 'agreements', 'reconciliation', 'notices',
+  'repasse', 'rescission', 'agreements', 'reconciliation', 'notices', 'iptu',
   'reports', 'settings', 'users',
 ] as const
 

--- a/apps/api/src/routes/reconciliation/index.ts
+++ b/apps/api/src/routes/reconciliation/index.ts
@@ -1,0 +1,174 @@
+/**
+ * Reconciliation Routes — Conciliação bancária (extrato / CNAB retorno)
+ *
+ *   POST /api/v1/reconciliation/import   — importa entradas (CSV/CNAB400/JSON),
+ *                                          concilia contra aluguéis em aberto
+ *                                          e (opcional) dá baixa nos conciliados.
+ *   GET  /api/v1/reconciliation          — lista lotes de conciliação
+ *   GET  /api/v1/reconciliation/:id      — lote + entradas
+ *   POST /api/v1/reconciliation/entries/:id/match — concilia manualmente uma entrada
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import {
+  parseCsvStatement,
+  parseCnab400Return,
+  matchEntries,
+  type ParsedEntry,
+  type MatchCandidate,
+} from '../../services/reconciliation.service.js'
+
+export default async function reconciliationRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  // POST /import — importa + concilia
+  app.post('/import', {
+    schema: { tags: ['reconciliation'], summary: 'Import statement and reconcile' },
+  }, async (req, reply) => {
+    const b = z.object({
+      source: z.enum(['CSV', 'CNAB400', 'JSON']),
+      reference: z.string().optional(),
+      bankCode: z.string().optional(),
+      content: z.string().optional(), // para CSV/CNAB400
+      delimiter: z.string().optional(),
+      entries: z.array(z.object({ // para JSON
+        entryDate: z.string(),
+        amount: z.number(),
+        direction: z.enum(['CREDIT', 'DEBIT']).optional(),
+        description: z.string().optional(),
+        nossoNumero: z.string().optional(),
+        documentNumber: z.string().optional(),
+        occurrenceCode: z.string().optional(),
+      })).optional(),
+      autoSettle: z.boolean().default(false), // dá baixa nos aluguéis conciliados
+    }).parse(req.body)
+
+    // 1. Parse das entradas conforme a origem.
+    let parsed: ParsedEntry[] = []
+    if (b.source === 'CSV') {
+      if (!b.content) return reply.status(400).send({ error: 'MISSING_CONTENT' })
+      parsed = parseCsvStatement(b.content, b.delimiter ?? ',')
+    } else if (b.source === 'CNAB400') {
+      if (!b.content) return reply.status(400).send({ error: 'MISSING_CONTENT' })
+      parsed = parseCnab400Return(b.content)
+    } else {
+      parsed = (b.entries ?? []).map((e) => ({
+        ...e,
+        direction: e.direction ?? 'CREDIT',
+        amount: Math.abs(e.amount),
+      }))
+    }
+    if (parsed.length === 0) return reply.status(400).send({ error: 'NO_ENTRIES_PARSED' })
+
+    // 2. Candidatos = aluguéis em aberto da empresa.
+    const openRentals = await db().rental.findMany({
+      where: { companyId: req.user.cid, status: { in: ['PENDING', 'LATE'] } },
+      select: { id: true, boletoNumber: true, totalAmount: true, rentAmount: true, dueDate: true },
+      take: 5000,
+    })
+    const candidates: MatchCandidate[] = openRentals.map((r: any) => ({
+      rentalId: r.id,
+      nossoNumero: r.boletoNumber ?? undefined,
+      amount: Number(r.totalAmount ?? r.rentAmount ?? 0),
+      dueDate: r.dueDate ? new Date(r.dueDate).toISOString().slice(0, 10) : undefined,
+    }))
+
+    // 3. Matching (puro).
+    const matched = matchEntries(parsed, candidates)
+    const matchedCount = matched.filter((m) => m.matchStatus === 'MATCHED').length
+
+    // 4. Persiste o lote + entradas.
+    const recon = await db().bankReconciliation.create({
+      data: {
+        companyId: req.user.cid,
+        source: b.source,
+        reference: b.reference ?? null,
+        bankCode: b.bankCode ?? null,
+        totalEntries: matched.length,
+        matchedCount,
+        unmatchedCount: matched.length - matchedCount,
+        status: matchedCount === matched.length ? 'RECONCILED' : matchedCount > 0 ? 'PARTIAL' : 'IMPORTED',
+        createdBy: req.user.sub ?? null,
+        entries: {
+          create: matched.map((m) => ({
+            companyId: req.user.cid,
+            entryDate: new Date(m.entryDate),
+            amount: m.amount,
+            direction: m.direction,
+            description: m.description ?? null,
+            nossoNumero: m.nossoNumero ?? null,
+            documentNumber: m.documentNumber ?? null,
+            occurrenceCode: m.occurrenceCode ?? null,
+            matchStatus: m.matchStatus,
+            matchedRentalId: m.matchedRentalId ?? null,
+            matchedInvoiceId: m.matchedInvoiceId ?? null,
+          })),
+        },
+      },
+      include: { entries: true },
+    })
+
+    // 5. Baixa opcional dos aluguéis conciliados.
+    let settled = 0
+    if (b.autoSettle) {
+      for (const m of matched) {
+        if (m.matchStatus === 'MATCHED' && m.matchedRentalId) {
+          await db().rental.update({
+            where: { id: m.matchedRentalId },
+            data: {
+              status: 'PAID',
+              paidAmount: m.amount,
+              paymentDate: new Date(m.entryDate),
+              paymentMethod: 'BOLETO',
+            },
+          }).then(() => { settled++ }).catch(() => {})
+        }
+      }
+    }
+
+    return reply.status(201).send({ success: true, data: { reconciliation: recon, matchedCount, settled } })
+  })
+
+  // GET / — lista lotes
+  app.get('/', { schema: { tags: ['reconciliation'], summary: 'List reconciliation batches' } }, async (req, reply) => {
+    const rows = await db().bankReconciliation.findMany({
+      where: { companyId: req.user.cid }, orderBy: { importedAt: 'desc' }, take: 100,
+    })
+    return reply.send({ success: true, data: rows })
+  })
+
+  // GET /:id — lote + entradas
+  app.get('/:id', { schema: { tags: ['reconciliation'], summary: 'Get reconciliation with entries' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const row = await db().bankReconciliation.findFirst({
+      where: { id, companyId: req.user.cid },
+      include: { entries: { orderBy: { entryDate: 'asc' } } },
+    })
+    if (!row) return reply.status(404).send({ error: 'NOT_FOUND' })
+    return reply.send({ success: true, data: row })
+  })
+
+  // POST /entries/:id/match — concilia manualmente uma entrada a um aluguel
+  app.post('/entries/:id/match', { schema: { tags: ['reconciliation'], summary: 'Manually match an entry' } }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const b = z.object({ rentalId: z.string(), settle: z.boolean().default(false) }).parse(req.body)
+
+    const entry = await db().bankStatementEntry.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!entry) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const rental = await db().rental.findFirst({ where: { id: b.rentalId, companyId: req.user.cid }, select: { id: true } })
+    if (!rental) return reply.status(404).send({ error: 'RENTAL_NOT_FOUND' })
+
+    const updated = await db().bankStatementEntry.update({
+      where: { id }, data: { matchStatus: 'MATCHED', matchedRentalId: b.rentalId },
+    })
+    if (b.settle) {
+      await db().rental.update({
+        where: { id: b.rentalId },
+        data: { status: 'PAID', paidAmount: entry.amount, paymentDate: entry.entryDate, paymentMethod: 'BOLETO' },
+      }).catch(() => {})
+    }
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/reconciliation/index.ts
+++ b/apps/api/src/routes/reconciliation/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { requirePermission } from '../../utils/permissions.js'
 import { z } from 'zod'
 import {
   parseCsvStatement,
@@ -21,10 +22,12 @@ import {
 
 export default async function reconciliationRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  const canView = requirePermission('reconciliation', 'view')
+  const canEdit = requirePermission('reconciliation', 'edit')
   const db = () => app.prisma as any
 
   // POST /import — importa + concilia
-  app.post('/import', {
+  app.post('/import', { preHandler: canEdit,
     schema: { tags: ['reconciliation'], summary: 'Import statement and reconcile' },
   }, async (req, reply) => {
     const b = z.object({
@@ -132,7 +135,7 @@ export default async function reconciliationRoutes(app: FastifyInstance) {
   })
 
   // GET / — lista lotes
-  app.get('/', { schema: { tags: ['reconciliation'], summary: 'List reconciliation batches' } }, async (req, reply) => {
+  app.get('/', { preHandler: canView, schema: { tags: ['reconciliation'], summary: 'List reconciliation batches' } }, async (req, reply) => {
     const rows = await db().bankReconciliation.findMany({
       where: { companyId: req.user.cid }, orderBy: { importedAt: 'desc' }, take: 100,
     })
@@ -140,7 +143,7 @@ export default async function reconciliationRoutes(app: FastifyInstance) {
   })
 
   // GET /:id — lote + entradas
-  app.get('/:id', { schema: { tags: ['reconciliation'], summary: 'Get reconciliation with entries' } }, async (req, reply) => {
+  app.get('/:id', { preHandler: canView, schema: { tags: ['reconciliation'], summary: 'Get reconciliation with entries' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const row = await db().bankReconciliation.findFirst({
       where: { id, companyId: req.user.cid },
@@ -151,7 +154,7 @@ export default async function reconciliationRoutes(app: FastifyInstance) {
   })
 
   // POST /entries/:id/match — concilia manualmente uma entrada a um aluguel
-  app.post('/entries/:id/match', { schema: { tags: ['reconciliation'], summary: 'Manually match an entry' } }, async (req, reply) => {
+  app.post('/entries/:id/match', { preHandler: canEdit, schema: { tags: ['reconciliation'], summary: 'Manually match an entry' } }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const b = z.object({ rentalId: z.string(), settle: z.boolean().default(false) }).parse(req.body)
 

--- a/apps/api/src/routes/repasse/index.ts
+++ b/apps/api/src/routes/repasse/index.ts
@@ -51,6 +51,89 @@ export default async function repasseRoutes(app: FastifyInstance) {
     return reply.status(201).send({ success: true, data: repasse })
   })
 
+  // ── Rateio de repasse: beneficiários por contrato ────────────────────────
+
+  // GET /contracts/:contractId/beneficiaries — lista os beneficiários do rateio
+  app.get('/contracts/:contractId/beneficiaries', {
+    schema: { tags: ['repasse'], summary: 'List repasse split beneficiaries of a contract' },
+  }, async (req, reply) => {
+    const { contractId } = req.params as { contractId: string }
+
+    const contract = await app.prisma.contract.findFirst({
+      where: { id: contractId, companyId: req.user.cid },
+      select: { id: true },
+    })
+    if (!contract) return reply.status(404).send({ error: 'CONTRACT_NOT_FOUND' })
+
+    const beneficiaries = await (app.prisma as any).repasseBeneficiary.findMany({
+      where: { contractId },
+      orderBy: { createdAt: 'asc' },
+    })
+    return reply.send({ success: true, data: beneficiaries })
+  })
+
+  // PUT /contracts/:contractId/beneficiaries — substitui o conjunto de beneficiários
+  // (validação: a soma dos percentuais ATIVOS deve ser exatamente 100%).
+  app.put('/contracts/:contractId/beneficiaries', {
+    schema: { tags: ['repasse'], summary: 'Replace repasse split beneficiaries of a contract' },
+  }, async (req, reply) => {
+    const { contractId } = req.params as { contractId: string }
+
+    const contract = await app.prisma.contract.findFirst({
+      where: { id: contractId, companyId: req.user.cid },
+      select: { id: true },
+    })
+    if (!contract) return reply.status(404).send({ error: 'CONTRACT_NOT_FOUND' })
+
+    const body = z.object({
+      beneficiaries: z.array(z.object({
+        clientId: z.string().optional(),
+        name: z.string().min(1),
+        percentage: z.number().min(0).max(100),
+        role: z.enum(['OWNER', 'SECONDARY', 'FAVORED']).default('OWNER'),
+        bankName: z.string().optional(),
+        bankAgency: z.string().optional(),
+        bankAccount: z.string().optional(),
+        pixKey: z.string().optional(),
+        isActive: z.boolean().default(true),
+      })),
+    }).parse(req.body)
+
+    const activeSum = body.beneficiaries
+      .filter((b) => b.isActive)
+      .reduce((s, b) => s + b.percentage, 0)
+    if (body.beneficiaries.length > 0 && Math.abs(activeSum - 100) > 0.01) {
+      return reply.status(400).send({
+        error: 'RATEIO_INVALIDO',
+        message: `A soma dos percentuais ativos é ${activeSum.toFixed(2)}% (esperado 100%).`,
+      })
+    }
+
+    // Substitui o conjunto inteiro de forma atômica.
+    const saved = await app.prisma.$transaction(async (tx: any) => {
+      await tx.repasseBeneficiary.deleteMany({ where: { contractId } })
+      if (body.beneficiaries.length === 0) return []
+      await tx.repasseBeneficiary.createMany({
+        data: body.beneficiaries.map((b) => ({
+          companyId: req.user.cid,
+          contractId,
+          clientId: b.clientId ?? null,
+          name: b.name,
+          percentage: b.percentage,
+          role: b.role,
+          bankName: b.bankName ?? null,
+          bankAgency: b.bankAgency ?? null,
+          bankAccount: b.bankAccount ?? null,
+          pixKey: b.pixKey ?? null,
+          isActive: b.isActive,
+        })),
+      })
+      return tx.repasseBeneficiary.findMany({ where: { contractId }, orderBy: { createdAt: 'asc' } })
+    })
+
+    return reply.send({ success: true, data: saved })
+  })
+
   // POST /process — Process all due repasses (SUPER_ADMIN or cron)
   app.post('/process', {
     schema: { tags: ['repasse'], summary: 'Process all due repasses' },

--- a/apps/api/src/routes/rescission/index.ts
+++ b/apps/api/src/routes/rescission/index.ts
@@ -1,0 +1,147 @@
+/**
+ * Rescission Routes — Motor de rescisão de locação
+ *
+ *   POST /api/v1/rescission/preview            — calcula o acerto (sem salvar)
+ *   POST /api/v1/rescission/contracts/:id      — calcula e PERSISTE o acerto
+ *   GET  /api/v1/rescission/contracts/:id       — lista rescisões do contrato
+ *   POST /api/v1/rescission/:id/confirm         — confirma a rescisão
+ *
+ * O cálculo usa `calculateRescission` (serviço puro). Quando vinculado a um
+ * contrato, os valores faltantes (aluguel, datas) são puxados do contrato.
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { calculateRescission, type RescissionInput } from '../../services/rescission.service.js'
+
+const inputSchema = z.object({
+  monthlyRent: z.number().positive().optional(),
+  exitDate: z.string(),
+  contractStart: z.string().optional(),
+  contractEnd: z.string().optional(),
+  monthlyIptu: z.number().min(0).optional(),
+  penaltyBaseValue: z.number().min(0).optional(),
+  penaltyProportional: z.boolean().optional(),
+  outstandingValue: z.number().min(0).optional(),
+  bonusValue: z.number().min(0).optional(),
+  depositHeld: z.number().min(0).optional(),
+})
+
+export default async function rescissionRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate)
+  const db = () => app.prisma as any
+
+  /** Monta o input do cálculo a partir do body + (opcional) dados do contrato. */
+  async function buildInput(
+    companyId: string,
+    body: z.infer<typeof inputSchema>,
+    contractId?: string,
+  ): Promise<RescissionInput | { error: string }> {
+    let contract: any = null
+    if (contractId) {
+      contract = await app.prisma.contract.findFirst({
+        where: { id: contractId, companyId },
+        select: { rentValue: true, startDate: true, endDate: true, duration: true, penalty: true },
+      })
+      if (!contract) return { error: 'CONTRACT_NOT_FOUND' }
+    }
+
+    const monthlyRent = body.monthlyRent ?? (contract?.rentValue != null ? Number(contract.rentValue) : undefined)
+    const contractStartStr = body.contractStart ?? (contract?.startDate ? contract.startDate.toISOString() : undefined)
+    let contractEndStr = body.contractEnd ?? (contract?.endDate ? contract.endDate.toISOString() : undefined)
+
+    // Se não houver término explícito mas houver início + duração (meses), calcula.
+    if (!contractEndStr && contractStartStr && contract?.duration) {
+      const s = new Date(contractStartStr)
+      const e = new Date(s.getFullYear(), s.getMonth() + Number(contract.duration), s.getDate())
+      contractEndStr = e.toISOString()
+    }
+
+    if (monthlyRent == null || !contractStartStr || !contractEndStr) {
+      return { error: 'MISSING_FIELDS: monthlyRent, contractStart e contractEnd são obrigatórios (informe no body ou via contrato).' }
+    }
+
+    return {
+      monthlyRent,
+      exitDate: new Date(body.exitDate),
+      contractStart: new Date(contractStartStr),
+      contractEnd: new Date(contractEndStr),
+      monthlyIptu: body.monthlyIptu,
+      penaltyBaseValue: body.penaltyBaseValue,
+      penaltyProportional: body.penaltyProportional,
+      outstandingValue: body.outstandingValue,
+      bonusValue: body.bonusValue,
+      depositHeld: body.depositHeld,
+    }
+  }
+
+  // POST /preview — calcula sem persistir
+  app.post('/preview', {
+    schema: { tags: ['rescission'], summary: 'Preview rescission settlement (no save)' },
+  }, async (req, reply) => {
+    const body = inputSchema.parse(req.body)
+    const input = await buildInput(req.user.cid, body)
+    if ('error' in input) return reply.status(400).send({ error: input.error })
+    return reply.send({ success: true, data: calculateRescission(input) })
+  })
+
+  // POST /contracts/:contractId — calcula e persiste
+  app.post('/contracts/:contractId', {
+    schema: { tags: ['rescission'], summary: 'Calculate and persist rescission for a contract' },
+  }, async (req, reply) => {
+    const { contractId } = req.params as { contractId: string }
+    const body = inputSchema.parse(req.body)
+    const input = await buildInput(req.user.cid, body, contractId)
+    if ('error' in input) {
+      const code = input.error === 'CONTRACT_NOT_FOUND' ? 404 : 400
+      return reply.status(code).send({ error: input.error })
+    }
+
+    const result = calculateRescission(input)
+    const created = await db().rescission.create({
+      data: {
+        companyId: req.user.cid,
+        contractId,
+        exitDate: new Date(result.exitDate),
+        proRataRent: result.items.find((i) => i.key === 'proRataRent')?.value ?? 0,
+        proRataIptu: result.items.find((i) => i.key === 'proRataIptu')?.value ?? 0,
+        penaltyValue: result.items.find((i) => i.key === 'penalty')?.value ?? 0,
+        outstandingValue: result.items.find((i) => i.key === 'outstanding')?.value ?? 0,
+        bonusValue: result.items.find((i) => i.key === 'bonus')?.value ?? 0,
+        depositRefund: result.items.find((i) => i.key === 'deposit')?.value ?? 0,
+        totalDebits: result.totalDebits,
+        totalCredits: result.totalCredits,
+        netResult: result.netResult,
+        settlement: result.settlement,
+        status: 'DRAFT',
+        items: result.items as any,
+        notes: (req.body as any)?.notes ?? null,
+        createdBy: req.user.sub ?? null,
+      },
+    })
+    return reply.status(201).send({ success: true, data: { rescission: created, calculation: result } })
+  })
+
+  // GET /contracts/:contractId — lista rescisões do contrato
+  app.get('/contracts/:contractId', {
+    schema: { tags: ['rescission'], summary: 'List rescissions of a contract' },
+  }, async (req, reply) => {
+    const { contractId } = req.params as { contractId: string }
+    const rows = await db().rescission.findMany({
+      where: { contractId, companyId: req.user.cid },
+      orderBy: { createdAt: 'desc' },
+    })
+    return reply.send({ success: true, data: rows })
+  })
+
+  // POST /:id/confirm — confirma a rescisão
+  app.post('/:id/confirm', {
+    schema: { tags: ['rescission'], summary: 'Confirm a rescission' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const existing = await db().rescission.findFirst({ where: { id, companyId: req.user.cid } })
+    if (!existing) return reply.status(404).send({ error: 'NOT_FOUND' })
+    const updated = await db().rescission.update({ where: { id }, data: { status: 'CONFIRMED' } })
+    return reply.send({ success: true, data: updated })
+  })
+}

--- a/apps/api/src/routes/rescission/index.ts
+++ b/apps/api/src/routes/rescission/index.ts
@@ -11,6 +11,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { requirePermission } from '../../utils/permissions.js'
 import { z } from 'zod'
 import { calculateRescission, type RescissionInput } from '../../services/rescission.service.js'
 
@@ -29,6 +30,8 @@ const inputSchema = z.object({
 
 export default async function rescissionRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate)
+  const canView = requirePermission('rescission', 'view')
+  const canEdit = requirePermission('rescission', 'edit')
   const db = () => app.prisma as any
 
   /** Monta o input do cálculo a partir do body + (opcional) dados do contrato. */
@@ -76,7 +79,7 @@ export default async function rescissionRoutes(app: FastifyInstance) {
   }
 
   // POST /preview — calcula sem persistir
-  app.post('/preview', {
+  app.post('/preview', { preHandler: canEdit,
     schema: { tags: ['rescission'], summary: 'Preview rescission settlement (no save)' },
   }, async (req, reply) => {
     const body = inputSchema.parse(req.body)
@@ -86,7 +89,7 @@ export default async function rescissionRoutes(app: FastifyInstance) {
   })
 
   // POST /contracts/:contractId — calcula e persiste
-  app.post('/contracts/:contractId', {
+  app.post('/contracts/:contractId', { preHandler: canEdit,
     schema: { tags: ['rescission'], summary: 'Calculate and persist rescission for a contract' },
   }, async (req, reply) => {
     const { contractId } = req.params as { contractId: string }
@@ -123,7 +126,7 @@ export default async function rescissionRoutes(app: FastifyInstance) {
   })
 
   // GET /contracts/:contractId — lista rescisões do contrato
-  app.get('/contracts/:contractId', {
+  app.get('/contracts/:contractId', { preHandler: canView,
     schema: { tags: ['rescission'], summary: 'List rescissions of a contract' },
   }, async (req, reply) => {
     const { contractId } = req.params as { contractId: string }
@@ -135,7 +138,7 @@ export default async function rescissionRoutes(app: FastifyInstance) {
   })
 
   // POST /:id/confirm — confirma a rescisão
-  app.post('/:id/confirm', {
+  app.post('/:id/confirm', { preHandler: canEdit,
     schema: { tags: ['rescission'], summary: 'Confirm a rescission' },
   }, async (req, reply) => {
     const { id } = req.params as { id: string }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -88,6 +88,7 @@ import tenantRoutes from './routes/tenants/index.js'
 import repasseRoutes from './routes/repasse/index.js'
 import payablesRoutes from './routes/payables/index.js'
 import rescissionRoutes from './routes/rescission/index.js'
+import agreementsRoutes from './routes/agreements/index.js'
 import signatureRoutes from './routes/signatures/index.js'
 import auctionAIRoutes from './routes/auction-ai/index.js'
 import importRoutes from './routes/import/index.js'
@@ -839,6 +840,7 @@ async function bootstrap() {
   await app.register(repasseRoutes,            { prefix: '/api/v1/repasse' })
   await app.register(payablesRoutes,           { prefix: '/api/v1/payables' })
   await app.register(rescissionRoutes,         { prefix: '/api/v1/rescission' })
+  await app.register(agreementsRoutes,         { prefix: '/api/v1/agreements' })
   await app.register(signatureRoutes,          { prefix: '/api/v1/signatures' })
   await app.register(auctionAIRoutes,          { prefix: '/api/v1/auction-ai' })
   await app.register(importRoutes,             { prefix: '/api/v1/import' })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -89,6 +89,9 @@ import repasseRoutes from './routes/repasse/index.js'
 import payablesRoutes from './routes/payables/index.js'
 import rescissionRoutes from './routes/rescission/index.js'
 import agreementsRoutes from './routes/agreements/index.js'
+import noticesRoutes from './routes/notices/index.js'
+import reconciliationRoutes from './routes/reconciliation/index.js'
+import permissionsRoutes from './routes/permissions/index.js'
 import signatureRoutes from './routes/signatures/index.js'
 import auctionAIRoutes from './routes/auction-ai/index.js'
 import importRoutes from './routes/import/index.js'
@@ -841,6 +844,9 @@ async function bootstrap() {
   await app.register(payablesRoutes,           { prefix: '/api/v1/payables' })
   await app.register(rescissionRoutes,         { prefix: '/api/v1/rescission' })
   await app.register(agreementsRoutes,         { prefix: '/api/v1/agreements' })
+  await app.register(noticesRoutes,            { prefix: '/api/v1/notices' })
+  await app.register(reconciliationRoutes,     { prefix: '/api/v1/reconciliation' })
+  await app.register(permissionsRoutes,        { prefix: '/api/v1/permissions' })
   await app.register(signatureRoutes,          { prefix: '/api/v1/signatures' })
   await app.register(auctionAIRoutes,          { prefix: '/api/v1/auction-ai' })
   await app.register(importRoutes,             { prefix: '/api/v1/import' })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -92,6 +92,7 @@ import agreementsRoutes from './routes/agreements/index.js'
 import noticesRoutes from './routes/notices/index.js'
 import reconciliationRoutes from './routes/reconciliation/index.js'
 import permissionsRoutes from './routes/permissions/index.js'
+import iptuRoutes from './routes/iptu/index.js'
 import signatureRoutes from './routes/signatures/index.js'
 import auctionAIRoutes from './routes/auction-ai/index.js'
 import importRoutes from './routes/import/index.js'
@@ -847,6 +848,7 @@ async function bootstrap() {
   await app.register(noticesRoutes,            { prefix: '/api/v1/notices' })
   await app.register(reconciliationRoutes,     { prefix: '/api/v1/reconciliation' })
   await app.register(permissionsRoutes,        { prefix: '/api/v1/permissions' })
+  await app.register(iptuRoutes,               { prefix: '/api/v1/iptu' })
   await app.register(signatureRoutes,          { prefix: '/api/v1/signatures' })
   await app.register(auctionAIRoutes,          { prefix: '/api/v1/auction-ai' })
   await app.register(importRoutes,             { prefix: '/api/v1/import' })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -86,6 +86,7 @@ import saasWebhookRoutes from './routes/billing/saas-webhook.js'
 import asaasWebhookRoutes from './routes/finance/webhook.js'
 import tenantRoutes from './routes/tenants/index.js'
 import repasseRoutes from './routes/repasse/index.js'
+import payablesRoutes from './routes/payables/index.js'
 import signatureRoutes from './routes/signatures/index.js'
 import auctionAIRoutes from './routes/auction-ai/index.js'
 import importRoutes from './routes/import/index.js'
@@ -835,6 +836,7 @@ async function bootstrap() {
   await app.register(asaasWebhookRoutes,       { prefix: '/api/v1/finance/webhook' })
   await app.register(tenantRoutes,             { prefix: '/api/v1/tenants' })
   await app.register(repasseRoutes,            { prefix: '/api/v1/repasse' })
+  await app.register(payablesRoutes,           { prefix: '/api/v1/payables' })
   await app.register(signatureRoutes,          { prefix: '/api/v1/signatures' })
   await app.register(auctionAIRoutes,          { prefix: '/api/v1/auction-ai' })
   await app.register(importRoutes,             { prefix: '/api/v1/import' })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -87,6 +87,7 @@ import asaasWebhookRoutes from './routes/finance/webhook.js'
 import tenantRoutes from './routes/tenants/index.js'
 import repasseRoutes from './routes/repasse/index.js'
 import payablesRoutes from './routes/payables/index.js'
+import rescissionRoutes from './routes/rescission/index.js'
 import signatureRoutes from './routes/signatures/index.js'
 import auctionAIRoutes from './routes/auction-ai/index.js'
 import importRoutes from './routes/import/index.js'
@@ -837,6 +838,7 @@ async function bootstrap() {
   await app.register(tenantRoutes,             { prefix: '/api/v1/tenants' })
   await app.register(repasseRoutes,            { prefix: '/api/v1/repasse' })
   await app.register(payablesRoutes,           { prefix: '/api/v1/payables' })
+  await app.register(rescissionRoutes,         { prefix: '/api/v1/rescission' })
   await app.register(signatureRoutes,          { prefix: '/api/v1/signatures' })
   await app.register(auctionAIRoutes,          { prefix: '/api/v1/auction-ai' })
   await app.register(importRoutes,             { prefix: '/api/v1/import' })

--- a/apps/api/src/services/agreement.service.ts
+++ b/apps/api/src/services/agreement.service.ts
@@ -1,0 +1,55 @@
+/**
+ * Agreement Service — Acordos / Renegociação de dívida
+ *
+ * Reparcela débitos em atraso num novo cronograma (equivalente Uniloc acordos).
+ * O gerador de parcelas é PURO (sem I/O) para ser testável.
+ */
+
+export interface InstallmentPlanInput {
+  /** Valor total acordado (já com desconto/acréscimo aplicado). */
+  agreedValue: number
+  /** Número de parcelas (>= 1). */
+  installments: number
+  /** Vencimento da primeira parcela. */
+  firstDueDate: Date
+  /** Intervalo entre parcelas em meses (default 1). */
+  intervalMonths?: number
+}
+
+export interface PlannedInstallment {
+  number: number
+  dueDate: string // YYYY-MM-DD
+  amount: number
+}
+
+/**
+ * Gera o cronograma de parcelas. O resto de arredondamento (centavos) é
+ * absorvido pela ÚLTIMA parcela, garantindo Σ(parcelas) === agreedValue.
+ */
+export function generateInstallmentPlan(input: InstallmentPlanInput): PlannedInstallment[] {
+  const n = Math.max(1, Math.floor(input.installments))
+  const interval = input.intervalMonths ?? 1
+  const totalCents = Math.round(input.agreedValue * 100)
+  const baseCents = Math.floor(totalCents / n)
+
+  const plan: PlannedInstallment[] = []
+  let allocated = 0
+  const base = input.firstDueDate
+  for (let i = 0; i < n; i++) {
+    const isLast = i === n - 1
+    const cents = isLast ? totalCents - allocated : baseCents
+    allocated += cents
+    // Vencimento: mesma "data" da primeira parcela + i*interval meses,
+    // com clamp para o último dia do mês quando o dia não existe.
+    const targetMonthDate = new Date(base.getFullYear(), base.getMonth() + i * interval, 1)
+    const lastDay = new Date(targetMonthDate.getFullYear(), targetMonthDate.getMonth() + 1, 0).getDate()
+    const day = Math.min(base.getDate(), lastDay)
+    const due = new Date(targetMonthDate.getFullYear(), targetMonthDate.getMonth(), day)
+    plan.push({
+      number: i + 1,
+      dueDate: due.toISOString().slice(0, 10),
+      amount: cents / 100,
+    })
+  }
+  return plan
+}

--- a/apps/api/src/services/reconciliation.service.ts
+++ b/apps/api/src/services/reconciliation.service.ts
@@ -1,0 +1,188 @@
+/**
+ * Reconciliation Service — Conciliação bancária (extrato / CNAB retorno)
+ *
+ * Equivalente Uniloc: movbanco + baixa por arquivo de retorno (BAIXACNAB).
+ *
+ * As funções de parsing e de matching são PURAS (sem I/O) para serem testáveis.
+ * O caminho CSV/JSON é determinístico; o parser CNAB400 segue o layout padrão
+ * FEBRABAN e pode exigir ajuste de posições por banco (validar por banco).
+ */
+
+export interface ParsedEntry {
+  entryDate: string // YYYY-MM-DD
+  amount: number
+  direction: 'CREDIT' | 'DEBIT'
+  description?: string
+  nossoNumero?: string
+  documentNumber?: string
+  occurrenceCode?: string
+}
+
+export interface MatchCandidate {
+  rentalId?: string
+  invoiceId?: string
+  nossoNumero?: string
+  amount: number
+  dueDate?: string // YYYY-MM-DD
+}
+
+export interface MatchedEntry extends ParsedEntry {
+  matchStatus: 'MATCHED' | 'UNMATCHED'
+  matchedRentalId?: string
+  matchedInvoiceId?: string
+}
+
+function onlyDigits(s: string): string {
+  return (s || '').replace(/\D/g, '')
+}
+
+/** Parseia data DDMMYYYY ou DDMMYY → YYYY-MM-DD. */
+function parseCnabDate(raw: string): string | null {
+  const d = onlyDigits(raw)
+  if (d.length === 8) {
+    const dd = d.slice(0, 2), mm = d.slice(2, 4), yyyy = d.slice(4, 8)
+    if (yyyy === '0000') return null
+    return `${yyyy}-${mm}-${dd}`
+  }
+  if (d.length === 6) {
+    const dd = d.slice(0, 2), mm = d.slice(2, 4), yy = d.slice(4, 6)
+    if (yy === '00' && dd === '00') return null
+    return `20${yy}-${mm}-${dd}`
+  }
+  return null
+}
+
+/**
+ * CSV simples de extrato. Cabeçalho flexível; reconhece colunas:
+ *   data|date, valor|amount, descricao|description, nossonumero|nosso_numero,
+ *   documento|document, ocorrencia|occurrence, tipo|direction
+ * Datas aceitas: YYYY-MM-DD ou DD/MM/YYYY. Valor: vírgula ou ponto decimal.
+ */
+export function parseCsvStatement(content: string, delimiter = ','): ParsedEntry[] {
+  const lines = content.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+  if (lines.length === 0) return []
+  const header = lines[0].split(delimiter).map((h) => h.trim().toLowerCase())
+  const idx = (names: string[]) => header.findIndex((h) => names.includes(h))
+
+  const iDate = idx(['data', 'date'])
+  const iAmount = idx(['valor', 'amount', 'value'])
+  const iDesc = idx(['descricao', 'description', 'historico'])
+  const iNosso = idx(['nossonumero', 'nosso_numero', 'nosso numero'])
+  const iDoc = idx(['documento', 'document', 'doc'])
+  const iOcc = idx(['ocorrencia', 'occurrence', 'codigo'])
+  const iDir = idx(['tipo', 'direction', 'debcred'])
+
+  const out: ParsedEntry[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i].split(delimiter).map((c) => c.trim())
+    const rawDate = cols[iDate] ?? ''
+    let entryDate: string | null = null
+    if (/^\d{4}-\d{2}-\d{2}/.test(rawDate)) entryDate = rawDate.slice(0, 10)
+    else if (/^\d{2}\/\d{2}\/\d{4}/.test(rawDate)) {
+      const [d, m, y] = rawDate.slice(0, 10).split('/')
+      entryDate = `${y}-${m}-${d}`
+    }
+    if (!entryDate) continue
+
+    const rawAmount = (cols[iAmount] ?? '').replace(/\./g, '').replace(',', '.')
+    const amount = Math.abs(parseFloat(rawAmount))
+    if (!Number.isFinite(amount)) continue
+
+    const dirRaw = (cols[iDir] ?? '').toUpperCase()
+    const direction: 'CREDIT' | 'DEBIT' =
+      dirRaw.startsWith('D') ? 'DEBIT' : dirRaw.startsWith('C') ? 'CREDIT'
+      : (cols[iAmount] ?? '').trim().startsWith('-') ? 'DEBIT' : 'CREDIT'
+
+    out.push({
+      entryDate,
+      amount,
+      direction,
+      description: iDesc >= 0 ? cols[iDesc] : undefined,
+      nossoNumero: iNosso >= 0 ? onlyDigits(cols[iNosso]) || undefined : undefined,
+      documentNumber: iDoc >= 0 ? cols[iDoc] : undefined,
+      occurrenceCode: iOcc >= 0 ? cols[iOcc] : undefined,
+    })
+  }
+  return out
+}
+
+/**
+ * Parser CNAB400 de retorno (layout padrão FEBRABAN/CBR643).
+ * Lê os registros de detalhe (tipo '1' na posição 0) extraindo nosso número,
+ * valor, data de ocorrência e código de ocorrência. ATENÇÃO: as posições
+ * variam por banco — validar/ajustar conforme o layout do banco emissor.
+ */
+export function parseCnab400Return(content: string): ParsedEntry[] {
+  const lines = content.split(/\r?\n/).filter((l) => l.length >= 400)
+  const out: ParsedEntry[] = []
+  for (const line of lines) {
+    if (line[0] !== '1') continue // só registros de transação (detalhe)
+    const nossoNumero = onlyDigits(line.slice(62, 82))
+    const occurrenceCode = line.slice(108, 110)
+    const occurrenceDate = parseCnabDate(line.slice(110, 116)) // DDMMYY
+    const valorRaw = line.slice(152, 165) // 11 inteiros + 2 decimais
+    const amount = parseInt(onlyDigits(valorRaw) || '0', 10) / 100
+    out.push({
+      entryDate: occurrenceDate ?? new Date(0).toISOString().slice(0, 10),
+      amount,
+      direction: 'CREDIT',
+      nossoNumero: nossoNumero || undefined,
+      occurrenceCode,
+    })
+  }
+  return out
+}
+
+function daysApart(a: string, b: string): number {
+  const da = new Date(a + 'T00:00:00Z').getTime()
+  const db = new Date(b + 'T00:00:00Z').getTime()
+  return Math.abs(Math.round((da - db) / 86400000))
+}
+
+/**
+ * Concilia entradas contra candidatos (boletos/aluguéis em aberto). PURO.
+ * Regras (em ordem):
+ *   1. Match por nossoNumero exato.
+ *   2. Senão, por valor igual + data dentro de ±`dateToleranceDays` do
+ *      vencimento, desde que haja UM único candidato compatível.
+ */
+export function matchEntries(
+  entries: ParsedEntry[],
+  candidates: MatchCandidate[],
+  dateToleranceDays = 5,
+): MatchedEntry[] {
+  const usedRental = new Set<string>()
+  const usedInvoice = new Set<string>()
+
+  return entries.map((e) => {
+    // 1. nossoNumero exato
+    if (e.nossoNumero) {
+      const byNosso = candidates.find(
+        (c) => c.nossoNumero && onlyDigits(c.nossoNumero) === e.nossoNumero
+          && !(c.rentalId && usedRental.has(c.rentalId))
+          && !(c.invoiceId && usedInvoice.has(c.invoiceId)),
+      )
+      if (byNosso) {
+        if (byNosso.rentalId) usedRental.add(byNosso.rentalId)
+        if (byNosso.invoiceId) usedInvoice.add(byNosso.invoiceId)
+        return { ...e, matchStatus: 'MATCHED', matchedRentalId: byNosso.rentalId, matchedInvoiceId: byNosso.invoiceId }
+      }
+    }
+
+    // 2. valor + data, match único
+    const byValue = candidates.filter(
+      (c) => Math.abs(c.amount - e.amount) < 0.005
+        && (!c.dueDate || daysApart(c.dueDate, e.entryDate) <= dateToleranceDays)
+        && !(c.rentalId && usedRental.has(c.rentalId))
+        && !(c.invoiceId && usedInvoice.has(c.invoiceId)),
+    )
+    if (byValue.length === 1) {
+      const c = byValue[0]
+      if (c.rentalId) usedRental.add(c.rentalId)
+      if (c.invoiceId) usedInvoice.add(c.invoiceId)
+      return { ...e, matchStatus: 'MATCHED', matchedRentalId: c.rentalId, matchedInvoiceId: c.invoiceId }
+    }
+
+    return { ...e, matchStatus: 'UNMATCHED' }
+  })
+}

--- a/apps/api/src/services/repasse.service.ts
+++ b/apps/api/src/services/repasse.service.ts
@@ -25,6 +25,23 @@ export interface ScheduleRepasseInput {
   contractId?: string
   rentalId?: string
   landlordId: string
+  landlordName?: string
+  grossValue: number
+  commissionPercent?: number
+  delayDays?: number
+  fixedDay?: number
+  /** Campos extras gravados em ScheduledRepasse.metadata (ex.: dados do rateio). */
+  metadata?: Record<string, unknown>
+}
+
+export interface SplitRepasseInput {
+  tenantId?: string
+  companyId: string
+  contractId?: string
+  rentalId?: string
+  /** Favorecido usado quando o contrato não tem rateio (beneficiários) cadastrado. */
+  fallbackLandlordId: string
+  fallbackLandlordName?: string
   grossValue: number
   commissionPercent?: number
   delayDays?: number
@@ -125,6 +142,8 @@ export async function scheduleRepasse(
         commissionPercent,
         delayDays,
         fixedDay: input.fixedDay || null,
+        ...(input.landlordName ? { landlordName: input.landlordName } : {}),
+        ...(input.metadata ?? {}),
       },
     },
   })
@@ -156,6 +175,102 @@ export async function scheduleRepasse(
   }
 
   return repasse
+}
+
+/**
+ * Agenda o repasse de um contrato **rateando** entre os beneficiários
+ * cadastrados (RepasseBeneficiary), quando houver.
+ *
+ * Regras de negócio (Uniloc favopor/secunda):
+ *   • Sem beneficiários ativos → 1 repasse de 100% para `fallbackLandlordId`
+ *     (comportamento histórico preservado).
+ *   • Com beneficiários ativos → 1 repasse por favorecido, proporcional ao
+ *     seu `percentage`. A comissão é aplicada sobre a parte de cada um, então
+ *     a soma dos brutos e a soma das comissões batem com o total.
+ *   • O resto de arredondamento (centavos) é absorvido pelo ÚLTIMO favorecido,
+ *     garantindo que Σ(brutos) === grossValue exatamente.
+ *
+ * Retorna a lista de ScheduledRepasse criados.
+ */
+export async function scheduleRepasseWithSplit(
+  prisma: PrismaClient,
+  input: SplitRepasseInput,
+): Promise<any[]> {
+  const beneficiaries = input.contractId
+    ? await (prisma as any).repasseBeneficiary.findMany({
+        where: { contractId: input.contractId, isActive: true },
+        orderBy: { createdAt: 'asc' },
+      })
+    : []
+
+  // Monta a lista de partes (favorecido + percentual).
+  type Share = { landlordId: string; landlordName?: string; pct: number; role: string; beneficiaryId: string | null }
+  let shares: Share[]
+
+  if (beneficiaries.length > 0) {
+    const totalPct = beneficiaries.reduce((s: number, b: any) => s + Number(b.percentage), 0)
+    if (Math.abs(totalPct - 100) > 0.01) {
+      // Configuração inválida não deve gerar repasses errados silenciosamente.
+      throw new Error(
+        `RATEIO_INVALIDO: soma dos percentuais dos beneficiários do contrato ${input.contractId} ` +
+        `é ${totalPct.toFixed(2)}% (esperado 100%).`,
+      )
+    }
+    shares = beneficiaries.map((b: any) => ({
+      landlordId: b.clientId || input.fallbackLandlordId,
+      landlordName: b.name,
+      pct: Number(b.percentage),
+      role: b.role,
+      beneficiaryId: b.id,
+    }))
+  } else {
+    shares = [{
+      landlordId: input.fallbackLandlordId,
+      landlordName: input.fallbackLandlordName,
+      pct: 100,
+      role: 'OWNER',
+      beneficiaryId: null,
+    }]
+  }
+
+  // Distribui o bruto em centavos para evitar erro de arredondamento; o
+  // último favorecido absorve o resto, de modo que a soma feche com o total.
+  const totalCents = Math.round(input.grossValue * 100)
+  let allocatedCents = 0
+  const created: any[] = []
+
+  for (let i = 0; i < shares.length; i++) {
+    const share = shares[i]
+    const isLast = i === shares.length - 1
+    const shareCents = isLast
+      ? totalCents - allocatedCents
+      : Math.round(totalCents * share.pct / 100)
+    allocatedCents += shareCents
+    const shareGross = shareCents / 100
+    if (shareGross <= 0) continue
+
+    const repasse = await scheduleRepasse(prisma, {
+      tenantId: input.tenantId,
+      companyId: input.companyId,
+      contractId: input.contractId,
+      rentalId: input.rentalId,
+      landlordId: share.landlordId,
+      landlordName: share.landlordName,
+      grossValue: shareGross,
+      commissionPercent: input.commissionPercent,
+      delayDays: input.delayDays,
+      fixedDay: input.fixedDay,
+      metadata: {
+        split: shares.length > 1,
+        beneficiaryId: share.beneficiaryId,
+        role: share.role,
+        sharePercent: share.pct,
+      },
+    })
+    created.push(repasse)
+  }
+
+  return created
 }
 
 /**

--- a/apps/api/src/services/rescission.service.ts
+++ b/apps/api/src/services/rescission.service.ts
@@ -1,0 +1,149 @@
+/**
+ * Rescission Service — Motor de cálculo de rescisão de locação
+ *
+ * Apura o acerto de saída de um contrato (equivalente Uniloc rescisao/resclncs):
+ *   • Aluguel proporcional aos dias ocupados no mês de saída
+ *   • IPTU proporcional
+ *   • Multa por rescisão antecipada (Lei 8.245/91, art. 4º — proporcional ao
+ *     período restante do contrato)
+ *   • Débitos em aberto (aluguéis/lançamentos não pagos)
+ *   • Bonificações/descontos concedidos
+ *   • Devolução de caução
+ *
+ * O cálculo é PURO (sem I/O) para ser testável e reaproveitável.
+ */
+
+export interface RescissionInput {
+  /** Aluguel mensal vigente. */
+  monthlyRent: number
+  /** Data de saída/entrega das chaves. */
+  exitDate: Date
+  /** Início do contrato. */
+  contractStart: Date
+  /** Término previsto do contrato. */
+  contractEnd: Date
+  /** IPTU mensal (parcela) embutido na cobrança, se houver. Default 0. */
+  monthlyIptu?: number
+  /**
+   * Multa-base de rescisão (tipicamente 3 aluguéis). A multa efetiva é
+   * proporcional ao período restante. Se não informado, assume 3x o aluguel.
+   */
+  penaltyBaseValue?: number
+  /** Se true (default), a multa é proporcional ao tempo restante do contrato. */
+  penaltyProportional?: boolean
+  /** Débitos em aberto (somatório de aluguéis/lançamentos vencidos e não pagos). */
+  outstandingValue?: number
+  /** Bonificação/desconto concedido na rescisão. */
+  bonusValue?: number
+  /** Caução retida a ser devolvida ao inquilino. */
+  depositHeld?: number
+}
+
+export interface RescissionLineItem {
+  key: string
+  label: string
+  /** Sinal contábil para o inquilino: 'debit' soma ao que ele deve; 'credit' abate. */
+  kind: 'debit' | 'credit'
+  value: number
+  detail?: string
+}
+
+export interface RescissionResult {
+  exitDate: string
+  items: RescissionLineItem[]
+  totalDebits: number
+  totalCredits: number
+  /** Resultado líquido. > 0: inquilino deve pagar; < 0: a receber pelo inquilino. */
+  netResult: number
+  /** Quem paga: 'TENANT' (inquilino paga) | 'TENANT_REFUND' (inquilino recebe) | 'SETTLED' (zero). */
+  settlement: 'TENANT' | 'TENANT_REFUND' | 'SETTLED'
+  breakdown: {
+    daysInExitMonth: number
+    occupiedDays: number
+    remainingMonths: number
+    totalMonths: number
+  }
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function daysInMonth(year: number, monthZeroBased: number): number {
+  return new Date(year, monthZeroBased + 1, 0).getDate()
+}
+
+/** Diferença em meses (arredondada para cima em frações) entre duas datas. */
+function monthsBetween(from: Date, to: Date): number {
+  if (to <= from) return 0
+  let months = (to.getFullYear() - from.getFullYear()) * 12 + (to.getMonth() - from.getMonth())
+  if (to.getDate() > from.getDate()) months += 1
+  return Math.max(0, months)
+}
+
+/**
+ * Calcula o acerto de rescisão. Função pura — não toca em banco.
+ */
+export function calculateRescission(input: RescissionInput): RescissionResult {
+  const {
+    monthlyRent,
+    exitDate,
+    contractStart,
+    contractEnd,
+    monthlyIptu = 0,
+    penaltyProportional = true,
+    outstandingValue = 0,
+    bonusValue = 0,
+    depositHeld = 0,
+  } = input
+
+  const penaltyBaseValue = input.penaltyBaseValue ?? round(monthlyRent * 3)
+
+  const year = exitDate.getFullYear()
+  const month = exitDate.getMonth()
+  const totalDaysInMonth = daysInMonth(year, month)
+  // Dias ocupados no mês de saída = do dia 1 até o dia da saída (inclusive).
+  const occupiedDays = Math.min(exitDate.getDate(), totalDaysInMonth)
+
+  const proRataRent = round(monthlyRent * occupiedDays / totalDaysInMonth)
+  const proRataIptu = round(monthlyIptu * occupiedDays / totalDaysInMonth)
+
+  // Multa proporcional ao período restante do contrato (Lei do Inquilinato).
+  const totalMonths = monthsBetween(contractStart, contractEnd)
+  const remainingMonths = monthsBetween(exitDate, contractEnd)
+  let penaltyValue = 0
+  if (remainingMonths > 0 && penaltyBaseValue > 0) {
+    penaltyValue = penaltyProportional && totalMonths > 0
+      ? round(penaltyBaseValue * remainingMonths / totalMonths)
+      : round(penaltyBaseValue)
+  }
+
+  const items: RescissionLineItem[] = []
+  items.push({ key: 'proRataRent', label: 'Aluguel proporcional', kind: 'debit', value: proRataRent, detail: `${occupiedDays}/${totalDaysInMonth} dias` })
+  if (proRataIptu > 0) items.push({ key: 'proRataIptu', label: 'IPTU proporcional', kind: 'debit', value: proRataIptu, detail: `${occupiedDays}/${totalDaysInMonth} dias` })
+  if (penaltyValue > 0) items.push({ key: 'penalty', label: 'Multa por rescisão antecipada', kind: 'debit', value: penaltyValue, detail: penaltyProportional ? `${remainingMonths}/${totalMonths} meses restantes` : 'integral' })
+  if (outstandingValue > 0) items.push({ key: 'outstanding', label: 'Débitos em aberto', kind: 'debit', value: round(outstandingValue) })
+  if (bonusValue > 0) items.push({ key: 'bonus', label: 'Bonificação/desconto', kind: 'credit', value: round(bonusValue) })
+  if (depositHeld > 0) items.push({ key: 'deposit', label: 'Devolução de caução', kind: 'credit', value: round(depositHeld) })
+
+  const totalDebits = round(items.filter((i) => i.kind === 'debit').reduce((s, i) => s + i.value, 0))
+  const totalCredits = round(items.filter((i) => i.kind === 'credit').reduce((s, i) => s + i.value, 0))
+  const netResult = round(totalDebits - totalCredits)
+
+  const settlement = netResult > 0 ? 'TENANT' : netResult < 0 ? 'TENANT_REFUND' : 'SETTLED'
+
+  return {
+    exitDate: exitDate.toISOString().slice(0, 10),
+    items,
+    totalDebits,
+    totalCredits,
+    netResult,
+    settlement,
+    breakdown: {
+      daysInExitMonth: totalDaysInMonth,
+      occupiedDays,
+      remainingMonths,
+      totalMonths,
+    },
+  }
+}

--- a/apps/api/src/utils/permissions.ts
+++ b/apps/api/src/utils/permissions.ts
@@ -1,0 +1,43 @@
+/**
+ * Permissões granulares por módulo (complementa UserRole).
+ *
+ * Modelo "opt-in progressivo":
+ *   • SUPER_ADMIN / ADMIN / MANAGER → acesso total (bypass).
+ *   • Usuário SEM nenhuma permissão cadastrada → liberado (mantém o
+ *     comportamento atual; permissões só passam a valer quando configuradas).
+ *   • Usuário COM permissões cadastradas → exige a flag do módulo/ação;
+ *     ausência da linha do módulo ou flag falsa → 403.
+ */
+
+import type { FastifyReply, FastifyRequest } from 'fastify'
+
+export type PermAction = 'view' | 'edit' | 'delete'
+
+const BYPASS_ROLES = new Set(['SUPER_ADMIN', 'ADMIN', 'MANAGER'])
+
+const FIELD: Record<PermAction, 'canView' | 'canEdit' | 'canDelete'> = {
+  view: 'canView',
+  edit: 'canEdit',
+  delete: 'canDelete',
+}
+
+export function requirePermission(module: string, action: PermAction) {
+  return async function permissionGuard(req: FastifyRequest, reply: FastifyReply) {
+    const user = (req as any).user
+    if (!user) return reply.status(401).send({ error: 'UNAUTHORIZED' })
+    if (BYPASS_ROLES.has(user.role)) return
+
+    const prisma = (req.server as any).prisma
+    const perms = await prisma.userModulePermission.findMany({
+      where: { userId: user.sub },
+      select: { module: true, canView: true, canEdit: true, canDelete: true },
+    })
+    // Sem permissões cadastradas → não há enforcement (opt-in).
+    if (!perms || perms.length === 0) return
+
+    const p = perms.find((x: any) => x.module === module)
+    if (!p || !p[FIELD[action]]) {
+      return reply.status(403).send({ error: 'FORBIDDEN', module, action })
+    }
+  }
+}

--- a/apps/api/test/agreement.test.ts
+++ b/apps/api/test/agreement.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { generateInstallmentPlan } from '../src/services/agreement.service.js'
+
+function sum(plan: { amount: number }[]) {
+  return Math.round(plan.reduce((s, p) => s + p.amount, 0) * 100) / 100
+}
+
+test('acordo: parcelas somam exatamente o valor acordado (resto na última)', () => {
+  const plan = generateInstallmentPlan({
+    agreedValue: 1000,
+    installments: 3,
+    firstDueDate: new Date(2026, 0, 31),
+  })
+  assert.equal(plan.length, 3)
+  assert.equal(sum(plan), 1000)
+  assert.equal(plan[0].amount, 333.33)
+  assert.equal(plan[2].amount, 333.34) // última absorve o centavo
+})
+
+test('acordo: clamp de fim de mês nos vencimentos (jan31 -> fev28 -> mar31)', () => {
+  const plan = generateInstallmentPlan({
+    agreedValue: 900,
+    installments: 3,
+    firstDueDate: new Date(2026, 0, 31),
+  })
+  assert.equal(plan[0].dueDate, '2026-01-31')
+  assert.equal(plan[1].dueDate, '2026-02-28')
+  assert.equal(plan[2].dueDate, '2026-03-31')
+})
+
+test('acordo: parcela única', () => {
+  const plan = generateInstallmentPlan({
+    agreedValue: 5000,
+    installments: 1,
+    firstDueDate: new Date(2026, 5, 10),
+  })
+  assert.equal(plan.length, 1)
+  assert.equal(plan[0].amount, 5000)
+  assert.equal(plan[0].dueDate, '2026-06-10')
+})
+
+test('acordo: valor quebrado fecha em centavos', () => {
+  const plan = generateInstallmentPlan({
+    agreedValue: 999.99,
+    installments: 4,
+    firstDueDate: new Date(2026, 11, 15),
+  })
+  assert.equal(sum(plan), 999.99)
+})
+
+test('acordo: intervalo bimestral', () => {
+  const plan = generateInstallmentPlan({
+    agreedValue: 600,
+    installments: 3,
+    firstDueDate: new Date(2026, 0, 10),
+    intervalMonths: 2,
+  })
+  assert.equal(plan[0].dueDate, '2026-01-10')
+  assert.equal(plan[1].dueDate, '2026-03-10')
+  assert.equal(plan[2].dueDate, '2026-05-10')
+})

--- a/apps/api/test/reconciliation.test.ts
+++ b/apps/api/test/reconciliation.test.ts
@@ -1,0 +1,96 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseCsvStatement,
+  parseCnab400Return,
+  matchEntries,
+  type MatchCandidate,
+} from '../src/services/reconciliation.service.js'
+
+test('CSV: parseia data, valor (vírgula), nossoNumero e direção', () => {
+  // Extratos BR usam ';' como delimitador (vírgula é o separador decimal).
+  const csv = [
+    'data;valor;descricao;nossonumero;tipo',
+    '2026-06-10;1.500,50;Aluguel jun;000123456;C',
+    '15/06/2026;-200,00;Tarifa;;D',
+  ].join('\n')
+  const e = parseCsvStatement(csv, ';')
+  assert.equal(e.length, 2)
+  assert.equal(e[0].entryDate, '2026-06-10')
+  assert.equal(e[0].amount, 1500.5)
+  assert.equal(e[0].direction, 'CREDIT')
+  assert.equal(e[0].nossoNumero, '000123456')
+  assert.equal(e[1].entryDate, '2026-06-15')
+  assert.equal(e[1].direction, 'DEBIT')
+})
+
+test('matching: por nossoNumero exato', () => {
+  const entries = parseCsvStatement([
+    'data;valor;nossonumero',
+    '2026-06-10;1500,00;000999',
+  ].join('\n'), ';')
+  const candidates: MatchCandidate[] = [
+    { rentalId: 'R1', nossoNumero: '000999', amount: 1500, dueDate: '2026-06-10' },
+    { rentalId: 'R2', nossoNumero: '000111', amount: 1500, dueDate: '2026-06-10' },
+  ]
+  const m = matchEntries(entries, candidates)
+  assert.equal(m[0].matchStatus, 'MATCHED')
+  assert.equal(m[0].matchedRentalId, 'R1')
+})
+
+test('matching: por valor + data quando único, dentro da tolerância', () => {
+  const entries = [{ entryDate: '2026-06-12', amount: 2000, direction: 'CREDIT' as const }]
+  const candidates: MatchCandidate[] = [
+    { rentalId: 'R1', amount: 2000, dueDate: '2026-06-10' }, // 2 dias de diferença
+  ]
+  const m = matchEntries(entries, candidates)
+  assert.equal(m[0].matchStatus, 'MATCHED')
+  assert.equal(m[0].matchedRentalId, 'R1')
+})
+
+test('matching: ambíguo (dois candidatos mesmo valor) → não concilia', () => {
+  const entries = [{ entryDate: '2026-06-10', amount: 2000, direction: 'CREDIT' as const }]
+  const candidates: MatchCandidate[] = [
+    { rentalId: 'R1', amount: 2000, dueDate: '2026-06-10' },
+    { rentalId: 'R2', amount: 2000, dueDate: '2026-06-11' },
+  ]
+  const m = matchEntries(entries, candidates)
+  assert.equal(m[0].matchStatus, 'UNMATCHED')
+})
+
+test('matching: fora da tolerância de data → não concilia', () => {
+  const entries = [{ entryDate: '2026-06-30', amount: 2000, direction: 'CREDIT' as const }]
+  const candidates: MatchCandidate[] = [{ rentalId: 'R1', amount: 2000, dueDate: '2026-06-10' }]
+  const m = matchEntries(entries, candidates)
+  assert.equal(m[0].matchStatus, 'UNMATCHED')
+})
+
+test('matching: não reusa o mesmo candidato em duas entradas', () => {
+  const entries = [
+    { entryDate: '2026-06-10', amount: 1000, direction: 'CREDIT' as const, nossoNumero: '777' },
+    { entryDate: '2026-06-10', amount: 1000, direction: 'CREDIT' as const, nossoNumero: '777' },
+  ]
+  const candidates: MatchCandidate[] = [{ rentalId: 'R1', nossoNumero: '777', amount: 1000 }]
+  const m = matchEntries(entries, candidates)
+  assert.equal(m[0].matchStatus, 'MATCHED')
+  assert.equal(m[1].matchStatus, 'UNMATCHED') // candidato já usado
+})
+
+test('CNAB400: extrai nossoNumero, valor, ocorrência e data de detalhe', () => {
+  // Constrói uma linha de 400 chars com os campos nas posições esperadas.
+  const arr = new Array(400).fill(' ')
+  arr[0] = '1' // registro de detalhe
+  const put = (start: number, str: string) => { for (let i = 0; i < str.length; i++) arr[start + i] = str[i] }
+  put(62, '0000000001234567'.padEnd(20, ' ')) // nossoNumero (slice 62..82)
+  put(108, '06')        // ocorrência (liquidação)
+  put(110, '100626')    // data DDMMYY → 2026-06-10
+  put(152, '0000000150000') // valor 13 dígitos → 1500.00
+  const line = arr.join('')
+  const e = parseCnab400Return(line)
+  assert.equal(e.length, 1)
+  // nossoNumero preserva os dígitos como vêm no arquivo (zeros à esquerda incluídos).
+  assert.equal(e[0].nossoNumero, '0000000001234567')
+  assert.equal(e[0].occurrenceCode, '06')
+  assert.equal(e[0].entryDate, '2026-06-10')
+  assert.equal(e[0].amount, 1500)
+})

--- a/apps/api/test/repasse-split.test.ts
+++ b/apps/api/test/repasse-split.test.ts
@@ -1,0 +1,88 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { scheduleRepasseWithSplit } from '../src/services/repasse.service.js'
+
+/** Mock mínimo do Prisma que captura os ScheduledRepasse criados. */
+function mockPrisma(beneficiaries: any[]) {
+  const created: any[] = []
+  const prisma: any = {
+    repasseBeneficiary: { findMany: async () => beneficiaries },
+    scheduledRepasse: {
+      create: async ({ data }: any) => {
+        created.push(data)
+        return { id: `r${created.length}`, ...data }
+      },
+    },
+    tenant: { findUnique: async () => null },
+  }
+  return { prisma, created }
+}
+
+test('rateio: sem beneficiários → 1 repasse de 100% para o fallback', async () => {
+  const { prisma, created } = mockPrisma([])
+  const res = await scheduleRepasseWithSplit(prisma, {
+    companyId: 'c1',
+    contractId: 'k1',
+    fallbackLandlordId: 'L1',
+    grossValue: 3000,
+    commissionPercent: 10,
+  })
+  assert.equal(res.length, 1)
+  assert.equal(created.length, 1)
+  assert.equal(Number(created[0].grossValue), 3000)
+  assert.equal(created[0].landlordId, 'L1')
+  assert.equal(Number(created[0].commissionValue), 300)
+  assert.equal(Number(created[0].netValue), 2700)
+})
+
+test('rateio: 60/40 entre dois proprietários, comissão 10%', async () => {
+  const { prisma, created } = mockPrisma([
+    { id: 'b1', clientId: 'A', name: 'Dono A', percentage: 60, role: 'OWNER' },
+    { id: 'b2', clientId: 'B', name: 'Dono B', percentage: 40, role: 'OWNER' },
+  ])
+  const res = await scheduleRepasseWithSplit(prisma, {
+    companyId: 'c1',
+    contractId: 'k1',
+    fallbackLandlordId: 'L1',
+    grossValue: 3000,
+    commissionPercent: 10,
+  })
+  assert.equal(res.length, 2)
+  const gross = created.map((c) => Number(c.grossValue))
+  assert.deepEqual(gross, [1800, 1200])
+  // soma dos brutos === total
+  assert.equal(gross.reduce((a, b) => a + b, 0), 3000)
+  // comissão e líquido por parte
+  assert.equal(Number(created[0].commissionValue), 180)
+  assert.equal(Number(created[0].netValue), 1620)
+  assert.equal(Number(created[1].netValue), 1080)
+  // destinos corretos
+  assert.equal(created[0].landlordId, 'A')
+  assert.equal(created[1].landlordId, 'B')
+})
+
+test('rateio: 3 partes 33.33/33.33/33.34 fecha em centavos', async () => {
+  const { prisma, created } = mockPrisma([
+    { id: 'b1', clientId: 'A', name: 'A', percentage: 33.33, role: 'OWNER' },
+    { id: 'b2', clientId: 'B', name: 'B', percentage: 33.33, role: 'SECONDARY' },
+    { id: 'b3', clientId: 'C', name: 'C', percentage: 33.34, role: 'FAVORED' },
+  ])
+  await scheduleRepasseWithSplit(prisma, {
+    companyId: 'c1', contractId: 'k1', fallbackLandlordId: 'L1', grossValue: 1000, commissionPercent: 0,
+  })
+  const gross = created.map((c) => Number(c.grossValue))
+  assert.equal(gross.reduce((a, b) => a + b, 0), 1000)
+})
+
+test('rateio: percentuais que não somam 100 lançam erro', async () => {
+  const { prisma } = mockPrisma([
+    { id: 'b1', clientId: 'A', name: 'A', percentage: 50, role: 'OWNER' },
+    { id: 'b2', clientId: 'B', name: 'B', percentage: 30, role: 'OWNER' },
+  ])
+  await assert.rejects(
+    () => scheduleRepasseWithSplit(prisma, {
+      companyId: 'c1', contractId: 'k1', fallbackLandlordId: 'L1', grossValue: 1000,
+    }),
+    /RATEIO_INVALIDO/,
+  )
+})

--- a/apps/api/test/rescission.test.ts
+++ b/apps/api/test/rescission.test.ts
@@ -1,0 +1,67 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { calculateRescission } from '../src/services/rescission.service.js'
+
+test('rescisão: aluguel proporcional na metade do mês (15/30)', () => {
+  const r = calculateRescission({
+    monthlyRent: 3000,
+    exitDate: new Date(2026, 5, 15), // 15/jun (30 dias)
+    contractStart: new Date(2025, 6, 1),
+    contractEnd: new Date(2026, 6, 1),
+  })
+  assert.equal(r.items.find((i) => i.key === 'proRataRent')?.value, 1500)
+  assert.equal(r.breakdown.occupiedDays, 15)
+  assert.equal(r.breakdown.daysInExitMonth, 30)
+})
+
+test('rescisão: multa proporcional ao período restante', () => {
+  // base 9000 (3x3000), 1 mês restante de 12 => 750
+  const r = calculateRescission({
+    monthlyRent: 3000,
+    exitDate: new Date(2026, 5, 15),
+    contractStart: new Date(2025, 6, 1),
+    contractEnd: new Date(2026, 6, 1),
+  })
+  assert.equal(r.items.find((i) => i.key === 'penalty')?.value, 750)
+  assert.equal(r.netResult, 2250) // 1500 + 750
+  assert.equal(r.settlement, 'TENANT')
+})
+
+test('rescisão: IPTU proporcional + débito - caução (fev 28 dias)', () => {
+  const r = calculateRescission({
+    monthlyRent: 2000,
+    monthlyIptu: 200,
+    exitDate: new Date(2026, 1, 10), // 10/fev (28 dias)
+    contractStart: new Date(2026, 0, 5),
+    contractEnd: new Date(2027, 0, 5),
+    outstandingValue: 500,
+    depositHeld: 2000,
+  })
+  assert.equal(r.items.find((i) => i.key === 'proRataRent')?.value, 714.29)
+  assert.equal(r.items.find((i) => i.key === 'proRataIptu')?.value, 71.43)
+  assert.equal(r.totalCredits, 2000)
+  assert.equal(r.netResult, 4785.72)
+})
+
+test('rescisão: sem período restante (saída após término) => multa 0', () => {
+  const r = calculateRescission({
+    monthlyRent: 2500,
+    exitDate: new Date(2026, 5, 30),
+    contractStart: new Date(2024, 0, 1),
+    contractEnd: new Date(2026, 0, 1),
+  })
+  assert.equal(r.items.find((i) => i.key === 'penalty'), undefined)
+  assert.equal(r.breakdown.remainingMonths, 0)
+})
+
+test('rescisão: multa integral quando penaltyProportional=false', () => {
+  const r = calculateRescission({
+    monthlyRent: 1000,
+    exitDate: new Date(2026, 2, 10),
+    contractStart: new Date(2026, 0, 1),
+    contractEnd: new Date(2026, 11, 1),
+    penaltyBaseValue: 3000,
+    penaltyProportional: false,
+  })
+  assert.equal(r.items.find((i) => i.key === 'penalty')?.value, 3000)
+})

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/acerto-rescisao/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/acerto-rescisao/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState } from 'react'
+import { Scissors, Calculator, Save } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtBRL, todayISO } from '@/lib/locacao-api'
+
+export default function AcertoRescisaoPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [result, setResult] = useState<any>(null)
+  const [contractId, setContractId] = useState('')
+  const [f, setF] = useState({
+    monthlyRent: '', exitDate: todayISO(), contractStart: '', contractEnd: '',
+    monthlyIptu: '', penaltyBaseValue: '', outstandingValue: '', bonusValue: '', depositHeld: '',
+    penaltyProportional: true,
+  })
+
+  function body() {
+    const num = (v: string) => (v === '' ? undefined : parseFloat(v))
+    return {
+      monthlyRent: num(f.monthlyRent), exitDate: f.exitDate,
+      contractStart: f.contractStart || undefined, contractEnd: f.contractEnd || undefined,
+      monthlyIptu: num(f.monthlyIptu), penaltyBaseValue: num(f.penaltyBaseValue),
+      penaltyProportional: f.penaltyProportional,
+      outstandingValue: num(f.outstandingValue), bonusValue: num(f.bonusValue), depositHeld: num(f.depositHeld),
+    }
+  }
+
+  async function preview(e: React.FormEvent) {
+    e.preventDefault(); setMsg(null)
+    try {
+      const r = await locacaoFetch(token, '/api/v1/rescission/preview', { method: 'POST', body: JSON.stringify(body()) })
+      setResult(r.data)
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }); setResult(null) }
+  }
+
+  async function persist() {
+    if (!contractId) { setMsg({ type: 'error', text: 'Informe o ID do contrato para salvar.' }); return }
+    try {
+      await locacaoFetch(token, `/api/v1/rescission/contracts/${contractId}`, { method: 'POST', body: JSON.stringify(body()) })
+      setMsg({ type: 'success', text: 'Rescisão calculada e salva no contrato.' })
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold flex items-center gap-2 mb-1"><Scissors size={24} /> Acerto de Rescisão</h1>
+      <p className="text-sm text-gray-500 mb-6">Calcula o saldo de saída: aluguel e IPTU proporcionais, multa proporcional ao período restante (Lei 8.245/91), débitos, bonificação e caução.</p>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <form onSubmit={preview} className="p-4 rounded-xl border bg-gray-50 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm">Aluguel mensal*<input required type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.monthlyRent} onChange={e => setF({ ...f, monthlyRent: e.target.value })} /></label>
+            <label className="text-sm">Data de saída*<input required type="date" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.exitDate} onChange={e => setF({ ...f, exitDate: e.target.value })} /></label>
+            <label className="text-sm">Início do contrato*<input required type="date" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.contractStart} onChange={e => setF({ ...f, contractStart: e.target.value })} /></label>
+            <label className="text-sm">Término previsto*<input required type="date" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.contractEnd} onChange={e => setF({ ...f, contractEnd: e.target.value })} /></label>
+            <label className="text-sm">IPTU mensal<input type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.monthlyIptu} onChange={e => setF({ ...f, monthlyIptu: e.target.value })} /></label>
+            <label className="text-sm">Multa-base (3x aluguel)<input type="number" step="0.01" placeholder="auto" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.penaltyBaseValue} onChange={e => setF({ ...f, penaltyBaseValue: e.target.value })} /></label>
+            <label className="text-sm">Débitos em aberto<input type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.outstandingValue} onChange={e => setF({ ...f, outstandingValue: e.target.value })} /></label>
+            <label className="text-sm">Bonificação<input type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.bonusValue} onChange={e => setF({ ...f, bonusValue: e.target.value })} /></label>
+            <label className="text-sm">Caução a devolver<input type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.depositHeld} onChange={e => setF({ ...f, depositHeld: e.target.value })} /></label>
+          </div>
+          <label className="text-sm flex items-center gap-2"><input type="checkbox" checked={f.penaltyProportional} onChange={e => setF({ ...f, penaltyProportional: e.target.checked })} /> Multa proporcional ao período restante</label>
+          <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Calculator size={16} /> Calcular</button>
+        </form>
+
+        <div className="p-4 rounded-xl border bg-white">
+          {!result && <p className="text-sm text-gray-400">Preencha e clique em Calcular para ver o acerto.</p>}
+          {result && (
+            <>
+              <h2 className="font-semibold mb-3">Resultado</h2>
+              <table className="w-full text-sm mb-4">
+                <tbody>
+                  {result.items?.map((i: any) => (
+                    <tr key={i.key} className="border-t">
+                      <td className="py-1.5">{i.label}{i.detail ? <span className="text-gray-400"> ({i.detail})</span> : ''}</td>
+                      <td className={`py-1.5 text-right ${i.kind === 'credit' ? 'text-green-600' : 'text-gray-800'}`}>{i.kind === 'credit' ? '− ' : ''}{fmtBRL(i.value)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className="flex justify-between text-sm border-t pt-2"><span>Total débitos</span><span>{fmtBRL(result.totalDebits)}</span></div>
+              <div className="flex justify-between text-sm"><span>Total créditos</span><span>− {fmtBRL(result.totalCredits)}</span></div>
+              <div className="flex justify-between font-bold text-lg border-t mt-2 pt-2">
+                <span>{result.settlement === 'TENANT_REFUND' ? 'A devolver ao inquilino' : 'Inquilino deve'}</span>
+                <span>{fmtBRL(Math.abs(result.netResult))}</span>
+              </div>
+              <div className="mt-4 pt-4 border-t">
+                <label className="text-sm block mb-1">Salvar no contrato (ID):</label>
+                <div className="flex gap-2">
+                  <input placeholder="contractId" className="border rounded-lg px-3 py-2 text-sm flex-1" value={contractId} onChange={e => setContractId(e.target.value)} />
+                  <button onClick={persist} className="px-3 py-2 rounded-lg bg-green-600 text-white text-sm flex items-center gap-1"><Save size={16} /> Salvar</button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/acordos/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/acordos/page.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Handshake, Plus, Eye, CheckCircle, RefreshCw } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtBRL, fmtDate, todayISO } from '@/lib/locacao-api'
+
+const STATUS: Record<string, { label: string; color: string }> = {
+  ACTIVE: { label: 'Ativo', color: '#2563eb' },
+  FULFILLED: { label: 'Cumprido', color: '#16a34a' },
+  BROKEN: { label: 'Quebrado', color: '#dc2626' },
+  CANCELLED: { label: 'Cancelado', color: '#6b7280' },
+}
+
+export default function AcordosPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [items, setItems] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [preview, setPreview] = useState<any[] | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [f, setF] = useState({ contractId: '', tenantName: '', originalDebt: '', discountValue: '0', agreedValue: '', installments: '1', firstDueDate: todayISO(), intervalMonths: '1' })
+
+  const load = useCallback(async () => {
+    setLoading(true); setMsg(null)
+    try { const r = await locacaoFetch(token, '/api/v1/agreements'); setItems(r.data ?? []) }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    finally { setLoading(false) }
+  }, [token])
+  useEffect(() => { if (token) load() }, [token, load])
+
+  function payload() {
+    return {
+      contractId: f.contractId || undefined, tenantName: f.tenantName || undefined,
+      originalDebt: parseFloat(f.originalDebt), discountValue: parseFloat(f.discountValue || '0'),
+      agreedValue: parseFloat(f.agreedValue), installments: parseInt(f.installments),
+      firstDueDate: f.firstDueDate, intervalMonths: parseInt(f.intervalMonths || '1'),
+    }
+  }
+
+  async function doPreview() {
+    setMsg(null)
+    try {
+      const r = await locacaoFetch(token, '/api/v1/agreements/preview', {
+        method: 'POST',
+        body: JSON.stringify({ agreedValue: parseFloat(f.agreedValue || '0'), installments: parseInt(f.installments || '1'), firstDueDate: f.firstDueDate, intervalMonths: parseInt(f.intervalMonths || '1') }),
+      })
+      setPreview(r.data)
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault(); setMsg(null)
+    try {
+      await locacaoFetch(token, '/api/v1/agreements', { method: 'POST', body: JSON.stringify(payload()) })
+      setMsg({ type: 'success', text: 'Acordo criado.' }); setShowForm(false); setPreview(null); load()
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  async function payInstallment(agreementId: string, number: number) {
+    try { await locacaoFetch(token, `/api/v1/agreements/${agreementId}/installments/${number}/pay`, { method: 'POST', body: '{}' }); load() }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2"><Handshake size={24} /> Acordos / Renegociação</h1>
+          <p className="text-sm text-gray-500">Reparcela débitos em atraso num novo cronograma.</p>
+        </div>
+        <div className="flex gap-2">
+          <button onClick={load} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><RefreshCw size={16} /> Atualizar</button>
+          <button onClick={() => setShowForm(v => !v)} className="px-3 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Plus size={16} /> Novo acordo</button>
+        </div>
+      </div>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      {showForm && (
+        <form onSubmit={create} className="mb-6 p-4 rounded-xl border bg-gray-50 grid md:grid-cols-3 gap-3">
+          <label className="text-sm">Contrato (ID, opcional)<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.contractId} onChange={e => setF({ ...f, contractId: e.target.value })} /></label>
+          <label className="text-sm">Inquilino<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.tenantName} onChange={e => setF({ ...f, tenantName: e.target.value })} /></label>
+          <label className="text-sm">Dívida original*<input required type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.originalDebt} onChange={e => setF({ ...f, originalDebt: e.target.value })} /></label>
+          <label className="text-sm">Desconto<input type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.discountValue} onChange={e => setF({ ...f, discountValue: e.target.value })} /></label>
+          <label className="text-sm">Valor acordado*<input required type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.agreedValue} onChange={e => setF({ ...f, agreedValue: e.target.value })} /></label>
+          <label className="text-sm">Nº parcelas*<input required type="number" min="1" max="120" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.installments} onChange={e => setF({ ...f, installments: e.target.value })} /></label>
+          <label className="text-sm">1º vencimento*<input required type="date" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.firstDueDate} onChange={e => setF({ ...f, firstDueDate: e.target.value })} /></label>
+          <label className="text-sm">Intervalo (meses)<input type="number" min="1" max="12" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.intervalMonths} onChange={e => setF({ ...f, intervalMonths: e.target.value })} /></label>
+          <div className="flex items-end gap-2">
+            <button type="button" onClick={doPreview} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><Eye size={16} /> Prever parcelas</button>
+            <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm">Salvar</button>
+          </div>
+          {preview && (
+            <div className="md:col-span-3 bg-white rounded-lg border p-3">
+              <div className="text-xs text-gray-500 mb-2">Cronograma previsto:</div>
+              <div className="flex flex-wrap gap-2">
+                {preview.map(p => <span key={p.number} className="text-xs bg-gray-100 rounded px-2 py-1">{p.number}) {fmtDate(p.dueDate)} — {fmtBRL(p.amount)}</span>)}
+              </div>
+            </div>
+          )}
+        </form>
+      )}
+
+      <div className="space-y-3">
+        {loading && <div className="p-6 text-center text-gray-400">Carregando…</div>}
+        {!loading && items.length === 0 && <div className="p-6 text-center text-gray-400 border rounded-xl">Nenhum acordo.</div>}
+        {items.map(a => (
+          <div key={a.id} className="rounded-xl border bg-white">
+            <div className="p-4 flex items-center justify-between flex-wrap gap-2 cursor-pointer" onClick={() => setExpanded(expanded === a.id ? null : a.id)}>
+              <div>
+                <div className="font-medium">{a.tenantName || 'Acordo'} · {fmtBRL(a.agreedValue)} em {a.installments}x</div>
+                <div className="text-xs text-gray-500">Dívida original {fmtBRL(a.originalDebt)} · desconto {fmtBRL(a.discountValue)}</div>
+              </div>
+              <span style={{ color: STATUS[a.status]?.color }} className="font-medium text-sm">{STATUS[a.status]?.label ?? a.status}</span>
+            </div>
+            {expanded === a.id && (
+              <div className="border-t p-4">
+                <table className="w-full text-sm">
+                  <thead className="text-left text-gray-500"><tr><th className="py-1">Parcela</th><th>Vencimento</th><th className="text-right">Valor</th><th>Status</th><th></th></tr></thead>
+                  <tbody>
+                    {a.schedule?.map((p: any) => (
+                      <tr key={p.id} className="border-t">
+                        <td className="py-2">{p.number}</td>
+                        <td>{fmtDate(p.dueDate)}</td>
+                        <td className="text-right">{fmtBRL(p.amount)}</td>
+                        <td>{p.status === 'PAID' ? <span className="text-green-600">Paga</span> : 'Pendente'}</td>
+                        <td className="text-right">{p.status !== 'PAID' && a.status === 'ACTIVE' && <button onClick={() => payInstallment(a.id, p.number)} className="text-green-600" title="Dar baixa"><CheckCircle size={18} /></button>}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/conciliacao/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/conciliacao/page.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Landmark, Upload, RefreshCw } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtDate } from '@/lib/locacao-api'
+
+export default function ConciliacaoPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [batches, setBatches] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [source, setSource] = useState<'CSV' | 'CNAB400'>('CSV')
+  const [content, setContent] = useState('')
+  const [delimiter, setDelimiter] = useState(';')
+  const [autoSettle, setAutoSettle] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try { const r = await locacaoFetch(token, '/api/v1/reconciliation'); setBatches(r.data ?? []) }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    finally { setLoading(false) }
+  }, [token])
+  useEffect(() => { if (token) load() }, [token, load])
+
+  async function doImport() {
+    setMsg(null)
+    if (!content.trim()) { setMsg({ type: 'error', text: 'Cole o conteúdo do extrato/arquivo.' }); return }
+    try {
+      const r = await locacaoFetch(token, '/api/v1/reconciliation/import', {
+        method: 'POST',
+        body: JSON.stringify({ source, content, delimiter: source === 'CSV' ? delimiter : undefined, autoSettle }),
+      })
+      setMsg({ type: 'success', text: `Importado: ${r.data.matchedCount} conciliado(s), ${r.data.settled} baixado(s).` })
+      setContent(''); load()
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold flex items-center gap-2 mb-1"><Landmark size={24} /> Conciliação Bancária</h1>
+      <p className="text-sm text-gray-500 mb-6">Importa extrato (CSV) ou retorno bancário (CNAB400) e concilia com os aluguéis em aberto (por nosso número ou valor+data).</p>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      <div className="p-4 rounded-xl border bg-gray-50 mb-6 space-y-3">
+        <div className="flex gap-3 flex-wrap items-center">
+          <select value={source} onChange={e => setSource(e.target.value as any)} className="border rounded-lg px-3 py-2 text-sm">
+            <option value="CSV">CSV (extrato)</option>
+            <option value="CNAB400">CNAB400 (retorno)</option>
+          </select>
+          {source === 'CSV' && (
+            <select value={delimiter} onChange={e => setDelimiter(e.target.value)} className="border rounded-lg px-3 py-2 text-sm">
+              <option value=";">Delimitador ;</option>
+              <option value=",">Delimitador ,</option>
+            </select>
+          )}
+          <label className="text-sm flex items-center gap-2"><input type="checkbox" checked={autoSettle} onChange={e => setAutoSettle(e.target.checked)} /> Dar baixa automática nos conciliados</label>
+        </div>
+        <textarea
+          className="border rounded-lg px-3 py-2 text-sm w-full font-mono h-40"
+          placeholder={source === 'CSV' ? 'data;valor;descricao;nossonumero;tipo\n2026-06-10;1.500,00;Aluguel;000123;C' : 'Cole as linhas do arquivo de retorno CNAB400…'}
+          value={content} onChange={e => setContent(e.target.value)}
+        />
+        <button onClick={doImport} className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Upload size={16} /> Importar e conciliar</button>
+      </div>
+
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="font-semibold">Lotes importados</h2>
+        <button onClick={load} className="px-3 py-1.5 rounded-lg border text-sm flex items-center gap-1"><RefreshCw size={14} /> Atualizar</button>
+      </div>
+      <div className="rounded-xl border bg-white overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left text-gray-500"><tr><th className="p-3">Data</th><th className="p-3">Origem</th><th className="p-3">Entradas</th><th className="p-3">Conciliadas</th><th className="p-3">Status</th></tr></thead>
+          <tbody>
+            {loading && <tr><td colSpan={5} className="p-6 text-center text-gray-400">Carregando…</td></tr>}
+            {!loading && batches.length === 0 && <tr><td colSpan={5} className="p-6 text-center text-gray-400">Nenhum lote importado.</td></tr>}
+            {batches.map(b => (
+              <tr key={b.id} className="border-t">
+                <td className="p-3">{fmtDate(b.importedAt)}</td>
+                <td className="p-3">{b.source}</td>
+                <td className="p-3">{b.totalEntries}</td>
+                <td className="p-3">{b.matchedCount} / {b.totalEntries}</td>
+                <td className="p-3">{b.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/contas-a-pagar/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/contas-a-pagar/page.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Plus, CheckCircle, XCircle, Clock, Banknote, RefreshCw } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtBRL, fmtDate, todayISO } from '@/lib/locacao-api'
+
+const STATUS: Record<string, { label: string; color: string }> = {
+  PENDING: { label: 'Pendente', color: '#d97706' },
+  PAID: { label: 'Paga', color: '#16a34a' },
+  CANCELLED: { label: 'Cancelada', color: '#6b7280' },
+}
+
+export default function ContasAPagarPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [items, setItems] = useState<any[]>([])
+  const [summary, setSummary] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [statusFilter, setStatusFilter] = useState('')
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState({ description: '', payeeName: '', category: '', amount: '', dueDate: todayISO() })
+
+  const load = useCallback(async () => {
+    setLoading(true); setMsg(null)
+    try {
+      const qs = statusFilter ? `?status=${statusFilter}` : ''
+      const [list, sum] = await Promise.all([
+        locacaoFetch(token, `/api/v1/payables${qs}`),
+        locacaoFetch(token, '/api/v1/payables/summary'),
+      ])
+      setItems(list.data?.items ?? [])
+      setSummary(sum.data)
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    finally { setLoading(false) }
+  }, [token, statusFilter])
+
+  useEffect(() => { if (token) load() }, [token, load])
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      await locacaoFetch(token, '/api/v1/payables', {
+        method: 'POST',
+        body: JSON.stringify({
+          description: form.description,
+          payeeName: form.payeeName,
+          category: form.category || undefined,
+          amount: parseFloat(form.amount),
+          dueDate: form.dueDate,
+        }),
+      })
+      setMsg({ type: 'success', text: 'Conta criada.' })
+      setShowForm(false)
+      setForm({ description: '', payeeName: '', category: '', amount: '', dueDate: todayISO() })
+      load()
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  async function pay(id: string) {
+    try { await locacaoFetch(token, `/api/v1/payables/${id}/pay`, { method: 'POST', body: '{}' }); load() }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+  async function cancel(id: string) {
+    if (!confirm('Cancelar esta conta?')) return
+    try { await locacaoFetch(token, `/api/v1/payables/${id}`, { method: 'DELETE' }); load() }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2"><Banknote size={24} /> Contas a Pagar</h1>
+          <p className="text-sm text-gray-500">Despesas da imobiliária e de terceiros (favorecido, vencimento, baixa).</p>
+        </div>
+        <div className="flex gap-2">
+          <button onClick={load} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><RefreshCw size={16} /> Atualizar</button>
+          <button onClick={() => setShowForm(v => !v)} className="px-3 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Plus size={16} /> Nova conta</button>
+        </div>
+      </div>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      {summary && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+          {summary.byStatus?.map((s: any) => (
+            <div key={s.status} className="p-4 rounded-xl border bg-white">
+              <div className="text-xs text-gray-500">{STATUS[s.status]?.label ?? s.status}</div>
+              <div className="text-lg font-bold">{fmtBRL(s.total)}</div>
+              <div className="text-xs text-gray-400">{s.count} conta(s)</div>
+            </div>
+          ))}
+          <div className="p-4 rounded-xl border bg-amber-50">
+            <div className="text-xs text-amber-700">Vencidas</div>
+            <div className="text-lg font-bold text-amber-800">{fmtBRL(summary.overdue?.total ?? 0)}</div>
+            <div className="text-xs text-amber-600">{summary.overdue?.count ?? 0} conta(s)</div>
+          </div>
+        </div>
+      )}
+
+      {showForm && (
+        <form onSubmit={create} className="mb-6 p-4 rounded-xl border bg-gray-50 grid md:grid-cols-2 gap-3">
+          <input required placeholder="Descrição" className="border rounded-lg px-3 py-2 text-sm" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} />
+          <input required placeholder="Favorecido" className="border rounded-lg px-3 py-2 text-sm" value={form.payeeName} onChange={e => setForm({ ...form, payeeName: e.target.value })} />
+          <input placeholder="Categoria (opcional)" className="border rounded-lg px-3 py-2 text-sm" value={form.category} onChange={e => setForm({ ...form, category: e.target.value })} />
+          <input required type="number" step="0.01" min="0" placeholder="Valor" className="border rounded-lg px-3 py-2 text-sm" value={form.amount} onChange={e => setForm({ ...form, amount: e.target.value })} />
+          <input required type="date" className="border rounded-lg px-3 py-2 text-sm" value={form.dueDate} onChange={e => setForm({ ...form, dueDate: e.target.value })} />
+          <div className="flex gap-2">
+            <button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm">Salvar</button>
+            <button type="button" onClick={() => setShowForm(false)} className="px-4 py-2 rounded-lg border text-sm">Cancelar</button>
+          </div>
+        </form>
+      )}
+
+      <div className="flex gap-2 mb-3">
+        <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="border rounded-lg px-3 py-2 text-sm">
+          <option value="">Todos os status</option>
+          {Object.entries(STATUS).map(([k, v]) => <option key={k} value={k}>{v.label}</option>)}
+        </select>
+      </div>
+
+      <div className="rounded-xl border bg-white overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left text-gray-500">
+            <tr>
+              <th className="p-3">Descrição</th><th className="p-3">Favorecido</th><th className="p-3">Vencimento</th>
+              <th className="p-3 text-right">Valor</th><th className="p-3">Status</th><th className="p-3 text-right">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && <tr><td colSpan={6} className="p-6 text-center text-gray-400">Carregando…</td></tr>}
+            {!loading && items.length === 0 && <tr><td colSpan={6} className="p-6 text-center text-gray-400">Nenhuma conta a pagar.</td></tr>}
+            {items.map(it => (
+              <tr key={it.id} className="border-t">
+                <td className="p-3">{it.description}</td>
+                <td className="p-3">{it.payeeName}</td>
+                <td className="p-3">{fmtDate(it.dueDate)}</td>
+                <td className="p-3 text-right font-medium">{fmtBRL(it.amount)}</td>
+                <td className="p-3"><span style={{ color: STATUS[it.status]?.color }} className="font-medium">{STATUS[it.status]?.label ?? it.status}</span></td>
+                <td className="p-3 text-right">
+                  {it.status === 'PENDING' && (
+                    <span className="inline-flex gap-2">
+                      <button onClick={() => pay(it.id)} title="Marcar como paga" className="text-green-600"><CheckCircle size={18} /></button>
+                      <button onClick={() => cancel(it.id)} title="Cancelar" className="text-gray-400"><XCircle size={18} /></button>
+                    </span>
+                  )}
+                  {it.status === 'PAID' && <span className="text-xs text-gray-400 flex items-center gap-1 justify-end"><Clock size={14} /> {fmtDate(it.paidAt)}</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/iptu/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/iptu/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Home, Plus, CheckCircle, RefreshCw } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtBRL, fmtDate, todayISO } from '@/lib/locacao-api'
+
+const STATUS: Record<string, { label: string; color: string }> = {
+  OPEN: { label: 'Aberto', color: '#2563eb' },
+  SETTLED: { label: 'Quitado', color: '#16a34a' },
+  CANCELLED: { label: 'Cancelado', color: '#6b7280' },
+}
+
+export default function IptuPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [items, setItems] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [f, setF] = useState({ propertyId: '', contractId: '', year: String(new Date().getFullYear()), iptuCode: '', totalAmount: '', installments: '10', firstDueDate: todayISO(), chargeToTenant: true })
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try { const r = await locacaoFetch(token, '/api/v1/iptu'); setItems(r.data ?? []) }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    finally { setLoading(false) }
+  }, [token])
+  useEffect(() => { if (token) load() }, [token, load])
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault(); setMsg(null)
+    try {
+      await locacaoFetch(token, '/api/v1/iptu', {
+        method: 'POST',
+        body: JSON.stringify({
+          propertyId: f.propertyId || undefined, contractId: f.contractId || undefined,
+          year: parseInt(f.year), iptuCode: f.iptuCode || undefined,
+          totalAmount: parseFloat(f.totalAmount), installments: parseInt(f.installments),
+          firstDueDate: f.firstDueDate, chargeToTenant: f.chargeToTenant,
+        }),
+      })
+      setMsg({ type: 'success', text: 'Carnê de IPTU criado.' }); setShowForm(false); load()
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+  async function pay(carneId: string, number: number) {
+    try { await locacaoFetch(token, `/api/v1/iptu/${carneId}/installments/${number}/pay`, { method: 'POST', body: '{}' }); load() }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2"><Home size={24} /> Carnê de IPTU</h1>
+          <p className="text-sm text-gray-500">IPTU anual por imóvel, parcelado e (opcionalmente) rateado ao inquilino.</p>
+        </div>
+        <div className="flex gap-2">
+          <button onClick={load} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><RefreshCw size={16} /> Atualizar</button>
+          <button onClick={() => setShowForm(v => !v)} className="px-3 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Plus size={16} /> Novo carnê</button>
+        </div>
+      </div>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      {showForm && (
+        <form onSubmit={create} className="mb-6 p-4 rounded-xl border bg-gray-50 grid md:grid-cols-3 gap-3">
+          <label className="text-sm">Imóvel (ID, opcional)<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.propertyId} onChange={e => setF({ ...f, propertyId: e.target.value })} /></label>
+          <label className="text-sm">Contrato (ID, opcional)<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.contractId} onChange={e => setF({ ...f, contractId: e.target.value })} /></label>
+          <label className="text-sm">Ano*<input required type="number" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.year} onChange={e => setF({ ...f, year: e.target.value })} /></label>
+          <label className="text-sm">Inscrição/Carnê<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.iptuCode} onChange={e => setF({ ...f, iptuCode: e.target.value })} /></label>
+          <label className="text-sm">Valor total*<input required type="number" step="0.01" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.totalAmount} onChange={e => setF({ ...f, totalAmount: e.target.value })} /></label>
+          <label className="text-sm">Nº parcelas*<input required type="number" min="1" max="24" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.installments} onChange={e => setF({ ...f, installments: e.target.value })} /></label>
+          <label className="text-sm">1º vencimento*<input required type="date" className="border rounded-lg px-3 py-2 w-full mt-1" value={f.firstDueDate} onChange={e => setF({ ...f, firstDueDate: e.target.value })} /></label>
+          <label className="text-sm flex items-center gap-2 mt-6"><input type="checkbox" checked={f.chargeToTenant} onChange={e => setF({ ...f, chargeToTenant: e.target.checked })} /> Ratear ao inquilino</label>
+          <div className="flex items-end gap-2"><button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm">Salvar</button><button type="button" onClick={() => setShowForm(false)} className="px-4 py-2 rounded-lg border text-sm">Cancelar</button></div>
+        </form>
+      )}
+
+      <div className="space-y-3">
+        {loading && <div className="p-6 text-center text-gray-400">Carregando…</div>}
+        {!loading && items.length === 0 && <div className="p-6 text-center text-gray-400 border rounded-xl">Nenhum carnê de IPTU.</div>}
+        {items.map(c => (
+          <div key={c.id} className="rounded-xl border bg-white">
+            <div className="p-4 flex items-center justify-between flex-wrap gap-2 cursor-pointer" onClick={() => setExpanded(expanded === c.id ? null : c.id)}>
+              <div>
+                <div className="font-medium">IPTU {c.year} · {fmtBRL(c.totalAmount)} em {c.installments}x {c.iptuCode ? `· ${c.iptuCode}` : ''}</div>
+                <div className="text-xs text-gray-500">{c.chargeToTenant ? 'Rateado ao inquilino' : 'Não rateado'}</div>
+              </div>
+              <span style={{ color: STATUS[c.status]?.color }} className="font-medium text-sm">{STATUS[c.status]?.label ?? c.status}</span>
+            </div>
+            {expanded === c.id && (
+              <div className="border-t p-4">
+                <table className="w-full text-sm">
+                  <thead className="text-left text-gray-500"><tr><th className="py-1">Parcela</th><th>Vencimento</th><th className="text-right">Valor</th><th>Status</th><th></th></tr></thead>
+                  <tbody>
+                    {c.schedule?.map((p: any) => (
+                      <tr key={p.id} className="border-t">
+                        <td className="py-2">{p.number}/{c.installments}</td>
+                        <td>{fmtDate(p.dueDate)}</td>
+                        <td className="text-right">{fmtBRL(p.amount)}</td>
+                        <td>{p.status === 'PAID' ? <span className="text-green-600">Paga</span> : 'Pendente'}</td>
+                        <td className="text-right">{p.status !== 'PAID' && c.status === 'OPEN' && <button onClick={() => pay(c.id, p.number)} className="text-green-600" title="Dar baixa"><CheckCircle size={18} /></button>}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/notificacoes-formais/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/notificacoes-formais/page.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { FileWarning, Plus, Send, CheckCircle, RefreshCw } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch, fmtDate } from '@/lib/locacao-api'
+
+const TYPES = [
+  { v: 'AVISO_COBRANCA', l: 'Aviso de cobrança' },
+  { v: 'EXTRAJUDICIAL', l: 'Notificação extrajudicial' },
+  { v: 'DESPEJO', l: 'Despejo' },
+  { v: 'REAJUSTE', l: 'Reajuste' },
+  { v: 'RENOVACAO', l: 'Renovação' },
+  { v: 'OUTRO', l: 'Outro' },
+]
+const STATUS: Record<string, { label: string; color: string }> = {
+  OPEN: { label: 'Aberta', color: '#d97706' },
+  SENT: { label: 'Enviada', color: '#2563eb' },
+  ACKNOWLEDGED: { label: 'Ciente', color: '#7c3aed' },
+  RESOLVED: { label: 'Resolvida', color: '#16a34a' },
+  CANCELLED: { label: 'Cancelada', color: '#6b7280' },
+}
+
+export default function NotificacoesFormaisPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [items, setItems] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [f, setF] = useState({ contractId: '', recipient: 'TENANT', recipientName: '', type: 'AVISO_COBRANCA', subject: '', body: '' })
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try { const r = await locacaoFetch(token, '/api/v1/notices'); setItems(r.data ?? []) }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    finally { setLoading(false) }
+  }, [token])
+  useEffect(() => { if (token) load() }, [token, load])
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault(); setMsg(null)
+    try {
+      await locacaoFetch(token, '/api/v1/notices', {
+        method: 'POST',
+        body: JSON.stringify({ contractId: f.contractId || undefined, recipient: f.recipient, recipientName: f.recipientName || undefined, type: f.type, subject: f.subject, body: f.body || undefined }),
+      })
+      setMsg({ type: 'success', text: 'Notificação criada.' }); setShowForm(false)
+      setF({ contractId: '', recipient: 'TENANT', recipientName: '', type: 'AVISO_COBRANCA', subject: '', body: '' }); load()
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+  async function act(id: string, action: 'send' | 'resolve') {
+    try { await locacaoFetch(token, `/api/v1/notices/${id}/${action}`, { method: 'POST', body: '{}' }); load() }
+    catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2"><FileWarning size={24} /> Notificações Formais</h1>
+          <p className="text-sm text-gray-500">Avisos e notificações extrajudiciais (cobrança → jurídico).</p>
+        </div>
+        <div className="flex gap-2">
+          <button onClick={load} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><RefreshCw size={16} /> Atualizar</button>
+          <button onClick={() => setShowForm(v => !v)} className="px-3 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Plus size={16} /> Nova</button>
+        </div>
+      </div>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      {showForm && (
+        <form onSubmit={create} className="mb-6 p-4 rounded-xl border bg-gray-50 grid md:grid-cols-2 gap-3">
+          <label className="text-sm">Contrato (ID, opcional)<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.contractId} onChange={e => setF({ ...f, contractId: e.target.value })} /></label>
+          <label className="text-sm">Destinatário<select className="border rounded-lg px-3 py-2 w-full mt-1" value={f.recipient} onChange={e => setF({ ...f, recipient: e.target.value })}><option value="TENANT">Inquilino</option><option value="LANDLORD">Proprietário</option><option value="OTHER">Outro</option></select></label>
+          <label className="text-sm">Nome do destinatário<input className="border rounded-lg px-3 py-2 w-full mt-1" value={f.recipientName} onChange={e => setF({ ...f, recipientName: e.target.value })} /></label>
+          <label className="text-sm">Tipo<select className="border rounded-lg px-3 py-2 w-full mt-1" value={f.type} onChange={e => setF({ ...f, type: e.target.value })}>{TYPES.map(t => <option key={t.v} value={t.v}>{t.l}</option>)}</select></label>
+          <label className="text-sm md:col-span-2">Assunto*<input required className="border rounded-lg px-3 py-2 w-full mt-1" value={f.subject} onChange={e => setF({ ...f, subject: e.target.value })} /></label>
+          <label className="text-sm md:col-span-2">Conteúdo<textarea className="border rounded-lg px-3 py-2 w-full mt-1 h-24" value={f.body} onChange={e => setF({ ...f, body: e.target.value })} /></label>
+          <div className="flex gap-2"><button type="submit" className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm">Salvar</button><button type="button" onClick={() => setShowForm(false)} className="px-4 py-2 rounded-lg border text-sm">Cancelar</button></div>
+        </form>
+      )}
+
+      <div className="rounded-xl border bg-white overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left text-gray-500"><tr><th className="p-3">Data</th><th className="p-3">Tipo</th><th className="p-3">Destinatário</th><th className="p-3">Assunto</th><th className="p-3">Status</th><th className="p-3 text-right">Ações</th></tr></thead>
+          <tbody>
+            {loading && <tr><td colSpan={6} className="p-6 text-center text-gray-400">Carregando…</td></tr>}
+            {!loading && items.length === 0 && <tr><td colSpan={6} className="p-6 text-center text-gray-400">Nenhuma notificação.</td></tr>}
+            {items.map(n => (
+              <tr key={n.id} className="border-t">
+                <td className="p-3">{fmtDate(n.noticeDate)}</td>
+                <td className="p-3">{TYPES.find(t => t.v === n.type)?.l ?? n.type}</td>
+                <td className="p-3">{n.recipientName || n.recipient}</td>
+                <td className="p-3">{n.subject}</td>
+                <td className="p-3"><span style={{ color: STATUS[n.status]?.color }} className="font-medium">{STATUS[n.status]?.label ?? n.status}</span></td>
+                <td className="p-3 text-right">
+                  <span className="inline-flex gap-2">
+                    {n.status === 'OPEN' && <button onClick={() => act(n.id, 'send')} title="Marcar enviada" className="text-blue-600"><Send size={16} /></button>}
+                    {n.status !== 'RESOLVED' && n.status !== 'CANCELLED' && <button onClick={() => act(n.id, 'resolve')} title="Resolver" className="text-green-600"><CheckCircle size={16} /></button>}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/lemosbank/rateio-repasse/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/lemosbank/rateio-repasse/page.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState } from 'react'
+import { Split, Plus, Trash2, Save, Search } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch } from '@/lib/locacao-api'
+
+type Benef = { clientId?: string; name: string; percentage: number; role: string; bankName?: string; pixKey?: string; isActive: boolean }
+
+const ROLES = [
+  { v: 'OWNER', l: 'Proprietário' },
+  { v: 'SECONDARY', l: 'Locador secundário' },
+  { v: 'FAVORED', l: 'Favorecido' },
+]
+
+export default function RateioRepassePage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [contractId, setContractId] = useState('')
+  const [rows, setRows] = useState<Benef[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  const sum = rows.filter(r => r.isActive).reduce((s, r) => s + (Number(r.percentage) || 0), 0)
+
+  async function load() {
+    if (!contractId) return
+    setMsg(null)
+    try {
+      const r = await locacaoFetch(token, `/api/v1/repasse/contracts/${contractId}/beneficiaries`)
+      setRows((r.data ?? []).map((b: any) => ({ clientId: b.clientId ?? '', name: b.name, percentage: Number(b.percentage), role: b.role, bankName: b.bankName ?? '', pixKey: b.pixKey ?? '', isActive: b.isActive })))
+      setLoaded(true)
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  function update(i: number, patch: Partial<Benef>) { setRows(rows.map((r, idx) => idx === i ? { ...r, ...patch } : r)) }
+  function add() { setRows([...rows, { name: '', percentage: 0, role: 'OWNER', isActive: true }]) }
+  function remove(i: number) { setRows(rows.filter((_, idx) => idx !== i)) }
+
+  async function save() {
+    setMsg(null)
+    if (rows.length > 0 && Math.abs(sum - 100) > 0.01) { setMsg({ type: 'error', text: `A soma dos % ativos é ${sum.toFixed(2)}% (precisa ser 100%).` }); return }
+    try {
+      await locacaoFetch(token, `/api/v1/repasse/contracts/${contractId}/beneficiaries`, {
+        method: 'PUT',
+        body: JSON.stringify({ beneficiaries: rows.map(r => ({ ...r, clientId: r.clientId || undefined, percentage: Number(r.percentage) })) }),
+      })
+      setMsg({ type: 'success', text: 'Rateio salvo.' })
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold flex items-center gap-2 mb-1"><Split size={24} /> Rateio de Repasse</h1>
+      <p className="text-sm text-gray-500 mb-6">Divide o repasse do contrato entre vários proprietários/favorecidos por percentual. Sem beneficiários, o repasse vai 100% ao locador do contrato.</p>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      <div className="flex gap-2 mb-6">
+        <input placeholder="ID do contrato" className="border rounded-lg px-3 py-2 text-sm flex-1" value={contractId} onChange={e => setContractId(e.target.value)} />
+        <button onClick={load} className="px-3 py-2 rounded-lg bg-blue-600 text-white text-sm flex items-center gap-1"><Search size={16} /> Carregar</button>
+      </div>
+
+      {loaded && (
+        <>
+          <div className="rounded-xl border bg-white overflow-x-auto mb-4">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-left text-gray-500">
+                <tr><th className="p-2">Nome</th><th className="p-2">Papel</th><th className="p-2 w-24">%</th><th className="p-2">Client ID</th><th className="p-2">PIX</th><th className="p-2">Ativo</th><th className="p-2"></th></tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <tr key={i} className="border-t">
+                    <td className="p-2"><input className="border rounded px-2 py-1 w-full" value={r.name} onChange={e => update(i, { name: e.target.value })} /></td>
+                    <td className="p-2"><select className="border rounded px-2 py-1" value={r.role} onChange={e => update(i, { role: e.target.value })}>{ROLES.map(o => <option key={o.v} value={o.v}>{o.l}</option>)}</select></td>
+                    <td className="p-2"><input type="number" step="0.01" className="border rounded px-2 py-1 w-20" value={r.percentage} onChange={e => update(i, { percentage: parseFloat(e.target.value) || 0 })} /></td>
+                    <td className="p-2"><input className="border rounded px-2 py-1 w-full" value={r.clientId ?? ''} onChange={e => update(i, { clientId: e.target.value })} /></td>
+                    <td className="p-2"><input className="border rounded px-2 py-1 w-full" value={r.pixKey ?? ''} onChange={e => update(i, { pixKey: e.target.value })} /></td>
+                    <td className="p-2 text-center"><input type="checkbox" checked={r.isActive} onChange={e => update(i, { isActive: e.target.checked })} /></td>
+                    <td className="p-2"><button onClick={() => remove(i)} className="text-red-500"><Trash2 size={16} /></button></td>
+                  </tr>
+                ))}
+                {rows.length === 0 && <tr><td colSpan={7} className="p-4 text-center text-gray-400">Sem beneficiários — repasse integral ao locador.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center justify-between">
+            <button onClick={add} className="px-3 py-2 rounded-lg border text-sm flex items-center gap-1"><Plus size={16} /> Adicionar</button>
+            <div className="flex items-center gap-4">
+              <span className={`text-sm font-medium ${Math.abs(sum - 100) > 0.01 && rows.length > 0 ? 'text-red-600' : 'text-green-600'}`}>Soma ativa: {sum.toFixed(2)}%</span>
+              <button onClick={save} className="px-4 py-2 rounded-lg bg-green-600 text-white text-sm flex items-center gap-1"><Save size={16} /> Salvar rateio</button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/permissoes/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/permissoes/page.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { ShieldCheck, Save } from 'lucide-react'
+import { useAuthStore } from '@/stores/auth.store'
+import { locacaoFetch } from '@/lib/locacao-api'
+
+type Perm = { module: string; canView: boolean; canEdit: boolean; canDelete: boolean }
+
+export default function PermissoesPage() {
+  const token = useAuthStore(s => s.accessToken)
+  const [users, setUsers] = useState<any[]>([])
+  const [modules, setModules] = useState<string[]>([])
+  const [userId, setUserId] = useState('')
+  const [perms, setPerms] = useState<Record<string, Perm>>({})
+  const [msg, setMsg] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    ;(async () => {
+      try {
+        const [u, m] = await Promise.all([
+          locacaoFetch(token, '/api/v1/users'),
+          locacaoFetch(token, '/api/v1/permissions/modules'),
+        ])
+        setUsers(u.data ?? u ?? [])
+        setModules(m.data ?? [])
+      } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+    })()
+  }, [token])
+
+  const loadUser = useCallback(async (id: string) => {
+    setUserId(id); setMsg(null)
+    const base: Record<string, Perm> = {}
+    modules.forEach(mod => { base[mod] = { module: mod, canView: false, canEdit: false, canDelete: false } })
+    if (!id) { setPerms(base); return }
+    try {
+      const r = await locacaoFetch(token, `/api/v1/permissions/users/${id}`)
+      ;(r.data ?? []).forEach((p: any) => { base[p.module] = { module: p.module, canView: p.canView, canEdit: p.canEdit, canDelete: p.canDelete } })
+      setPerms(base)
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }); setPerms(base) }
+  }, [token, modules])
+
+  function toggle(mod: string, field: keyof Omit<Perm, 'module'>) {
+    setPerms(p => ({ ...p, [mod]: { ...p[mod], [field]: !p[mod][field] } }))
+  }
+
+  async function save() {
+    setMsg(null)
+    try {
+      const permissions = Object.values(perms).filter(p => p.canView || p.canEdit || p.canDelete)
+      await locacaoFetch(token, `/api/v1/permissions/users/${userId}`, { method: 'PUT', body: JSON.stringify({ permissions }) })
+      setMsg({ type: 'success', text: 'Permissões salvas.' })
+    } catch (e: any) { setMsg({ type: 'error', text: e.message }) }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold flex items-center gap-2 mb-1"><ShieldCheck size={24} /> Permissões por Módulo</h1>
+      <p className="text-sm text-gray-500 mb-6">Acesso fino por usuário e módulo. Usuários sem nenhuma permissão cadastrada têm acesso liberado (opt-in). ADMIN/SUPER_ADMIN/MANAGER têm acesso total.</p>
+
+      {msg && <div className={`mb-4 p-3 rounded-lg text-sm ${msg.type === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-700'}`}>{msg.text}</div>}
+
+      <select value={userId} onChange={e => loadUser(e.target.value)} className="border rounded-lg px-3 py-2 text-sm mb-4 w-full md:w-80">
+        <option value="">Selecione um usuário…</option>
+        {users.map(u => <option key={u.id} value={u.id}>{u.name} ({u.role})</option>)}
+      </select>
+
+      {userId && (
+        <>
+          <div className="rounded-xl border bg-white overflow-x-auto mb-4">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-left text-gray-500"><tr><th className="p-2">Módulo</th><th className="p-2 text-center">Ver</th><th className="p-2 text-center">Editar</th><th className="p-2 text-center">Excluir</th></tr></thead>
+              <tbody>
+                {modules.map(mod => (
+                  <tr key={mod} className="border-t">
+                    <td className="p-2 font-medium">{mod}</td>
+                    <td className="p-2 text-center"><input type="checkbox" checked={perms[mod]?.canView ?? false} onChange={() => toggle(mod, 'canView')} /></td>
+                    <td className="p-2 text-center"><input type="checkbox" checked={perms[mod]?.canEdit ?? false} onChange={() => toggle(mod, 'canEdit')} /></td>
+                    <td className="p-2 text-center"><input type="checkbox" checked={perms[mod]?.canDelete ?? false} onChange={() => toggle(mod, 'canDelete')} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button onClick={save} className="px-4 py-2 rounded-lg bg-green-600 text-white text-sm flex items-center gap-1"><Save size={16} /> Salvar permissões</button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -119,6 +119,7 @@ const lemosbankSubItems = [
   { href: '/dashboard/lemosbank/rateio-repasse', icon: Split,    label: 'Rateio de Repasse' },
   { href: '/dashboard/lemosbank/contas-a-pagar', icon: Wallet,   label: 'Contas a Pagar' },
   { href: '/dashboard/lemosbank/conciliacao',  icon: Landmark,   label: 'Conciliação' },
+  { href: '/dashboard/lemosbank/iptu',         icon: Home,       label: 'Carnê de IPTU' },
   { href: '/dashboard/lemosbank/acordos',      icon: Handshake,  label: 'Acordos' },
   { href: '/dashboard/lemosbank/rescisoes',    icon: Scissors,   label: 'Rescisões' },
   { href: '/dashboard/lemosbank/acerto-rescisao', icon: Scissors, label: 'Acerto de Rescisão' },

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { useAuth } from '@/hooks/useAuth'
 import { useState, useEffect } from 'react'
 import {
+  Handshake, Split, FileWarning, ShieldCheck, Wallet,
   LayoutDashboard,
   Building2,
   Users,
@@ -115,7 +116,13 @@ const lemosbankSubItems = [
   { href: '/dashboard/lemosbank/boletos',      icon: ReceiptText, label: 'Boletos' },
   { href: '/dashboard/lemosbank/cobrancas',    icon: Receipt,    label: 'Cobranças' },
   { href: '/dashboard/lemosbank/repasses',     icon: RefreshCw,  label: 'Repasses' },
+  { href: '/dashboard/lemosbank/rateio-repasse', icon: Split,    label: 'Rateio de Repasse' },
+  { href: '/dashboard/lemosbank/contas-a-pagar', icon: Wallet,   label: 'Contas a Pagar' },
+  { href: '/dashboard/lemosbank/conciliacao',  icon: Landmark,   label: 'Conciliação' },
+  { href: '/dashboard/lemosbank/acordos',      icon: Handshake,  label: 'Acordos' },
   { href: '/dashboard/lemosbank/rescisoes',    icon: Scissors,   label: 'Rescisões' },
+  { href: '/dashboard/lemosbank/acerto-rescisao', icon: Scissors, label: 'Acerto de Rescisão' },
+  { href: '/dashboard/lemosbank/notificacoes-formais', icon: FileWarning, label: 'Notificações Formais' },
   { href: '/dashboard/lemosbank/automacao',    icon: Zap,        label: 'Automação' },
   { href: '/dashboard/lemosbank/relatorios',   icon: BarChart3,  label: 'Relatórios' },
   { href: '/dashboard/lemosbank/historico',             icon: Archive,      label: 'Histórico' },
@@ -132,6 +139,7 @@ const juridicoSubItems = [
 const bottomItems = [
   { href: '/dashboard/historico-alteracoes', icon: History,  label: 'Hist. Alterações' },
   { href: '/dashboard/notifications',        icon: Bell,     label: 'Notificações' },
+  { href: '/dashboard/permissoes',           icon: ShieldCheck, label: 'Permissões' },
   { href: '/dashboard/settings',             icon: Settings, label: 'Configurações' },
 ]
 

--- a/apps/web/src/lib/locacao-api.ts
+++ b/apps/web/src/lib/locacao-api.ts
@@ -1,0 +1,44 @@
+/**
+ * Cliente das funcionalidades de locação/financeiro (módulos novos):
+ * contas a pagar, rateio de repasse, rescisão, acordos, conciliação,
+ * notificações formais e permissões. Usa fetch direto com Bearer token.
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+export async function locacaoFetch<T = any>(
+  token: string | null | undefined,
+  path: string,
+  opts?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, {
+    ...opts,
+    headers: {
+      'Authorization': `Bearer ${token ?? ''}`,
+      'Content-Type': 'application/json',
+      ...opts?.headers,
+    },
+    credentials: 'include',
+  })
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error((json as any)?.message ?? (json as any)?.error ?? 'Erro na requisição')
+  }
+  return json as T
+}
+
+export function fmtBRL(v: number | string | null | undefined): string {
+  const n = typeof v === 'string' ? parseFloat(v) : (v ?? 0)
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number.isFinite(n as number) ? (n as number) : 0)
+}
+
+export function fmtDate(d: string | Date | null | undefined): string {
+  if (!d) return '—'
+  const date = typeof d === 'string' ? new Date(d) : d
+  if (isNaN(date.getTime())) return '—'
+  return new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeZone: 'UTC' }).format(date)
+}
+
+export function todayISO(): string {
+  return new Date().toISOString().slice(0, 10)
+}

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -1,0 +1,215 @@
+# Sistema UNILOC / IMOBILI — Mapeamento Completo
+
+> Sistema **offline** legado de administração de carteira de imóveis (locação) usado pela
+> **Imobiliária Lemos** (Noemia Pires Lemos — Franca/SP). Construído em **Visual FoxPro**.
+> Este documento mapeia caminhos, estrutura de dados, relacionamentos e funções, a partir do
+> backup de dados presente em `data/uniloc/`.
+
+---
+
+## 1. Identificação do sistema
+
+| Item | Valor |
+|------|-------|
+| Nome do produto | **UNILOC** (motor de dados) / **IMOBILI** (aplicação) |
+| Plataforma | Visual FoxPro (BDE — Borland Database Engine, `bde-vista64`) |
+| Empresa | NOEMIA PIRES LEMOS — Imobiliária Lemos |
+| Endereço | Estevão Leão Bourroul, 1685 — Franca/SP — CEP 14400-750 |
+| CNPJ/CGC | 75237326668 · CRECI 61053F/SP |
+| Telefone / Site | 3723-0045 · www.imobiliarialemos.com.br |
+| Banco padrão | SICREDI |
+| Comissão / Juros / Multa | 10% · 0,033%/dia · 10% |
+| Código da unidade | CODUNI `000851` · IDIMOBILIA `72164.G0TQ` |
+| Última versão aplicada | **17.0.372** (aplicada em 11/02/2022) |
+
+### Histórico de versões (`versoes.dbf`)
+`11.100.123` (02/2018) → `11.100.298` → `11.100.318` → `11.100.339` →
+`17.0.2` (10/2018) → `17.0.42` → `17.0.60` → `17.0.98` → `17.0.116/117` (2020) →
+**`17.0.372`** (02/2022, última).
+
+---
+
+## 2. Caminhos (no computador Windows original)
+
+| Caminho | Conteúdo |
+|---------|----------|
+| `C:\Imobili\` | Pasta da aplicação |
+| `C:\Imobili\IMOBILI.exe` | Executável principal (6,4 MB, atualizado em 06/01/2025) |
+| `C:\Imobili\bde-vista64.exe` | Borland Database Engine (acesso aos `.dbf`) |
+| `C:\Imobili\Estruturas.exe` | Utilitário de estrutura das tabelas (1999) |
+| `C:\Imobili\spdBoleto_dependencies_3.0.11.6487.exe` | Gerador de boletos |
+| `C:\Imobili\imobilichb.CFG` | Arquivo de configuração |
+| `C:\Imobili\Documentos\`, `C:\Imobili\utilidade\` | Documentos e utilitários |
+| **`C:\UNILOC\DADOS\`** | **Diretório do banco de dados** (alias `dadosservidorlemos`) — definido em `path_bd.dbf` |
+
+> No repositório, o backup desses dados está em `data/uniloc/backup_extraido/`.
+
+---
+
+## 3. Formato dos arquivos
+
+- **`.DBF`** — tabela de dados (dBase/FoxPro)
+- **`.FPT`** — campos memo/texto longo (referenciados pela tabela)
+- **`.CDX`** — índices compostos
+- **`*_Log.FPT`** — logs/auditoria
+- `dbesquema.dbf` — **dicionário oficial**: lista as 54 tabelas e indica quais têm `.CDX` e `.FPT`
+- `path_bd.dbf` — caminho do banco
+- `FOXUSER.DBF/.FPT` — recursos da interface FoxPro
+
+Leitura em Python: `pip install dbfread` →
+`DBF(path, ignore_missing_memofile=True, encoding='latin-1')`.
+
+---
+
+## 4. Chaves de relacionamento (PKs/FKs)
+
+Quase todas as tabelas se ligam por estes códigos de 6 dígitos (string):
+
+| Código | Significado | Tabela principal |
+|--------|-------------|------------------|
+| `CODLOC` | Locador (proprietário) | `locador.dbf` |
+| `CODINQ` | Inquilino | `inquili.dbf` |
+| `CODIMO` | Imóvel | `imovel.dbf` |
+| `CODCON` | Contrato | `contrato.dbf` |
+| `CODFIA` | Fiador | `fiador.dbf` |
+| `CODFAV` | Favorecido (repasse) | `favore.dbf` |
+| `CODSEC` | Locador secundário | `secunlo.dbf` |
+| `CODGR` | Grupo (plano de contas) | `grupo.dbf` |
+| `CODLAN` | Lançamento financeiro | `diversos.dbf` |
+| `CODBAN` | Conta bancária | `contas.dbf` / `bancos.dbf` |
+
+Contadores de sequência ficam nas tabelas `COD*` (`codcad.dbf` concentra os próximos
+números de locador, inquilino, imóvel, contrato, etc.).
+
+---
+
+## 5. Tabelas por área funcional
+
+### 5.1 Cadastros (pessoas e imóveis)
+| Tabela | Recs | Função |
+|--------|------|--------|
+| `locador.dbf` | 252 | Proprietários (dados, banco, repasse, cônjuge, representantes) — 90 campos |
+| `inquili.dbf` | 904 | Inquilinos — 64 campos |
+| `fiador.dbf` | 1.025 | Fiadores — 63 campos |
+| `favore.dbf` | 59 | Favorecidos de repasse — 90 campos |
+| `secunlo.dbf` / `secunda.dbf` | 28 / 31 | Locadores secundários e rateio (% de cada) |
+| `favopor.dbf` | 55 | % de favorecido por imóvel |
+| `imovel.dbf` | 623 | Imóveis (endereço, tipo, status, IPTU, luz, água) — 35 campos |
+| `garagem.dbf` | 19 | Vagas de garagem vinculadas a imóvel |
+| `cep.dbf` | 2.801 | Base de CEPs |
+
+### 5.2 Contratos
+| Tabela | Recs | Função |
+|--------|------|--------|
+| `contrato.dbf` | 982 | Contratos de locação (índice de reajuste, garantia, comissão, multa, juros, IRRF) — **88 campos** |
+| `continq.dbf` | 21 | Inquilinos adicionais por contrato |
+| `contfia.dbf` | 1.149 | Fiadores por contrato |
+| `acordos.dbf` | 322 | Acordos/renegociações |
+| `rescisao.dbf` | 809 | Rescisões de contrato |
+| `resclncs.dbf` | 1.561 | Lançamentos de rescisão |
+| `incendio.dbf` | 472 | Seguro incêndio |
+| `fianca.dbf` | 0 | Seguro fiança (vazia) |
+| `notifics.dbf` | 35 | Notificações ao inquilino/locador |
+
+### 5.3 Financeiro — recebimentos e cobrança
+| Tabela | Recs | Função |
+|--------|------|--------|
+| `aluguel.dbf` | 27.898 | **Lançamentos de aluguel** (vencimentos, recebimento, multa, juros, IR, comissão) — 45 campos |
+| `diversos.dbf` | 12.660 | Lançamentos diversos (débitos/créditos avulsos no contrato) — 68 campos |
+| `boletos.dbf` | 19.335 | Boletos emitidos (linha digitável, nosso número, código de barras) |
+| `lanciptu.dbf` | 9.505 | Parcelas de IPTU lançadas/cobradas |
+| `iptu.dbf` | 1.781 | IPTU por imóvel/ano |
+| `impresso.dbf` | 12.336 | Documentos impressos (recibos, comprovantes) |
+| `num_rec.dbf` | 60.073 | Sequência de nº de recibo |
+| `num_bol.dbf` / `num_edi.dbf` | 6 / 0 | Sequência de boleto/edital |
+
+### 5.4 Financeiro — repasses e caixa
+| Tabela | Recs | Função |
+|--------|------|--------|
+| `lanrepas.dbf` | **67.674** | **Repasses aos proprietários** (a maior tabela — quem recebe, %, valor, banco) — 42 campos |
+| `caixa.dbf` | 36.040 | Movimento de caixa (débito/crédito, grupo, contraparte) — 28 campos |
+| `movbanco.dbf` | 18.818 | Movimentação bancária |
+| `movfutur.dbf` | 0 | Movimentos futuros (vazia) |
+| `cadespe.dbf` | 4.800 | Despesas (contas a pagar) — favorecido, vencimento, pagamento |
+| `cp_cheqs.dbf` | 4.116 | Cheques a pagar |
+| `contas.dbf` / `bancos.dbf` | 1 / 4 | Contas bancárias da imobiliária |
+
+### 5.5 Apoio / parametrização
+| Tabela | Recs | Função |
+|--------|------|--------|
+| `parame.dbf` | 1 | **Configuração geral** (empresa, banco, taxas, NF, e-mail/SMTP, FTP) — 201 campos |
+| `indices.dbf` | 211 | Índices de reajuste (IGPM, IPCA, etc.) por data |
+| `tabela.dbf` | 216 | Tabela de IR (faixas, alíquota, dedução) |
+| `grupo.dbf` | 49 | Grupos / plano de contas |
+| `feriados.dbf` | 50 | Feriados (cálculo de vencimentos) |
+| `modelos.dbf` | 5 | Modelos de documento |
+| `usuarios.dbf` | 5 | Usuários do sistema (~50 flags de permissão por módulo) |
+| `lembre.dbf` | 1 | Lembretes/agenda |
+| `logoban.dbf` | 1 | Logos de banco (campo `General`/OLE) |
+| `versoes.dbf` | 11 | Histórico de versões |
+
+### 5.6 Tabelas temporárias (na raiz `data/uniloc/`)
+`tmp_rel.DBF`, `tmp_rep.DBF`, `tmp_div.DBF`, `tmp_iptu.DBF`, `tmp_repo.DBF`,
+`tmp_dash_calcula_txR.DBF`, `tmp2_dash_calcula_txA.DBF` — resultados intermediários de
+relatórios/dashboards. `RFBR.DBF` (593 KB) parece base auxiliar (provável Receita Federal/bairros).
+
+---
+
+## 6. Usuários cadastrados (`usuarios.dbf`)
+`UNION` (master), **NOEMIA LEMOS** (Diretora — lemos@imobiliarialemos.com.br),
+NAIRA LEMOS, GABRIEL LEAL, CELIA. Senhas existem nos campos `SENHA` (N6) e `PASSWORD` (C8) —
+**dados sensíveis: não expor.**
+
+---
+
+## 7. Fluxo operacional (como o sistema funciona)
+
+1. **Cadastro**: locador → imóvel (com % de repasse) → inquilino → fiador.
+2. **Contrato** (`contrato.dbf`) amarra locador+imóvel+inquilino+fiador, define índice de
+   reajuste, garantia, comissão da imobiliária, dia de vencimento e multa/juros.
+3. **Geração de cobrança**: todo mês gera lançamentos em `aluguel.dbf` (+ `diversos`/`lanciptu`)
+   e emite `boletos.dbf` (SICREDI).
+4. **Recebimento**: baixa do boleto atualiza situação (`A_SITUI/A_SITUP`) e alimenta o `caixa.dbf`.
+5. **Repasse**: o valor do aluguel menos comissão/IR vira `lanrepas.dbf` → pagamento ao
+   proprietário (e favorecidos via `favopor`/`secunda`).
+6. **Saída**: `rescisao.dbf` + `resclncs.dbf` encerram o contrato.
+
+Reajuste usa `indices.dbf`; retenção de IR usa `tabela.dbf`; despesas próprias da imobiliária
+em `cadespe.dbf`/`cp_cheqs.dbf`.
+
+---
+
+## 8. Correspondência com o AgoraEncontrei (Prisma) — para migração futura
+
+| UNILOC (legado) | AgoraEncontrei (Prisma) |
+|-----------------|--------------------------|
+| `locador` | `PropertyOwner` / `Client` (role proprietário) |
+| `inquili` | `Client` (role inquilino) / `Contact` |
+| `fiador` | (novo — fiador no `Contract`) |
+| `imovel` | `Property` |
+| `contrato` | `Contract` + `Rental` |
+| `aluguel` / `diversos` | `Transaction` / `Invoice` |
+| `boletos` | `Invoice` (Asaas/boleto) |
+| `lanrepas` | `OwnerRepasse` |
+| `caixa` / `movbanco` | `Transaction` |
+| `indices` | `bcb-rates` / reajuste |
+| `cadespe` / `cp_cheqs` | `Transaction` (despesa) |
+
+> Observação: os códigos legados (`CODLOC`, `CODIMO`, …) devem ser preservados como
+> `legacyId` em cada modelo para rastreabilidade na importação.
+
+---
+
+## 9. Como reler os dados (script de referência)
+
+```python
+from dbfread import DBF
+t = DBF("data/uniloc/backup_extraido/contrato.dbf",
+        ignore_missing_memofile=True, encoding='latin-1')
+print([f.name for f in t.fields])      # campos
+for rec in t:                          # registros
+    print(rec)
+```
+
+Para exportar tudo para CSV/JSON ou carregar num PostgreSQL de staging, basta iterar sobre
+cada `.dbf` listado em `dbesquema.dbf`.

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -97,7 +97,7 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | **Contas a pagar + cheques pré-datados** | `AccountPayable` + `BankCheck` + rota `/payables` | ✅ **Implementado** |
 | **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
 | **Acordos / renegociação de dívida** | — | ⚠️ **Lacuna** |
-| **Cálculo automatizado de rescisão** | campos existem, sem motor | ⚠️ **Parcial** |
+| **Cálculo automatizado de rescisão** | `calculateRescission` + `Rescission` + rota `/rescission` | ✅ **Implementado** |
 | **Notificação formal/extrajudicial** | `legal` + `alerts` (parcial) | ⚠️ **Parcial** |
 | Carnê de IPTU parcelado | `Rental.iptuAmount` (sem carnê) | ⚠️ **Parcial** |
 | Permissões granulares por módulo | `UserRole` (papéis fixos) | ⚠️ **Parcial** |

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -99,7 +99,7 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | **Acordos / renegociação de dívida** | `Agreement` + `AgreementInstallment` + rota `/agreements` | ✅ **Implementado** |
 | **Cálculo automatizado de rescisão** | `calculateRescission` + `Rescission` + rota `/rescission` | ✅ **Implementado** |
 | **Notificação formal/extrajudicial** | `FormalNotice` + rota `/notices` | ✅ **Implementado** |
-| Carnê de IPTU parcelado | `Rental.iptuAmount` (sem carnê) | ⚠️ **Parcial** |
+| Carnê de IPTU parcelado | `IptuCarne` + `IptuInstallment` + rota `/iptu` | ✅ **Implementado** |
 | Permissões granulares por módulo | `UserModulePermission` + `/permissions` + guard | ✅ **Implementado** |
 
 ---
@@ -134,10 +134,13 @@ Priorizado por impacto operacional numa imobiliária de locação:
    + guard `requirePermission` (opt-in) + rota `/api/v1/permissions`.
    Migrations 5–7: `20260630000004_add_notices_reconciliation_permissions`.
 
-### Ainda pendente (parcial)
-- **Carnê de IPTU parcelado** — hoje só `Rental.iptuAmount` (valor por cobrança); falta
-  o carnê anual por imóvel com rateio de parcelas (Uniloc `iptu`/`lanciptu`).
-- **Frontend (telas)** dos módulos novos.
+### Frontend
+Todas as 8 telas implementadas no dashboard (submenu **LemosBank** + **Permissões**):
+Contas a Pagar, Rateio de Repasse, Conciliação, Carnê de IPTU, Acordos, Acerto de
+Rescisão, Notificações Formais e Permissões por módulo.
+
+### Ainda pendente
+- **Backfill com dados reais** — aguardando definição de acesso ao banco.
 
 > Estas funcionalidades são apenas de **código**; nenhuma migração de dados foi feita.
 >

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -93,7 +93,7 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | Repasse simples ao proprietário | `OwnerRepasse`, `ScheduledRepasse` | ✅ |
 | Caixa / transações | `Transaction`, `FinancialForecast` | ✅ |
 | Nota fiscal de serviço | `FiscalNote` | ✅ |
-| **Rateio de repasse multi-proprietário/favorecido** | — | ⚠️ **Lacuna** |
+| **Rateio de repasse multi-proprietário/favorecido** | `RepasseBeneficiary` + `scheduleRepasseWithSplit` | ✅ **Implementado** |
 | **Contas a pagar + cheques pré-datados** | — | ⚠️ **Lacuna** |
 | **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
 | **Acordos / renegociação de dívida** | — | ⚠️ **Lacuna** |
@@ -108,9 +108,12 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 
 Priorizado por impacto operacional numa imobiliária de locação:
 
-1. **Rateio de repasse multi-proprietário** — `OwnerRepasse` hoje tem um único
-   `landlordId`. Imóveis com co-proprietários/favorecidos precisam de uma tabela de
-   participantes (`% por favorecido`), como `favopor`/`secunda`/`secunlo` faziam.
+1. ~~**Rateio de repasse multi-proprietário**~~ ✅ **Implementado** — modelo
+   `RepasseBeneficiary` (participantes com `%` + dados bancários por favorecido) e função
+   `scheduleRepasseWithSplit` que rateia o repasse entre os beneficiários do contrato.
+   Sem beneficiários cadastrados, mantém 100% para `Contract.landlordId`. Endpoints:
+   `GET/PUT /api/v1/repasse/contracts/:contractId/beneficiaries`. Migration:
+   `20260630000000_add_repasse_beneficiaries`.
 2. **Módulo Contas a Pagar + Cheques** — despesas da imobiliária e de terceiros
    (`cadespe`/`cp_cheqs`): favorecido, vencimento, status, controle de cheques pré-datados.
 3. **Motor de rescisão** — usar os campos já existentes em `Contract`/`Rental` para

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -114,13 +114,18 @@ Priorizado por impacto operacional numa imobiliária de locação:
    Sem beneficiários cadastrados, mantém 100% para `Contract.landlordId`. Endpoints:
    `GET/PUT /api/v1/repasse/contracts/:contractId/beneficiaries`. Migration:
    `20260630000000_add_repasse_beneficiaries`.
-2. **Módulo Contas a Pagar + Cheques** — despesas da imobiliária e de terceiros
-   (`cadespe`/`cp_cheqs`): favorecido, vencimento, status, controle de cheques pré-datados.
-3. **Motor de rescisão** — usar os campos já existentes em `Contract`/`Rental` para
-   calcular automaticamente o acerto de saída (proporcional + IPTU pro-rata + multa +
-   bonificação + caução).
-4. **Acordos/renegociação** — novo cronograma de parcelas para débitos em atraso, com
-   vínculo aos lançamentos originais.
+2. ~~**Módulo Contas a Pagar + Cheques**~~ ✅ **Implementado** — modelos `AccountPayable`
+   e `BankCheck`, rota `/api/v1/payables` (CRUD, marcar paga, summary, cheques com
+   compensar/cancelar). Migration `20260630000001_add_accounts_payable_checks`.
+3. ~~**Motor de rescisão**~~ ✅ **Implementado** — serviço puro `calculateRescission`
+   (aluguel/IPTU proporcionais, multa proporcional ao período restante, débitos, bonificação,
+   caução), modelo `Rescission`, rota `/api/v1/rescission` (preview/persistir/confirmar).
+   Migration `20260630000002_add_rescissions`.
+4. ~~**Acordos/renegociação**~~ ✅ **Implementado** — `generateInstallmentPlan` (parcelas
+   com reconciliação de centavos), modelos `Agreement`/`AgreementInstallment`, rota
+   `/api/v1/agreements`. Migration `20260630000003_add_agreements`.
+
+### Ainda pendente (parcial — próximos passos)
 5. **Conciliação bancária** — importar extrato/CNAB de retorno para baixa automática e
    bater caixa × banco.
 6. **Notificação formal padronizada** — tipo, assunto, situação e data de resolução
@@ -129,3 +134,8 @@ Priorizado por impacto operacional numa imobiliária de locação:
 
 > Estas recomendações são apenas de **funcionalidade**; nenhuma migração de dados é
 > proposta ou necessária.
+>
+> **Antes do deploy:** rodar `pnpm db:generate && pnpm typecheck` no ambiente de dev
+> (o engine do Prisma não funciona neste container) e aplicar as 4 migrations no Neon
+> (são idempotentes). A validação aqui foi por checagem de sintaxe (`node strip-types`)
+> e testes unitários da matemática (rateio, rescisão e parcelas — todos fecham em centavos).

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -96,7 +96,7 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | **Rateio de repasse multi-proprietário/favorecido** | `RepasseBeneficiary` + `scheduleRepasseWithSplit` | ✅ **Implementado** |
 | **Contas a pagar + cheques pré-datados** | `AccountPayable` + `BankCheck` + rota `/payables` | ✅ **Implementado** |
 | **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
-| **Acordos / renegociação de dívida** | — | ⚠️ **Lacuna** |
+| **Acordos / renegociação de dívida** | `Agreement` + `AgreementInstallment` + rota `/agreements` | ✅ **Implementado** |
 | **Cálculo automatizado de rescisão** | `calculateRescission` + `Rescission` + rota `/rescission` | ✅ **Implementado** |
 | **Notificação formal/extrajudicial** | `legal` + `alerts` (parcial) | ⚠️ **Parcial** |
 | Carnê de IPTU parcelado | `Rental.iptuAmount` (sem carnê) | ⚠️ **Parcial** |

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -95,12 +95,12 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | Nota fiscal de serviço | `FiscalNote` | ✅ |
 | **Rateio de repasse multi-proprietário/favorecido** | `RepasseBeneficiary` + `scheduleRepasseWithSplit` | ✅ **Implementado** |
 | **Contas a pagar + cheques pré-datados** | `AccountPayable` + `BankCheck` + rota `/payables` | ✅ **Implementado** |
-| **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
+| **Conciliação bancária / CNAB retorno** | `BankReconciliation` + `/reconciliation` (CSV/CNAB400) | ✅ **Implementado** |
 | **Acordos / renegociação de dívida** | `Agreement` + `AgreementInstallment` + rota `/agreements` | ✅ **Implementado** |
 | **Cálculo automatizado de rescisão** | `calculateRescission` + `Rescission` + rota `/rescission` | ✅ **Implementado** |
-| **Notificação formal/extrajudicial** | `legal` + `alerts` (parcial) | ⚠️ **Parcial** |
+| **Notificação formal/extrajudicial** | `FormalNotice` + rota `/notices` | ✅ **Implementado** |
 | Carnê de IPTU parcelado | `Rental.iptuAmount` (sem carnê) | ⚠️ **Parcial** |
-| Permissões granulares por módulo | `UserRole` (papéis fixos) | ⚠️ **Parcial** |
+| Permissões granulares por módulo | `UserModulePermission` + `/permissions` + guard | ✅ **Implementado** |
 
 ---
 

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -1,215 +1,128 @@
-# Sistema UNILOC / IMOBILI — Mapeamento Completo
+# Sistema IMOBILI/UNILOC — Mapa de Funcionalidades & Análise de Lacunas
 
-> Sistema **offline** legado de administração de carteira de imóveis (locação) usado pela
-> **Imobiliária Lemos** (Noemia Pires Lemos — Franca/SP). Construído em **Visual FoxPro**.
-> Este documento mapeia caminhos, estrutura de dados, relacionamentos e funções, a partir do
-> backup de dados presente em `data/uniloc/`.
-
----
-
-## 1. Identificação do sistema
-
-| Item | Valor |
-|------|-------|
-| Nome do produto | **UNILOC** (motor de dados) / **IMOBILI** (aplicação) |
-| Plataforma | Visual FoxPro (BDE — Borland Database Engine, `bde-vista64`) |
-| Empresa | NOEMIA PIRES LEMOS — Imobiliária Lemos |
-| Endereço | Estevão Leão Bourroul, 1685 — Franca/SP — CEP 14400-750 |
-| CNPJ/CGC | 75237326668 · CRECI 61053F/SP |
-| Telefone / Site | 3723-0045 · www.imobiliarialemos.com.br |
-| Banco padrão | SICREDI |
-| Comissão / Juros / Multa | 10% · 0,033%/dia · 10% |
-| Código da unidade | CODUNI `000851` · IDIMOBILIA `72164.G0TQ` |
-| Última versão aplicada | **17.0.372** (aplicada em 11/02/2022) |
-
-### Histórico de versões (`versoes.dbf`)
-`11.100.123` (02/2018) → `11.100.298` → `11.100.318` → `11.100.339` →
-`17.0.2` (10/2018) → `17.0.42` → `17.0.60` → `17.0.98` → `17.0.116/117` (2020) →
-**`17.0.372`** (02/2022, última).
+> Referência **funcional** (não de dados) do sistema offline legado de administração de
+> carteira de locação **IMOBILI** (motor **UNILOC**, Visual FoxPro). O objetivo deste
+> documento é **identificar funções comprovadas** desse sistema (em uso há ~25 anos) que
+> podem **faltar ou ser melhoradas** no AgoraEncontrei.
+>
+> ⚠️ **Sem dados pessoais.** Nenhum dado de cliente, contrato, proprietário ou usuário é
+> registrado aqui — apenas a engenharia de funcionalidades do software.
 
 ---
 
-## 2. Caminhos (no computador Windows original)
+## 1. O que é o sistema
 
-| Caminho | Conteúdo |
-|---------|----------|
-| `C:\Imobili\` | Pasta da aplicação |
-| `C:\Imobili\IMOBILI.exe` | Executável principal (6,4 MB, atualizado em 06/01/2025) |
-| `C:\Imobili\bde-vista64.exe` | Borland Database Engine (acesso aos `.dbf`) |
-| `C:\Imobili\Estruturas.exe` | Utilitário de estrutura das tabelas (1999) |
-| `C:\Imobili\spdBoleto_dependencies_3.0.11.6487.exe` | Gerador de boletos |
-| `C:\Imobili\imobilichb.CFG` | Arquivo de configuração |
-| `C:\Imobili\Documentos\`, `C:\Imobili\utilidade\` | Documentos e utilitários |
-| **`C:\UNILOC\DADOS\`** | **Diretório do banco de dados** (alias `dadosservidorlemos`) — definido em `path_bd.dbf` |
+Aplicação desktop de **administração de locação** (property management) para imobiliárias.
+Cobre todo o ciclo: cadastro → contrato → cobrança mensal → recebimento → repasse ao
+proprietário → rescisão, mais o financeiro interno da imobiliária.
 
-> No repositório, o backup desses dados está em `data/uniloc/backup_extraido/`.
+- **Aplicação:** `IMOBILI.exe` (Visual FoxPro) · motor de dados **UNILOC**
+- **Componentes:** BDE (Borland Database Engine), utilitário `Estruturas.exe`, gerador de
+  boletos `spdBoleto`, arquivo de config `.CFG`
+- **Dados:** ~54 tabelas DBF/FoxPro
 
 ---
 
-## 3. Formato dos arquivos
+## 2. Funcionalidades por módulo (derivadas da estrutura do sistema)
 
-- **`.DBF`** — tabela de dados (dBase/FoxPro)
-- **`.FPT`** — campos memo/texto longo (referenciados pela tabela)
-- **`.CDX`** — índices compostos
-- **`*_Log.FPT`** — logs/auditoria
-- `dbesquema.dbf` — **dicionário oficial**: lista as 54 tabelas e indica quais têm `.CDX` e `.FPT`
-- `path_bd.dbf` — caminho do banco
-- `FOXUSER.DBF/.FPT` — recursos da interface FoxPro
+### A. Cadastros
+- Proprietário (locador) com dados bancários para repasse
+- **Co-proprietários / locador secundário** com **rateio por percentual**
+- **Favorecidos de repasse** (terceiros) com **% por imóvel**
+- Inquilino, Fiador (até 2 fiadores por contrato), cônjuge e representantes legais
+- Imóvel com vínculo de % de propriedade, IPTU, luz, água, garagem
+- **Vagas de garagem** cadastradas e vinculáveis a imóveis distintos
+- Base de CEP própria
 
-Leitura em Python: `pip install dbfread` →
-`DBF(path, ignore_missing_memofile=True, encoding='latin-1')`.
+### B. Contratos
+- Índice de reajuste (IGPM/IPCA…), data-base e mês de reajuste anual
+- Tipo de garantia: fiador / caução / seguro fiança / título de capitalização
+- Comissão da imobiliária e taxa de administração configuráveis
+- Multa, juros (por dia/mês) e cálculo de IRRF retido
+- Encargos inclusos no aluguel (água, luz, condomínio, IPTU)
+- **Vistoria de entrada e de saída** (data + observações)
+- Renovação com contagem de renovações e próxima data de reajuste
 
----
+### C. Cobrança mensal (recebimentos)
+- Geração de lançamentos de aluguel + encargos + diversos
+- **Emissão de boleto** (linha digitável, nosso número, código de barras)
+- Lançamentos diversos (débitos/créditos avulsos no contrato)
+- **Carnê de IPTU parcelado** lançado por imóvel/ano e rateado ao inquilino
+- Sequenciadores de nº de boleto, recibo e edital
+- **Baixa por arquivo CNAB de retorno** (campo `BAIXACNAB`) + baixa manual
 
-## 4. Chaves de relacionamento (PKs/FKs)
+### D. Repasse ao proprietário
+- Cálculo do líquido = aluguel − comissão − IRRF − despesas
+- **Rateio do repasse entre múltiplos proprietários/favorecidos** por percentual
+- Registro de banco/conta de destino por favorecido
 
-Quase todas as tabelas se ligam por estes códigos de 6 dígitos (string):
+### E. Financeiro interno da imobiliária
+- **Caixa** (fluxo de débito/crédito por grupo/plano de contas)
+- **Movimentação bancária** por conta + conciliação caixa × banco
+- **Contas a pagar (despesas)** com favorecido, vencimento, pagamento e documento
+- **Controle de cheques (a pagar / pré-datados)** com situação e favorecido
+- Plano de contas (grupos)
 
-| Código | Significado | Tabela principal |
-|--------|-------------|------------------|
-| `CODLOC` | Locador (proprietário) | `locador.dbf` |
-| `CODINQ` | Inquilino | `inquili.dbf` |
-| `CODIMO` | Imóvel | `imovel.dbf` |
-| `CODCON` | Contrato | `contrato.dbf` |
-| `CODFIA` | Fiador | `fiador.dbf` |
-| `CODFAV` | Favorecido (repasse) | `favore.dbf` |
-| `CODSEC` | Locador secundário | `secunlo.dbf` |
-| `CODGR` | Grupo (plano de contas) | `grupo.dbf` |
-| `CODLAN` | Lançamento financeiro | `diversos.dbf` |
-| `CODBAN` | Conta bancária | `contas.dbf` / `bancos.dbf` |
+### F. Pós-contrato e jurídico
+- **Acordos / renegociação** de débitos em atraso (novo cronograma)
+- **Rescisão com apuração de saldo**: aluguel proporcional, IPTU pro-rata, multa,
+  bonificação, devolução de caução, lançamentos de rescisão
+- **Notificações formais** (aviso/extrajudicial) com tipo, assunto e situação
 
-Contadores de sequência ficam nas tabelas `COD*` (`codcad.dbf` concentra os próximos
-números de locador, inquilino, imóvel, contrato, etc.).
-
----
-
-## 5. Tabelas por área funcional
-
-### 5.1 Cadastros (pessoas e imóveis)
-| Tabela | Recs | Função |
-|--------|------|--------|
-| `locador.dbf` | 252 | Proprietários (dados, banco, repasse, cônjuge, representantes) — 90 campos |
-| `inquili.dbf` | 904 | Inquilinos — 64 campos |
-| `fiador.dbf` | 1.025 | Fiadores — 63 campos |
-| `favore.dbf` | 59 | Favorecidos de repasse — 90 campos |
-| `secunlo.dbf` / `secunda.dbf` | 28 / 31 | Locadores secundários e rateio (% de cada) |
-| `favopor.dbf` | 55 | % de favorecido por imóvel |
-| `imovel.dbf` | 623 | Imóveis (endereço, tipo, status, IPTU, luz, água) — 35 campos |
-| `garagem.dbf` | 19 | Vagas de garagem vinculadas a imóvel |
-| `cep.dbf` | 2.801 | Base de CEPs |
-
-### 5.2 Contratos
-| Tabela | Recs | Função |
-|--------|------|--------|
-| `contrato.dbf` | 982 | Contratos de locação (índice de reajuste, garantia, comissão, multa, juros, IRRF) — **88 campos** |
-| `continq.dbf` | 21 | Inquilinos adicionais por contrato |
-| `contfia.dbf` | 1.149 | Fiadores por contrato |
-| `acordos.dbf` | 322 | Acordos/renegociações |
-| `rescisao.dbf` | 809 | Rescisões de contrato |
-| `resclncs.dbf` | 1.561 | Lançamentos de rescisão |
-| `incendio.dbf` | 472 | Seguro incêndio |
-| `fianca.dbf` | 0 | Seguro fiança (vazia) |
-| `notifics.dbf` | 35 | Notificações ao inquilino/locador |
-
-### 5.3 Financeiro — recebimentos e cobrança
-| Tabela | Recs | Função |
-|--------|------|--------|
-| `aluguel.dbf` | 27.898 | **Lançamentos de aluguel** (vencimentos, recebimento, multa, juros, IR, comissão) — 45 campos |
-| `diversos.dbf` | 12.660 | Lançamentos diversos (débitos/créditos avulsos no contrato) — 68 campos |
-| `boletos.dbf` | 19.335 | Boletos emitidos (linha digitável, nosso número, código de barras) |
-| `lanciptu.dbf` | 9.505 | Parcelas de IPTU lançadas/cobradas |
-| `iptu.dbf` | 1.781 | IPTU por imóvel/ano |
-| `impresso.dbf` | 12.336 | Documentos impressos (recibos, comprovantes) |
-| `num_rec.dbf` | 60.073 | Sequência de nº de recibo |
-| `num_bol.dbf` / `num_edi.dbf` | 6 / 0 | Sequência de boleto/edital |
-
-### 5.4 Financeiro — repasses e caixa
-| Tabela | Recs | Função |
-|--------|------|--------|
-| `lanrepas.dbf` | **67.674** | **Repasses aos proprietários** (a maior tabela — quem recebe, %, valor, banco) — 42 campos |
-| `caixa.dbf` | 36.040 | Movimento de caixa (débito/crédito, grupo, contraparte) — 28 campos |
-| `movbanco.dbf` | 18.818 | Movimentação bancária |
-| `movfutur.dbf` | 0 | Movimentos futuros (vazia) |
-| `cadespe.dbf` | 4.800 | Despesas (contas a pagar) — favorecido, vencimento, pagamento |
-| `cp_cheqs.dbf` | 4.116 | Cheques a pagar |
-| `contas.dbf` / `bancos.dbf` | 1 / 4 | Contas bancárias da imobiliária |
-
-### 5.5 Apoio / parametrização
-| Tabela | Recs | Função |
-|--------|------|--------|
-| `parame.dbf` | 1 | **Configuração geral** (empresa, banco, taxas, NF, e-mail/SMTP, FTP) — 201 campos |
-| `indices.dbf` | 211 | Índices de reajuste (IGPM, IPCA, etc.) por data |
-| `tabela.dbf` | 216 | Tabela de IR (faixas, alíquota, dedução) |
-| `grupo.dbf` | 49 | Grupos / plano de contas |
-| `feriados.dbf` | 50 | Feriados (cálculo de vencimentos) |
-| `modelos.dbf` | 5 | Modelos de documento |
-| `usuarios.dbf` | 5 | Usuários do sistema (~50 flags de permissão por módulo) |
-| `lembre.dbf` | 1 | Lembretes/agenda |
-| `logoban.dbf` | 1 | Logos de banco (campo `General`/OLE) |
-| `versoes.dbf` | 11 | Histórico de versões |
-
-### 5.6 Tabelas temporárias (na raiz `data/uniloc/`)
-`tmp_rel.DBF`, `tmp_rep.DBF`, `tmp_div.DBF`, `tmp_iptu.DBF`, `tmp_repo.DBF`,
-`tmp_dash_calcula_txR.DBF`, `tmp2_dash_calcula_txA.DBF` — resultados intermediários de
-relatórios/dashboards. `RFBR.DBF` (593 KB) parece base auxiliar (provável Receita Federal/bairros).
+### G. Apoio
+- Tabela de **índices de reajuste** por data
+- Tabela de **IR** (faixas, alíquota, dedução) para retenção
+- Feriados (cálculo de vencimentos em dia útil)
+- Modelos de documento
+- **Permissões granulares por módulo** (~50 flags por usuário)
+- Lembretes/agenda operacional
+- Parametrização central (taxas, dados bancários, NF, e-mail/SMTP, FTP)
 
 ---
 
-## 6. Usuários cadastrados (`usuarios.dbf`)
-`UNION` (master), **NOEMIA LEMOS** (Diretora — lemos@imobiliarialemos.com.br),
-NAIRA LEMOS, GABRIEL LEAL, CELIA. Senhas existem nos campos `SENHA` (N6) e `PASSWORD` (C8) —
-**dados sensíveis: não expor.**
+## 3. Cobertura no AgoraEncontrei
+
+Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativo:
+
+| Funcionalidade IMOBILI | AgoraEncontrei | Status |
+|------------------------|----------------|--------|
+| Cadastro locador/inquilino/fiador/imóvel | `Client`, `Property`, `Contract.guarantor/guarantor2` | ✅ |
+| Contrato (reajuste, garantia, comissão, IRRF, vistoria) | `Contract` (campos completos) | ✅ |
+| Cobrança mensal + boleto | `Rental`, `Invoice` (Asaas) | ✅ |
+| Índices de reajuste | `bcb-rates` | ✅ |
+| Repasse simples ao proprietário | `OwnerRepasse`, `ScheduledRepasse` | ✅ |
+| Caixa / transações | `Transaction`, `FinancialForecast` | ✅ |
+| Nota fiscal de serviço | `FiscalNote` | ✅ |
+| **Rateio de repasse multi-proprietário/favorecido** | — | ⚠️ **Lacuna** |
+| **Contas a pagar + cheques pré-datados** | — | ⚠️ **Lacuna** |
+| **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
+| **Acordos / renegociação de dívida** | — | ⚠️ **Lacuna** |
+| **Cálculo automatizado de rescisão** | campos existem, sem motor | ⚠️ **Parcial** |
+| **Notificação formal/extrajudicial** | `legal` + `alerts` (parcial) | ⚠️ **Parcial** |
+| Carnê de IPTU parcelado | `Rental.iptuAmount` (sem carnê) | ⚠️ **Parcial** |
+| Permissões granulares por módulo | `UserRole` (papéis fixos) | ⚠️ **Parcial** |
 
 ---
 
-## 7. Fluxo operacional (como o sistema funciona)
+## 4. Recomendações (caminhos a corrigir/melhorar)
 
-1. **Cadastro**: locador → imóvel (com % de repasse) → inquilino → fiador.
-2. **Contrato** (`contrato.dbf`) amarra locador+imóvel+inquilino+fiador, define índice de
-   reajuste, garantia, comissão da imobiliária, dia de vencimento e multa/juros.
-3. **Geração de cobrança**: todo mês gera lançamentos em `aluguel.dbf` (+ `diversos`/`lanciptu`)
-   e emite `boletos.dbf` (SICREDI).
-4. **Recebimento**: baixa do boleto atualiza situação (`A_SITUI/A_SITUP`) e alimenta o `caixa.dbf`.
-5. **Repasse**: o valor do aluguel menos comissão/IR vira `lanrepas.dbf` → pagamento ao
-   proprietário (e favorecidos via `favopor`/`secunda`).
-6. **Saída**: `rescisao.dbf` + `resclncs.dbf` encerram o contrato.
+Priorizado por impacto operacional numa imobiliária de locação:
 
-Reajuste usa `indices.dbf`; retenção de IR usa `tabela.dbf`; despesas próprias da imobiliária
-em `cadespe.dbf`/`cp_cheqs.dbf`.
+1. **Rateio de repasse multi-proprietário** — `OwnerRepasse` hoje tem um único
+   `landlordId`. Imóveis com co-proprietários/favorecidos precisam de uma tabela de
+   participantes (`% por favorecido`), como `favopor`/`secunda`/`secunlo` faziam.
+2. **Módulo Contas a Pagar + Cheques** — despesas da imobiliária e de terceiros
+   (`cadespe`/`cp_cheqs`): favorecido, vencimento, status, controle de cheques pré-datados.
+3. **Motor de rescisão** — usar os campos já existentes em `Contract`/`Rental` para
+   calcular automaticamente o acerto de saída (proporcional + IPTU pro-rata + multa +
+   bonificação + caução).
+4. **Acordos/renegociação** — novo cronograma de parcelas para débitos em atraso, com
+   vínculo aos lançamentos originais.
+5. **Conciliação bancária** — importar extrato/CNAB de retorno para baixa automática e
+   bater caixa × banco.
+6. **Notificação formal padronizada** — tipo, assunto, situação e data de resolução
+   (cobrança amigável → extrajudicial).
+7. **Permissões granulares por módulo** — complementar `UserRole` com flags por recurso.
 
----
-
-## 8. Correspondência com o AgoraEncontrei (Prisma) — para migração futura
-
-| UNILOC (legado) | AgoraEncontrei (Prisma) |
-|-----------------|--------------------------|
-| `locador` | `PropertyOwner` / `Client` (role proprietário) |
-| `inquili` | `Client` (role inquilino) / `Contact` |
-| `fiador` | (novo — fiador no `Contract`) |
-| `imovel` | `Property` |
-| `contrato` | `Contract` + `Rental` |
-| `aluguel` / `diversos` | `Transaction` / `Invoice` |
-| `boletos` | `Invoice` (Asaas/boleto) |
-| `lanrepas` | `OwnerRepasse` |
-| `caixa` / `movbanco` | `Transaction` |
-| `indices` | `bcb-rates` / reajuste |
-| `cadespe` / `cp_cheqs` | `Transaction` (despesa) |
-
-> Observação: os códigos legados (`CODLOC`, `CODIMO`, …) devem ser preservados como
-> `legacyId` em cada modelo para rastreabilidade na importação.
-
----
-
-## 9. Como reler os dados (script de referência)
-
-```python
-from dbfread import DBF
-t = DBF("data/uniloc/backup_extraido/contrato.dbf",
-        ignore_missing_memofile=True, encoding='latin-1')
-print([f.name for f in t.fields])      # campos
-for rec in t:                          # registros
-    print(rec)
-```
-
-Para exportar tudo para CSV/JSON ou carregar num PostgreSQL de staging, basta iterar sobre
-cada `.dbf` listado em `dbesquema.dbf`.
+> Estas recomendações são apenas de **funcionalidade**; nenhuma migração de dados é
+> proposta ou necessária.

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -125,17 +125,26 @@ Priorizado por impacto operacional numa imobiliária de locação:
    com reconciliação de centavos), modelos `Agreement`/`AgreementInstallment`, rota
    `/api/v1/agreements`. Migration `20260630000003_add_agreements`.
 
-### Ainda pendente (parcial — próximos passos)
-5. **Conciliação bancária** — importar extrato/CNAB de retorno para baixa automática e
-   bater caixa × banco.
-6. **Notificação formal padronizada** — tipo, assunto, situação e data de resolução
-   (cobrança amigável → extrajudicial).
-7. **Permissões granulares por módulo** — complementar `UserRole` com flags por recurso.
+5. ~~**Conciliação bancária**~~ ✅ **Implementado** — `BankReconciliation` +
+   `BankStatementEntry`, parsers CSV/CNAB400 e engine de matching (`matchEntries`), com
+   baixa automática opcional. Rota `/api/v1/reconciliation`.
+6. ~~**Notificação formal padronizada**~~ ✅ **Implementado** — `FormalNotice` (tipo,
+   assunto, situação, data de resolução). Rota `/api/v1/notices`.
+7. ~~**Permissões granulares por módulo**~~ ✅ **Implementado** — `UserModulePermission`
+   + guard `requirePermission` (opt-in) + rota `/api/v1/permissions`.
+   Migrations 5–7: `20260630000004_add_notices_reconciliation_permissions`.
 
-> Estas recomendações são apenas de **funcionalidade**; nenhuma migração de dados é
-> proposta ou necessária.
+### Ainda pendente (parcial)
+- **Carnê de IPTU parcelado** — hoje só `Rental.iptuAmount` (valor por cobrança); falta
+  o carnê anual por imóvel com rateio de parcelas (Uniloc `iptu`/`lanciptu`).
+- **Frontend (telas)** dos módulos novos.
+
+> Estas funcionalidades são apenas de **código**; nenhuma migração de dados foi feita.
 >
-> **Antes do deploy:** rodar `pnpm db:generate && pnpm typecheck` no ambiente de dev
-> (o engine do Prisma não funciona neste container) e aplicar as 4 migrations no Neon
-> (são idempotentes). A validação aqui foi por checagem de sintaxe (`node strip-types`)
-> e testes unitários da matemática (rateio, rescisão e parcelas — todos fecham em centavos).
+> **Estado da validação (neste container):** dependências instaladas, **Prisma client
+> gerado** (engine baixado manualmente), **`tsc --noEmit` sem nenhum erro novo** (só 11
+> pré-existentes em `automation.ts`/`tomas.service.ts`) e **suíte de 21 testes 100% verde**.
+>
+> **Antes do deploy:** aplicar as **5 migrations** (`20260630000000`..`20260630000004`)
+> no banco Neon — são idempotentes (`IF NOT EXISTS`) e o projeto não roda
+> `prisma migrate deploy` automaticamente.

--- a/docs/SISTEMA-UNILOC-MAPEAMENTO.md
+++ b/docs/SISTEMA-UNILOC-MAPEAMENTO.md
@@ -94,7 +94,7 @@ Boa parte já existe (o schema Prisma já cita `legacyId` do Uniloc). Comparativ
 | Caixa / transações | `Transaction`, `FinancialForecast` | ✅ |
 | Nota fiscal de serviço | `FiscalNote` | ✅ |
 | **Rateio de repasse multi-proprietário/favorecido** | `RepasseBeneficiary` + `scheduleRepasseWithSplit` | ✅ **Implementado** |
-| **Contas a pagar + cheques pré-datados** | — | ⚠️ **Lacuna** |
+| **Contas a pagar + cheques pré-datados** | `AccountPayable` + `BankCheck` + rota `/payables` | ✅ **Implementado** |
 | **Conciliação bancária / CNAB retorno** | parcial (Asaas webhook) | ⚠️ **Parcial** |
 | **Acordos / renegociação de dívida** | — | ⚠️ **Lacuna** |
 | **Cálculo automatizado de rescisão** | campos existem, sem motor | ⚠️ **Parcial** |

--- a/packages/database/prisma/migrations/20260630000000_add_repasse_beneficiaries/migration.sql
+++ b/packages/database/prisma/migrations/20260630000000_add_repasse_beneficiaries/migration.sql
@@ -1,0 +1,44 @@
+-- Rateio de repasse multi-proprietário (equivalente Uniloc: favore/secunlo/favopor/secunda).
+--
+-- Cria a tabela de beneficiários do repasse de um contrato. Cada linha define
+-- um favorecido (proprietário, locador secundário ou terceiro) e o percentual
+-- do repasse líquido que ele recebe. Quando um contrato não tem beneficiários,
+-- o repasse continua indo 100% para contracts.landlordId (comportamento atual).
+--
+-- NOTE: produção não roda `prisma migrate deploy` automaticamente — aplicar
+-- este script manualmente no banco Neon. Idempotente (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS "repasse_beneficiaries" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "contractId" TEXT NOT NULL,
+    "clientId" TEXT,
+    "name" TEXT NOT NULL,
+    "percentage" DECIMAL(5,2) NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'OWNER',
+    "bankName" TEXT,
+    "bankAgency" TEXT,
+    "bankAccount" TEXT,
+    "pixKey" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "repasse_beneficiaries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "repasse_beneficiaries_companyId_idx" ON "repasse_beneficiaries"("companyId");
+CREATE INDEX IF NOT EXISTS "repasse_beneficiaries_contractId_idx" ON "repasse_beneficiaries"("contractId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'repasse_beneficiaries_contractId_fkey'
+  ) THEN
+    ALTER TABLE "repasse_beneficiaries"
+      ADD CONSTRAINT "repasse_beneficiaries_contractId_fkey"
+      FOREIGN KEY ("contractId") REFERENCES "contracts"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/migrations/20260630000001_add_accounts_payable_checks/migration.sql
+++ b/packages/database/prisma/migrations/20260630000001_add_accounts_payable_checks/migration.sql
@@ -1,0 +1,73 @@
+-- Contas a pagar + cheques (financeiro interno da imobiliária).
+-- Equivalente Uniloc: cadespe (despesas) e cp_cheqs (cheques).
+--
+-- NOTE: produção não roda `prisma migrate deploy` automaticamente — aplicar
+-- este script manualmente no banco Neon. Idempotente (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS "accounts_payable" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "legacyId" TEXT,
+    "description" TEXT NOT NULL,
+    "payeeName" TEXT NOT NULL,
+    "payeeId" TEXT,
+    "category" TEXT,
+    "documentNumber" TEXT,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "paidAt" TIMESTAMP(3),
+    "paymentDoc" TEXT,
+    "paymentMethod" TEXT,
+    "contractId" TEXT,
+    "propertyId" TEXT,
+    "notes" TEXT,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_payable_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "accounts_payable_companyId_idx" ON "accounts_payable"("companyId");
+CREATE INDEX IF NOT EXISTS "accounts_payable_status_idx" ON "accounts_payable"("status");
+CREATE INDEX IF NOT EXISTS "accounts_payable_dueDate_idx" ON "accounts_payable"("dueDate");
+
+CREATE TABLE IF NOT EXISTS "bank_checks" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "legacyId" TEXT,
+    "checkNumber" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "bankCode" TEXT,
+    "payeeName" TEXT,
+    "category" TEXT,
+    "issueDate" TIMESTAMP(3),
+    "dueDate" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "clearedAt" TIMESTAMP(3),
+    "accountPayableId" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "bank_checks_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "bank_checks_companyId_idx" ON "bank_checks"("companyId");
+CREATE INDEX IF NOT EXISTS "bank_checks_status_idx" ON "bank_checks"("status");
+CREATE INDEX IF NOT EXISTS "bank_checks_dueDate_idx" ON "bank_checks"("dueDate");
+CREATE INDEX IF NOT EXISTS "bank_checks_accountPayableId_idx" ON "bank_checks"("accountPayableId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'bank_checks_accountPayableId_fkey'
+  ) THEN
+    ALTER TABLE "bank_checks"
+      ADD CONSTRAINT "bank_checks_accountPayableId_fkey"
+      FOREIGN KEY ("accountPayableId") REFERENCES "accounts_payable"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/migrations/20260630000002_add_rescissions/migration.sql
+++ b/packages/database/prisma/migrations/20260630000002_add_rescissions/migration.sql
@@ -1,0 +1,34 @@
+-- Acerto de rescisão de contrato (equivalente Uniloc rescisao/resclncs).
+--
+-- NOTE: produção não roda `prisma migrate deploy` automaticamente — aplicar
+-- este script manualmente no banco Neon. Idempotente (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS "rescissions" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "contractId" TEXT NOT NULL,
+    "legacyId" TEXT,
+    "exitDate" TIMESTAMP(3) NOT NULL,
+    "proRataRent" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "proRataIptu" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "penaltyValue" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "outstandingValue" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "bonusValue" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "depositRefund" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "totalDebits" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "totalCredits" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "netResult" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "settlement" TEXT NOT NULL DEFAULT 'SETTLED',
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "items" JSONB NOT NULL DEFAULT '[]',
+    "notes" TEXT,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "rescissions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "rescissions_companyId_idx" ON "rescissions"("companyId");
+CREATE INDEX IF NOT EXISTS "rescissions_contractId_idx" ON "rescissions"("contractId");
+CREATE INDEX IF NOT EXISTS "rescissions_status_idx" ON "rescissions"("status");

--- a/packages/database/prisma/migrations/20260630000003_add_agreements/migration.sql
+++ b/packages/database/prisma/migrations/20260630000003_add_agreements/migration.sql
@@ -1,0 +1,60 @@
+-- Acordos / renegociação de dívida (equivalente Uniloc acordos).
+--
+-- NOTE: produção não roda `prisma migrate deploy` automaticamente — aplicar
+-- este script manualmente no banco Neon. Idempotente (IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS "agreements" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "contractId" TEXT,
+    "legacyId" TEXT,
+    "tenantName" TEXT,
+    "originalDebt" DECIMAL(12,2) NOT NULL,
+    "discountValue" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "agreedValue" DECIMAL(12,2) NOT NULL,
+    "installments" INTEGER NOT NULL,
+    "firstDueDate" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "notes" TEXT,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agreements_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "agreements_companyId_idx" ON "agreements"("companyId");
+CREATE INDEX IF NOT EXISTS "agreements_contractId_idx" ON "agreements"("contractId");
+CREATE INDEX IF NOT EXISTS "agreements_status_idx" ON "agreements"("status");
+
+CREATE TABLE IF NOT EXISTS "agreement_installments" (
+    "id" TEXT NOT NULL,
+    "agreementId" TEXT NOT NULL,
+    "number" INTEGER NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "paidAt" TIMESTAMP(3),
+    "paidAmount" DECIMAL(12,2),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agreement_installments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "agreement_installments_agreementId_number_key" ON "agreement_installments"("agreementId", "number");
+CREATE INDEX IF NOT EXISTS "agreement_installments_agreementId_idx" ON "agreement_installments"("agreementId");
+CREATE INDEX IF NOT EXISTS "agreement_installments_status_idx" ON "agreement_installments"("status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'agreement_installments_agreementId_fkey'
+  ) THEN
+    ALTER TABLE "agreement_installments"
+      ADD CONSTRAINT "agreement_installments_agreementId_fkey"
+      FOREIGN KEY ("agreementId") REFERENCES "agreements"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/migrations/20260630000004_add_notices_reconciliation_permissions/migration.sql
+++ b/packages/database/prisma/migrations/20260630000004_add_notices_reconciliation_permissions/migration.sql
@@ -1,0 +1,96 @@
+-- Notificações formais + conciliação bancária + permissões por módulo.
+-- Equivalente Uniloc: notifics, movbanco/BAIXACNAB, usuarios.U_MODULO*.
+--
+-- NOTE: produção não roda `prisma migrate deploy` automaticamente — aplicar
+-- manualmente no banco Neon. Idempotente (IF NOT EXISTS).
+
+-- Notificações formais/extrajudiciais
+CREATE TABLE IF NOT EXISTS "formal_notices" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "contractId" TEXT,
+    "legacyId" TEXT,
+    "recipient" TEXT NOT NULL DEFAULT 'TENANT',
+    "recipientName" TEXT,
+    "type" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "noticeDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "operator" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "formal_notices_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "formal_notices_companyId_idx" ON "formal_notices"("companyId");
+CREATE INDEX IF NOT EXISTS "formal_notices_contractId_idx" ON "formal_notices"("contractId");
+CREATE INDEX IF NOT EXISTS "formal_notices_status_idx" ON "formal_notices"("status");
+
+-- Conciliação bancária: lote
+CREATE TABLE IF NOT EXISTS "bank_reconciliations" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'CSV',
+    "reference" TEXT,
+    "bankCode" TEXT,
+    "importedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "totalEntries" INTEGER NOT NULL DEFAULT 0,
+    "matchedCount" INTEGER NOT NULL DEFAULT 0,
+    "unmatchedCount" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'IMPORTED',
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "bank_reconciliations_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "bank_reconciliations_companyId_idx" ON "bank_reconciliations"("companyId");
+CREATE INDEX IF NOT EXISTS "bank_reconciliations_status_idx" ON "bank_reconciliations"("status");
+
+-- Conciliação bancária: movimentos
+CREATE TABLE IF NOT EXISTS "bank_statement_entries" (
+    "id" TEXT NOT NULL,
+    "reconciliationId" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "entryDate" TIMESTAMP(3) NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "direction" TEXT NOT NULL DEFAULT 'CREDIT',
+    "description" TEXT,
+    "nossoNumero" TEXT,
+    "documentNumber" TEXT,
+    "occurrenceCode" TEXT,
+    "matchStatus" TEXT NOT NULL DEFAULT 'UNMATCHED',
+    "matchedRentalId" TEXT,
+    "matchedInvoiceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "bank_statement_entries_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "bank_statement_entries_reconciliationId_idx" ON "bank_statement_entries"("reconciliationId");
+CREATE INDEX IF NOT EXISTS "bank_statement_entries_companyId_idx" ON "bank_statement_entries"("companyId");
+CREATE INDEX IF NOT EXISTS "bank_statement_entries_matchStatus_idx" ON "bank_statement_entries"("matchStatus");
+CREATE INDEX IF NOT EXISTS "bank_statement_entries_nossoNumero_idx" ON "bank_statement_entries"("nossoNumero");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = 'bank_statement_entries_reconciliationId_fkey') THEN
+    ALTER TABLE "bank_statement_entries" ADD CONSTRAINT "bank_statement_entries_reconciliationId_fkey"
+      FOREIGN KEY ("reconciliationId") REFERENCES "bank_reconciliations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- Permissões por módulo
+CREATE TABLE IF NOT EXISTS "user_module_permissions" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "module" TEXT NOT NULL,
+    "canView" BOOLEAN NOT NULL DEFAULT true,
+    "canEdit" BOOLEAN NOT NULL DEFAULT false,
+    "canDelete" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "user_module_permissions_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "user_module_permissions_userId_module_key" ON "user_module_permissions"("userId", "module");
+CREATE INDEX IF NOT EXISTS "user_module_permissions_companyId_idx" ON "user_module_permissions"("companyId");
+CREATE INDEX IF NOT EXISTS "user_module_permissions_userId_idx" ON "user_module_permissions"("userId");

--- a/packages/database/prisma/migrations/20260630000005_add_iptu_carne/migration.sql
+++ b/packages/database/prisma/migrations/20260630000005_add_iptu_carne/migration.sql
@@ -1,0 +1,49 @@
+-- Carnê de IPTU parcelado (equivalente Uniloc iptu/lanciptu).
+-- NOTE: aplicar manualmente no Neon. Idempotente.
+
+CREATE TABLE IF NOT EXISTS "iptu_carnes" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "propertyId" TEXT,
+    "contractId" TEXT,
+    "legacyId" TEXT,
+    "year" INTEGER NOT NULL,
+    "iptuCode" TEXT,
+    "totalAmount" DECIMAL(12,2) NOT NULL,
+    "installments" INTEGER NOT NULL,
+    "chargeToTenant" BOOLEAN NOT NULL DEFAULT true,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "notes" TEXT,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "iptu_carnes_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "iptu_carnes_companyId_idx" ON "iptu_carnes"("companyId");
+CREATE INDEX IF NOT EXISTS "iptu_carnes_propertyId_idx" ON "iptu_carnes"("propertyId");
+CREATE INDEX IF NOT EXISTS "iptu_carnes_year_idx" ON "iptu_carnes"("year");
+
+CREATE TABLE IF NOT EXISTS "iptu_installments" (
+    "id" TEXT NOT NULL,
+    "carneId" TEXT NOT NULL,
+    "number" INTEGER NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "paidAt" TIMESTAMP(3),
+    "rentalId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "iptu_installments_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "iptu_installments_carneId_number_key" ON "iptu_installments"("carneId","number");
+CREATE INDEX IF NOT EXISTS "iptu_installments_carneId_idx" ON "iptu_installments"("carneId");
+CREATE INDEX IF NOT EXISTS "iptu_installments_status_idx" ON "iptu_installments"("status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = 'iptu_installments_carneId_fkey') THEN
+    ALTER TABLE "iptu_installments" ADD CONSTRAINT "iptu_installments_carneId_fkey"
+      FOREIGN KEY ("carneId") REFERENCES "iptu_carnes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1181,6 +1181,7 @@ model Contract {
   documents         Document[]
   legalCases        LegalCase[]
   history           ContractHistory[]
+  repasseBeneficiaries RepasseBeneficiary[]
   @@unique([companyId, legacyId])
   @@index([companyId])
   @@index([tenantId])
@@ -1188,6 +1189,36 @@ model Contract {
   @@index([propertyId])
   @@index([status])
   @@map("contracts")
+}
+
+/// Beneficiários do rateio de repasse de um contrato.
+///
+/// Permite que o aluguel recebido seja dividido entre vários
+/// proprietários/favorecidos com percentuais distintos — equivalente às
+/// tabelas `favore`/`secunlo`/`favopor`/`secunda` do sistema legado Uniloc.
+/// Quando um contrato NÃO tem beneficiários cadastrados, o repasse continua
+/// indo 100% para `Contract.landlordId` (comportamento atual preservado).
+model RepasseBeneficiary {
+  id          String   @id @default(cuid())
+  companyId   String
+  contractId  String
+  contract    Contract @relation(fields: [contractId], references: [id], onDelete: Cascade)
+  clientId    String?  // Client.id do favorecido (destino da transferência), se cadastrado
+  name        String   // Nome do favorecido (desnormalizado p/ histórico)
+  percentage  Decimal  @db.Decimal(5, 2) // % do repasse líquido destinado a este favorecido
+  role        String   @default("OWNER") // OWNER (locador) | SECONDARY (locador secundário) | FAVORED (favorecido/terceiro)
+  // Dados bancários do favorecido (opcionais — usados na transferência)
+  bankName    String?
+  bankAgency  String?
+  bankAccount String?
+  pixKey      String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([companyId])
+  @@index([contractId])
+  @@map("repasse_beneficiaries")
 }
 
 model Rental {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1340,6 +1340,67 @@ model FinancialForecast {
   @@map("financial_forecasts")
 }
 
+// ── Contas a Pagar + Cheques (financeiro interno da imobiliária) ───────────
+// Equivalente Uniloc: cadespe (despesas/contas a pagar) e cp_cheqs (cheques).
+
+/// Conta a pagar / despesa da imobiliária ou de terceiros (cadespe).
+model AccountPayable {
+  id            String      @id @default(cuid())
+  companyId     String
+  legacyId      String?     // coddes
+  description   String      // descricao
+  payeeName     String      // favorecido
+  payeeId       String?     // Contact/Client.id do favorecido, se cadastrado
+  category      String?     // grupo / plano de contas
+  documentNumber String?    // documento
+  amount        Decimal     @db.Decimal(12, 2)
+  dueDate       DateTime    // vencimento
+  status        String      @default("PENDING") // PENDING | PAID | CANCELLED
+  paidAt        DateTime?   // pagamento
+  paymentDoc    String?     // doc_pagto (comprovante)
+  paymentMethod String?     // PIX | TED | BOLETO | DINHEIRO | CHEQUE
+  contractId    String?     // vínculo opcional a contrato
+  propertyId    String?     // vínculo opcional a imóvel
+  notes         String?
+  createdBy     String?     // userId (usercad)
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+
+  checks        BankCheck[]
+
+  @@index([companyId])
+  @@index([status])
+  @@index([dueDate])
+  @@map("accounts_payable")
+}
+
+/// Cheque emitido / pré-datado (cp_cheqs).
+model BankCheck {
+  id              String          @id @default(cuid())
+  companyId       String
+  legacyId        String?         // codcp
+  checkNumber     String          // cheque_n
+  amount          Decimal         @db.Decimal(12, 2) // valor_cp
+  bankCode        String?         // codban
+  payeeName       String?         // favorecp
+  category        String?         // codgr / grupo
+  issueDate       DateTime?       // dataemi
+  dueDate         DateTime?       // data_cp (data do cheque / pré-datado)
+  status          String          @default("PENDING") // PENDING | CLEARED | CANCELLED (situcp)
+  clearedAt       DateTime?
+  accountPayableId String?        // vínculo à conta a pagar que originou
+  accountPayable  AccountPayable? @relation(fields: [accountPayableId], references: [id])
+  notes           String?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  @@index([companyId])
+  @@index([status])
+  @@index([dueDate])
+  @@index([accountPayableId])
+  @@map("bank_checks")
+}
+
 // ── NF-e / Notas Fiscais de Serviço ───────────────────────────────────────
 
 enum FiscalNoteStatus {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1573,6 +1573,54 @@ model UserModulePermission {
   @@map("user_module_permissions")
 }
 
+// ── Carnê de IPTU parcelado (equivalente Uniloc iptu/lanciptu) ─────────────
+
+/// Carnê anual de IPTU de um imóvel, com parcelas.
+model IptuCarne {
+  id           String           @id @default(cuid())
+  companyId    String
+  propertyId   String?
+  contractId   String?
+  legacyId     String?          // codiptu
+  year         Int              // ano de referência
+  iptuCode     String?          // nº do carnê / inscrição
+  totalAmount  Decimal          @db.Decimal(12, 2)
+  installments Int              // nº de parcelas
+  chargeToTenant Boolean        @default(true) // ratear ao inquilino
+  status       String           @default("OPEN") // OPEN | SETTLED | CANCELLED
+  notes        String?
+  createdBy    String?
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+
+  schedule     IptuInstallment[]
+
+  @@index([companyId])
+  @@index([propertyId])
+  @@index([year])
+  @@map("iptu_carnes")
+}
+
+/// Parcela de um carnê de IPTU.
+model IptuInstallment {
+  id         String    @id @default(cuid())
+  carneId    String
+  carne      IptuCarne @relation(fields: [carneId], references: [id], onDelete: Cascade)
+  number     Int
+  dueDate    DateTime
+  amount     Decimal   @db.Decimal(12, 2)
+  status     String    @default("PENDING") // PENDING | PAID
+  paidAt     DateTime?
+  rentalId   String?   // aluguel onde foi cobrada (se rateada ao inquilino)
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  @@unique([carneId, number])
+  @@index([carneId])
+  @@index([status])
+  @@map("iptu_installments")
+}
+
 // ── NF-e / Notas Fiscais de Serviço ───────────────────────────────────────
 
 enum FiscalNoteStatus {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1432,6 +1432,52 @@ model Rescission {
   @@map("rescissions")
 }
 
+/// Acordo / renegociação de dívida em atraso (equivalente Uniloc acordos).
+model Agreement {
+  id            String                 @id @default(cuid())
+  companyId     String
+  contractId    String?
+  legacyId      String?
+  tenantName    String?                // inquilino (desnormalizado)
+  originalDebt  Decimal                @db.Decimal(12, 2) // dívida original
+  discountValue Decimal                @db.Decimal(12, 2) @default(0)
+  agreedValue   Decimal                @db.Decimal(12, 2) // valor acordado (= original - desconto + acréscimos)
+  installments  Int                    // nº de parcelas
+  firstDueDate  DateTime
+  status        String                 @default("ACTIVE") // ACTIVE | FULFILLED | BROKEN | CANCELLED
+  notes         String?
+  createdBy     String?
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+
+  schedule      AgreementInstallment[]
+
+  @@index([companyId])
+  @@index([contractId])
+  @@index([status])
+  @@map("agreements")
+}
+
+/// Parcela de um acordo.
+model AgreementInstallment {
+  id          String    @id @default(cuid())
+  agreementId String
+  agreement   Agreement @relation(fields: [agreementId], references: [id], onDelete: Cascade)
+  number      Int       // nº da parcela (1..N)
+  dueDate     DateTime
+  amount      Decimal   @db.Decimal(12, 2)
+  status      String    @default("PENDING") // PENDING | PAID | OVERDUE
+  paidAt      DateTime?
+  paidAmount  Decimal?  @db.Decimal(12, 2)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([agreementId, number])
+  @@index([agreementId])
+  @@index([status])
+  @@map("agreement_installments")
+}
+
 // ── NF-e / Notas Fiscais de Serviço ───────────────────────────────────────
 
 enum FiscalNoteStatus {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1401,6 +1401,37 @@ model BankCheck {
   @@map("bank_checks")
 }
 
+/// Acerto de rescisão de contrato (equivalente Uniloc rescisao/resclncs).
+/// Guarda o resultado calculado por `calculateRescission` + o detalhamento.
+model Rescission {
+  id             String   @id @default(cuid())
+  companyId      String
+  contractId     String
+  legacyId       String?  // codcon/coddoc original
+  exitDate       DateTime // data de saída/entrega das chaves
+  proRataRent    Decimal  @db.Decimal(12, 2) @default(0)
+  proRataIptu    Decimal  @db.Decimal(12, 2) @default(0)
+  penaltyValue   Decimal  @db.Decimal(12, 2) @default(0)
+  outstandingValue Decimal @db.Decimal(12, 2) @default(0)
+  bonusValue     Decimal  @db.Decimal(12, 2) @default(0)
+  depositRefund  Decimal  @db.Decimal(12, 2) @default(0)
+  totalDebits    Decimal  @db.Decimal(12, 2) @default(0)
+  totalCredits   Decimal  @db.Decimal(12, 2) @default(0)
+  netResult      Decimal  @db.Decimal(12, 2) @default(0) // >0 inquilino paga; <0 a devolver
+  settlement     String   @default("SETTLED") // TENANT | TENANT_REFUND | SETTLED
+  status         String   @default("DRAFT")   // DRAFT | CONFIRMED | SETTLED
+  items          Json     @default("[]")       // detalhamento das linhas
+  notes          String?
+  createdBy      String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@index([companyId])
+  @@index([contractId])
+  @@index([status])
+  @@map("rescissions")
+}
+
 // ── NF-e / Notas Fiscais de Serviço ───────────────────────────────────────
 
 enum FiscalNoteStatus {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1478,6 +1478,101 @@ model AgreementInstallment {
   @@map("agreement_installments")
 }
 
+/// Notificação formal/extrajudicial ao inquilino/locador (equivalente Uniloc notifics).
+/// Distinta de `Notification` (avisos in-app do sistema).
+model FormalNotice {
+  id          String    @id @default(cuid())
+  companyId   String
+  contractId  String?
+  legacyId    String?   // n_codnot
+  recipient   String    @default("TENANT") // TENANT | LANDLORD | OTHER
+  recipientName String?
+  type        String    // AVISO_COBRANCA | EXTRAJUDICIAL | DESPEJO | REAJUSTE | RENOVACAO | OUTRO
+  subject     String    // assunto
+  body        String?   // notas/conteúdo
+  status      String    @default("OPEN") // OPEN | SENT | ACKNOWLEDGED | RESOLVED | CANCELLED
+  noticeDate  DateTime  @default(now()) // data da notificação
+  resolvedAt  DateTime? // data de resolução
+  operator    String?   // userId que emitiu
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([companyId])
+  @@index([contractId])
+  @@index([status])
+  @@map("formal_notices")
+}
+
+// ── Conciliação bancária (extrato / CNAB retorno) ──────────────────────────
+// Equivalente Uniloc: movbanco + baixa por CNAB (campos BAIXACNAB).
+
+/// Lote de importação de extrato/retorno bancário.
+model BankReconciliation {
+  id            String               @id @default(cuid())
+  companyId     String
+  source        String               @default("CSV") // CNAB240 | CNAB400 | OFX | CSV | MANUAL
+  reference     String?              // nome do arquivo / referência
+  bankCode      String?
+  importedAt    DateTime             @default(now())
+  totalEntries  Int                  @default(0)
+  matchedCount  Int                  @default(0)
+  unmatchedCount Int                 @default(0)
+  status        String               @default("IMPORTED") // IMPORTED | RECONCILED | PARTIAL
+  createdBy     String?
+  createdAt     DateTime             @default(now())
+  updatedAt     DateTime             @updatedAt
+
+  entries       BankStatementEntry[]
+
+  @@index([companyId])
+  @@index([status])
+  @@map("bank_reconciliations")
+}
+
+/// Movimento individual de um extrato/retorno bancário.
+model BankStatementEntry {
+  id               String             @id @default(cuid())
+  reconciliationId String
+  reconciliation   BankReconciliation @relation(fields: [reconciliationId], references: [id], onDelete: Cascade)
+  companyId        String
+  entryDate        DateTime
+  amount           Decimal            @db.Decimal(12, 2)
+  direction        String             @default("CREDIT") // CREDIT | DEBIT
+  description      String?
+  nossoNumero      String?            // identificador do boleto (liga ao Rental/Invoice)
+  documentNumber   String?
+  occurrenceCode   String?            // código de ocorrência CNAB (ex: 06 = liquidação)
+  matchStatus      String             @default("UNMATCHED") // UNMATCHED | MATCHED | IGNORED
+  matchedRentalId  String?
+  matchedInvoiceId String?
+  createdAt        DateTime           @default(now())
+
+  @@index([reconciliationId])
+  @@index([companyId])
+  @@index([matchStatus])
+  @@index([nossoNumero])
+  @@map("bank_statement_entries")
+}
+
+/// Permissão granular de um usuário por módulo (complementa UserRole).
+/// Equivalente Uniloc: usuarios.U_MODULO* (~50 flags por usuário).
+model UserModulePermission {
+  id         String   @id @default(cuid())
+  companyId  String
+  userId     String
+  module     String   // ex: properties | contracts | finance | payables | repasse | rescission | agreements | reports
+  canView    Boolean  @default(true)
+  canEdit    Boolean  @default(false)
+  canDelete  Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@unique([userId, module])
+  @@index([companyId])
+  @@index([userId])
+  @@map("user_module_permissions")
+}
+
 // ── NF-e / Notas Fiscais de Serviço ───────────────────────────────────────
 
 enum FiscalNoteStatus {


### PR DESCRIPTION
## Contexto

Mapeamento do sistema offline legado **IMOBILI/UNILOC** (Visual FoxPro, ~25 anos de operação em locação) e implementação no AgoraEncontrei das funcionalidades comprovadas que faltavam. Trabalho **somente de código** — nenhum dado real foi tocado.

Referência funcional: `docs/SISTEMA-UNILOC-MAPEAMENTO.md`. Skill de domínio: `.claude/skills/sistema-imobiliario-locacao/`.

## Funcionalidades (backend + frontend)

| Módulo | Backend | Tela |
|---|---|---|
| Rateio de repasse multi-proprietário | `RepasseBeneficiary` + `scheduleRepasseWithSplit` | ✅ |
| Contas a pagar + cheques | `AccountPayable`, `BankCheck` + `/payables` | ✅ |
| Motor de rescisão | `calculateRescission` + `Rescission` + `/rescission` | ✅ |
| Acordos / renegociação | `Agreement` + `generateInstallmentPlan` + `/agreements` | ✅ |
| Conciliação bancária (CSV/CNAB400) | `BankReconciliation` + `matchEntries` + `/reconciliation` | ✅ |
| Notificações formais/extrajudiciais | `FormalNotice` + `/notices` | ✅ |
| Permissões granulares por módulo | `UserModulePermission` + `requirePermission` + `/permissions` | ✅ |
| Carnê de IPTU parcelado | `IptuCarne` + `IptuInstallment` + `/iptu` | ✅ |

- 11 modelos Prisma novos · 6 migrations idempotentes (`20260630000000`–`...0005`)
- 8 grupos de rotas registrados em `apps/api/src/server.ts`
- 8 telas no dashboard (submenu LemosBank + Permissões) + lib `locacao-api.ts`
- Guard de permissões (opt-in) aplicado a todos os módulos novos
- Script de backfill do rateio a partir de dados existentes (dry-run por padrão)

## Lógica de negócio

- Rescisão: aluguel/IPTU proporcionais por dias, multa proporcional ao período restante (Lei 8.245/91), débitos, bonificação, caução.
- Rateio e parcelas: reconciliação de centavos (o último item absorve o resto → soma fecha exata).
- Conciliação: match por nosso número, depois valor+data, sem reusar candidato.

## Validação

- **Prisma client gerado** — schema válido com os 11 modelos novos.
- **`tsc --noEmit`**: 0 erros novos na API e no Web (apenas erros pré-existentes conhecidos em `automation.ts`, `tomas.service.ts` e telas legadas).
- **21/21 testes unitários** verdes (`node:test` via `tsx`): rateio, rescisão, parcelas e conciliação.
- **Servidor boota** e todas as rotas respondem (401 com auth, 404 para método/rota inexistente).

## Antes do deploy (requer banco)

1. Aplicar as 6 migrations no Neon (idempotentes; o projeto não roda `migrate deploy` automático).
2. `pnpm db:generate && pnpm typecheck`.
3. (Opcional) rodar o backfill do rateio com `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012yfHHJB54MNKWUEhbqynvj)_