### PR TITLE
rename: produto offline → "Sistema Administrador AgoraEncontrei"

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,6 +1,6 @@
 name: Build Desktop (.exe)
 
-# Compila a edição OFFLINE (AgoraEncontrei Software) num runner Windows na nuvem
+# Compila a edição OFFLINE (Sistema Administrador AgoraEncontrei) num runner Windows na nuvem
 # e publica o instalador .exe como artifact — sem precisar de toolchain local.
 #
 # Disparo: manual (workflow_dispatch) ou ao mexer em apps/desktop no branch de trabalho.
@@ -95,7 +95,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: desktop-latest
-          name: AgoraEncontrei Software (instalador offline)
+          name: Sistema Administrador AgoraEncontrei (instalador offline)
           body: |
             Instalador da edição offline. Baixe o `.exe`, instale e ative com sua chave de licença.
             Atualizado automaticamente a cada build do app desktop.

--- a/apps/api/src/routes/finance/webhook.ts
+++ b/apps/api/src/routes/finance/webhook.ts
@@ -41,7 +41,7 @@ async function handleOfflineLicensePurchase(app: FastifyInstance, externalRef: s
 
   const html = `
     <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;color:#1B2B5B">
-      <h2>Sua licença do AgoraEncontrei Software</h2>
+      <h2>Sua licença do Sistema Administrador AgoraEncontrei</h2>
       <p>Pagamento confirmado — obrigado pela compra! 🎉</p>
       <p><strong>1.</strong> Baixe o instalador: <a href="${downloadUrl}">${downloadUrl}</a></p>
       <p><strong>2.</strong> Instale e, na tela de ativação, cole a sua chave de licença:</p>
@@ -50,7 +50,7 @@ async function handleOfflineLicensePurchase(app: FastifyInstance, externalRef: s
       <p style="color:#6b7799;font-size:13px">Guarde este e-mail. Em caso de dúvida, responda esta mensagem.</p>
     </div>`
 
-  const res = await sendEmail({ to: email, subject: 'Sua licença — AgoraEncontrei Software', html })
+  const res = await sendEmail({ to: email, subject: 'Sua licença — Sistema Administrador AgoraEncontrei', html })
   if (res.success) app.log.info(`[offline-license] licença enviada para ${email}`)
   else app.log.error(`[offline-license] falha ao enviar e-mail: ${res.error}`)
 }

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,4 +1,4 @@
-# AgoraEncontrei Software — Edição Offline (Desktop)
+# Sistema Administrador AgoraEncontrei — Edição Offline (Desktop)
 
 Empacotamento da plataforma para rodar **instalada no Windows**, offline, com
 banco **SQLite local** e **ativação por licença assinada**.
@@ -54,7 +54,7 @@ chave por e-mail — fechando o fluxo de venda automatizado da versão offline.
 
 ```bash
 pnpm install
-pnpm --filter @agoraencontrei/desktop dist   # gera dist/AgoraEncontrei Software Setup.exe
+pnpm --filter @agoraencontrei/desktop dist   # gera dist/Sistema Administrador AgoraEncontrei Setup.exe
 ```
 
 ## Banco local: PostgreSQL embarcado (não SQLite)

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -1,5 +1,5 @@
 /**
- * AgoraEncontrei Software — processo principal Electron (edição offline).
+ * Sistema Administrador AgoraEncontrei — processo principal Electron (edição offline).
  *
  * Estratégia: sobe a aplicação web (API Fastify + Next standalone) em localhost
  * dentro do próprio app, usando banco SQLite local. A janela carrega essa URL.
@@ -39,7 +39,7 @@ function createWindow(startUrl) {
     height: 820,
     minWidth: 1024,
     minHeight: 700,
-    title: 'AgoraEncontrei Software',
+    title: 'Sistema Administrador AgoraEncontrei',
     backgroundColor: '#0a0e1a',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@agoraencontrei/desktop",
   "version": "0.1.0",
   "private": true,
-  "description": "AgoraEncontrei Software — edição offline (instalável no Windows). Empacota a plataforma para rodar local com PostgreSQL embarcado e ativação por licença.",
+  "description": "Sistema Administrador AgoraEncontrei — edição offline (instalável no Windows). Empacota a plataforma para rodar local com PostgreSQL embarcado e ativação por licença.",
   "main": "main.js",
   "author": "Imobiliária Lemos",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "build": {
     "appId": "com.agoraencontrei.software",
-    "productName": "AgoraEncontrei Software",
+    "productName": "Sistema Administrador AgoraEncontrei",
     "artifactName": "AgoraEncontrei-Software-Setup.${ext}",
     "npmRebuild": false,
     "directories": { "output": "dist" },
@@ -25,7 +25,7 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
-      "shortcutName": "AgoraEncontrei Software"
+      "shortcutName": "Sistema Administrador AgoraEncontrei"
     }
   },
   "devDependencies": {

--- a/apps/desktop/renderer/activate.html
+++ b/apps/desktop/renderer/activate.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Ativar — AgoraEncontrei Software</title>
+<title>Ativar — Sistema Administrador AgoraEncontrei</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:'Segoe UI',system-ui,sans-serif;background:#0a0e1a;color:#eef2ff;
@@ -24,7 +24,7 @@
 </head>
 <body>
   <div class="card">
-    <div class="logo">Agora<span>Encontrei</span> Software</div>
+    <div class="logo">Sistema Administrador Agora<span>Encontrei</span></div>
     <p class="sub">Cole a sua chave de licença para ativar o programa.</p>
     <label>Chave de licença</label>
     <input id="key" placeholder="payload.assinatura" autofocus />

--- a/apps/desktop/renderer/onboarding.html
+++ b/apps/desktop/renderer/onboarding.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="pt-BR"><head><meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Bem-vindo — AgoraEncontrei Software</title>
+<title>Bem-vindo — Sistema Administrador AgoraEncontrei</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}
   body{font-family:'Segoe UI',system-ui,sans-serif;background:#0a0e1a;color:#eef2ff;
@@ -21,7 +21,7 @@
   .msg{margin-top:22px;color:#22d3a6;font-size:14px;min-height:20px}
 </style></head><body>
   <div class="wrap">
-    <div class="logo">Agora<span>Encontrei</span> Software</div>
+    <div class="logo">Sistema Administrador Agora<span>Encontrei</span></div>
     <p class="sub">Bem-vindo! Como você quer começar?</p>
     <div class="cards">
       <div class="card" id="fresh">

--- a/public/software/index.html
+++ b/public/software/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>AgoraEncontrei Software — Sistema imobiliário inteligente, online ou no seu PC</title>
+<title>Sistema Administrador AgoraEncontrei — Sistema imobiliário inteligente, online ou no seu PC</title>
 <meta name="description" content="O sistema imobiliário completo da AgoraEncontrei. Use na nuvem ou instale offline na sua máquina. CRM, IA Tomás, vitrine de imóveis. A partir de R$ 97/mês." />
-<meta property="og:title" content="AgoraEncontrei Software" />
+<meta property="og:title" content="Sistema Administrador AgoraEncontrei" />
 <meta property="og:description" content="Seu sistema imobiliário completo — na nuvem ou no seu PC." />
 <style>
   :root{
@@ -112,7 +112,7 @@
 <header>
   <div class="wrap">
     <nav>
-      <div class="logo">Agora<span>Encontrei</span> Software</div>
+      <div class="logo">Sistema Administrador Agora<span>Encontrei</span></div>
       <div class="nav-links">
         <a href="#modos">Online ou Offline</a>
         <a href="#recursos">Recursos</a>
@@ -298,7 +298,7 @@
 
 <footer>
   <div class="wrap">
-    <div class="logo" style="font-size:17px;margin-bottom:8px">Agora<span>Encontrei</span> Software</div>
+    <div class="logo" style="font-size:17px;margin-bottom:8px">Sistema Administrador Agora<span>Encontrei</span></div>
     © 2026 AgoraEncontrei — Imobiliária Lemos. Todos os direitos reservados.
     <div class="note">
       Esta página é um protótipo de vendas. Os botões de assinatura devem ser conectados ao checkout


### PR DESCRIPTION
Renomeia o produto offline de "AgoraEncontrei Software" para **"Sistema Administrador AgoraEncontrei"** em todos os pontos visíveis:
- Instalador (productName, atalho), telas (ativação, onboarding), título da janela
- E-mail de licença (assunto + corpo)
- Landing `public/software`
- Nome do Release

O **nome do arquivo de download** (`AgoraEncontrei-Software-Setup.exe`) foi **preservado** para não quebrar o `SOFTWARE_DOWNLOAD_URL` já configurado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_