### PR TITLE
ci: publica instalador .exe em GitHub Release (link público para download)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/build-desktop.yml'
 
 permissions:
-  contents: read
+  contents: write   # necessário para publicar o instalador num Release
 
 jobs:
   build-windows:
@@ -87,3 +87,18 @@ jobs:
             apps/desktop/dist/*.blockmap
           if-no-files-found: error
           retention-days: 30
+
+      # Publica o instalador num Release com tag fixa "desktop-latest", gerando
+      # uma URL pública estável para o SOFTWARE_DOWNLOAD_URL:
+      #   https://github.com/<owner>/<repo>/releases/download/desktop-latest/AgoraEncontrei-Software-Setup.exe
+      - name: Publish installer to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: desktop-latest
+          name: AgoraEncontrei Software (instalador offline)
+          body: |
+            Instalador da edição offline. Baixe o `.exe`, instale e ative com sua chave de licença.
+            Atualizado automaticamente a cada build do app desktop.
+          files: |
+            apps/desktop/dist/AgoraEncontrei-Software-Setup.exe
+          make_latest: "true"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
   "build": {
     "appId": "com.agoraencontrei.software",
     "productName": "AgoraEncontrei Software",
+    "artifactName": "AgoraEncontrei-Software-Setup.${ext}",
     "npmRebuild": false,
     "directories": { "output": "dist" },
     "files": ["main.js", "preload.js", "license.js", "db.js", "renderer/**", "server/**"],


### PR DESCRIPTION
## Por quê
O `.exe` só saía como artifact (exige login). Para o cliente baixar, precisa de URL pública.

## O que muda
- `apps/desktop/package.json`: `artifactName` fixo → `AgoraEncontrei-Software-Setup.exe` (sem versão/espaços)
- `build-desktop.yml`: `permissions: contents: write` + passo que **publica o `.exe` num Release** (tag `desktop-latest`)

## Resultado — URL pública estável p/ `SOFTWARE_DOWNLOAD_URL`
```
https://github.com/tomascesarlemossil/agoraencontrei/releases/download/desktop-latest/AgoraEncontrei-Software-Setup.exe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_