### PR TITLE
chore(ci): Dependabot ignora bumps de versão maior (previne quebras de produção)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,12 @@ updates:
           - "minor"
     allow:
       - dependency-type: "all"
+    # Bumps de versão MAIOR quebram o build (ex.: prisma 5→7 derrubou a produção,
+    # electron 31→42, nodemailer 8→9, typescript 5→6). Majors devem ser feitos
+    # MANUALMENTE, com teste. O Dependabot fica só com patch/minor seguros.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
## Por quê
Bumps de **versão MAIOR** do Dependabot vinham quebrando o build de produção:
- `prisma` 5→7 (derrubou todos os deploys — corrigido no PR #211)
- `electron` 31→42, `nodemailer` 8→9, `typescript` 5→6 (deploys vermelhos)

## O que muda
Adiciona um `ignore` no `.github/dependabot.yml` para **bumps `semver-major`** de qualquer dependência. O Dependabot continua automatizando **patch/minor** (seguros); majors passam a ser feitos **manualmente**, com teste.

Isso evita que um único PR automático derrube a produção de novo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_