### PR TITLE
feat(web): modernize public site visuals (typography, motion, contras…

### DIFF
--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -58,7 +58,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
             </span>
           </div>
           <div className="flex items-center gap-4">
-            <span className="text-white/50">Marketplace Imobiliário · Franca/SP</span>
+            <span className="text-white/70">Marketplace Imobiliário · Franca/SP</span>
             <a href="https://www.instagram.com/imobiliarialemos" target="_blank" rel="noreferrer" className="flex items-center gap-1 hover:text-white transition-colors" aria-label="Instagram da Imobiliária Lemos (@imobiliarialemos)">
               <Instagram className="w-3.5 h-3.5" aria-hidden="true" />
             </a>
@@ -104,16 +104,16 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                   <span className="text-[10px] font-medium" style={{ color: '#9ca3af', letterSpacing: '0.04em' }}>Marketplace</span>
                 </div>
               </div>
-              <p className="text-white/50 text-xs leading-relaxed">
+              <p className="text-white/70 text-xs leading-relaxed">
                 O Marketplace Imobiliário de Franca e Região.
               </p>
-              <p className="text-white/40 text-xs mt-1">
+              <p className="text-white/60 text-xs mt-1">
                 Criado pela <span className="text-white/60 font-medium">Imobiliária Lemos</span>, referência desde 2002.
               </p>
 
               {/* Social media */}
               <div className="mt-5">
-                <p className="text-white/30 text-xs uppercase tracking-wider mb-3">Redes Sociais</p>
+                <p className="text-white/55 text-xs uppercase tracking-wider mb-3">Redes Sociais</p>
                 <div className="flex flex-col gap-2">
                   <a
                     href="https://www.instagram.com/imobiliarialemos"
@@ -125,7 +125,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                     <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0 text-white/60 group-hover:text-white transition-colors" style={{ backgroundColor: 'rgba(255,255,255,0.08)' }}>
                       <Instagram className="w-3.5 h-3.5" />
                     </div>
-                    <span className="text-white/50 text-xs group-hover:text-white transition-colors">@imobiliarialemos</span>
+                    <span className="text-white/70 text-xs group-hover:text-white transition-colors">@imobiliarialemos</span>
                   </a>
                   <a
                     href="https://www.instagram.com/tomaslemosbr"
@@ -137,7 +137,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                     <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0 text-white/60 group-hover:text-white transition-colors" style={{ backgroundColor: 'rgba(255,255,255,0.08)' }}>
                       <Instagram className="w-3.5 h-3.5" />
                     </div>
-                    <span className="text-white/50 text-xs group-hover:text-white transition-colors">@tomaslemosbr</span>
+                    <span className="text-white/70 text-xs group-hover:text-white transition-colors">@tomaslemosbr</span>
                   </a>
                   <a
                     href="https://www.youtube.com/@imobiliarialemos"
@@ -149,7 +149,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                     <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0 text-white/60 group-hover:text-white transition-colors" style={{ backgroundColor: 'rgba(255,255,255,0.08)' }}>
                       <Youtube className="w-3.5 h-3.5" />
                     </div>
-                    <span className="text-white/50 text-xs group-hover:text-white transition-colors">Imobiliária Lemos</span>
+                    <span className="text-white/70 text-xs group-hover:text-white transition-colors">Imobiliária Lemos</span>
                   </a>
                   <a
                     href="https://facebook.com/imobiliarialemos"
@@ -161,7 +161,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
                     <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0 text-white/60 group-hover:text-white transition-colors" style={{ backgroundColor: 'rgba(255,255,255,0.08)' }}>
                       <Facebook className="w-3.5 h-3.5" />
                     </div>
-                    <span className="text-white/50 text-xs group-hover:text-white transition-colors">imobiliarialemos</span>
+                    <span className="text-white/70 text-xs group-hover:text-white transition-colors">imobiliarialemos</span>
                   </a>
                 </div>
               </div>
@@ -173,7 +173,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
               <ul className="space-y-2.5">
                 {FOOTER_IMOVEIS.map(l => (
                   <li key={l.href}>
-                    <Link href={l.href} className="text-white/50 text-sm hover:text-white transition-colors">{l.label}</Link>
+                    <Link href={l.href} className="text-white/70 text-sm hover:text-white transition-colors">{l.label}</Link>
                   </li>
                 ))}
               </ul>
@@ -185,7 +185,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
               <ul className="space-y-2.5">
                 {FOOTER_SERVICOS.map(l => (
                   <li key={l.href}>
-                    <Link href={l.href} className="text-white/50 text-sm hover:text-white transition-colors">{l.label}</Link>
+                    <Link href={l.href} className="text-white/70 text-sm hover:text-white transition-colors">{l.label}</Link>
                   </li>
                 ))}
               </ul>
@@ -193,19 +193,19 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
               <p className="text-sm font-semibold mt-6 mb-3 tracking-wide uppercase" style={{ color: '#C9A84C' }}>Área de Acesso</p>
               <ul className="space-y-2.5">
                 <li>
-                  <Link href="/login" className="flex items-center gap-2 text-white/50 text-sm hover:text-white transition-colors group">
+                  <Link href="/login" className="flex items-center gap-2 text-white/70 text-sm hover:text-white transition-colors group">
                     <span className="w-1.5 h-1.5 rounded-full inline-block" style={{ backgroundColor: '#C9A84C' }} />
                     Painel Administrativo
                   </Link>
                 </li>
                 <li>
-                  <Link href="/login" className="flex items-center gap-2 text-white/50 text-sm hover:text-white transition-colors">
+                  <Link href="/login" className="flex items-center gap-2 text-white/70 text-sm hover:text-white transition-colors">
                     <span className="w-1.5 h-1.5 rounded-full inline-block" style={{ backgroundColor: '#4a90d9' }} />
                     Área do Corretor
                   </Link>
                 </li>
                 <li>
-                  <Link href="/portal/login" className="flex items-center gap-2 text-white/50 text-sm hover:text-white transition-colors">
+                  <Link href="/portal/login" className="flex items-center gap-2 text-white/70 text-sm hover:text-white transition-colors">
                     <span className="w-1.5 h-1.5 rounded-full inline-block" style={{ backgroundColor: '#5cb85c' }} />
                     Portal do Cliente
                   </Link>
@@ -218,28 +218,28 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
               <p className="text-sm font-semibold mb-4 tracking-wide uppercase" style={{ color: '#C9A84C' }}>Contato</p>
               <ul className="space-y-3 text-sm">
                 <li>
-                  <p className="text-white/40 text-xs uppercase tracking-wider mb-0.5">Fixo</p>
+                  <p className="text-white/60 text-xs uppercase tracking-wider mb-0.5">Fixo</p>
                   <a href="tel:1637230045" className="text-white/70 hover:text-white transition-colors">(16) 3723-0045</a>
                 </li>
                 <li>
-                  <p className="text-white/40 text-xs uppercase tracking-wider mb-0.5">Vendas / Locação</p>
+                  <p className="text-white/60 text-xs uppercase tracking-wider mb-0.5">Vendas / Locação</p>
                   <a href="tel:16981010004" className="text-white/70 hover:text-white transition-colors">(16) 98101-0004</a>
                 </li>
                 <li>
-                  <p className="text-white/40 text-xs uppercase tracking-wider mb-0.5">WhatsApp</p>
+                  <p className="text-white/60 text-xs uppercase tracking-wider mb-0.5">WhatsApp</p>
                   <a href="https://wa.me/5516981010004" target="_blank" rel="noreferrer"
                     className="hover:opacity-80 transition-opacity" style={{ color: '#C9A84C' }}>
                     (16) 98101-0004
                   </a>
                 </li>
                 <li className="pt-1">
-                  <p className="text-white/40 text-xs uppercase tracking-wider mb-0.5">Endereço</p>
+                  <p className="text-white/60 text-xs uppercase tracking-wider mb-0.5">Endereço</p>
                   <p className="text-white/60 text-sm leading-relaxed">
                     Rua Simão Caleiro, 2383<br />
                     Vila Industrial — Franca/SP<br />
                     CEP 14400-340
                   </p>
-                  <p className="text-white/40 text-xs mt-1">CNPJ: 10.962.301/0001-50</p>
+                  <p className="text-white/60 text-xs mt-1">CNPJ: 10.962.301/0001-50</p>
                   <a
                     href="https://www.imobiliarialemos.com.br"
                     target="_blank"
@@ -255,15 +255,15 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
           </div>
 
           <div className="border-t border-white/10 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-            <p className="text-white/50 text-xs">
+            <p className="text-white/70 text-xs">
               © {new Date().getFullYear()} AgoraEncontrei Marketplace. Todos os direitos reservados.
             </p>
             <div className="flex items-center gap-4">
-              <Link href="/termos-uso" className="text-white/40 text-xs hover:text-white/70 transition-colors">Termos de Uso</Link>
+              <Link href="/termos-uso" className="text-white/60 text-xs hover:text-white/70 transition-colors">Termos de Uso</Link>
               <span className="text-white/20 text-xs">·</span>
-              <Link href="/politica-privacidade" className="text-white/40 text-xs hover:text-white/70 transition-colors">Política de Privacidade</Link>
+              <Link href="/politica-privacidade" className="text-white/60 text-xs hover:text-white/70 transition-colors">Política de Privacidade</Link>
               <span className="text-white/20 text-xs">·</span>
-              <p className="text-white/40 text-xs">Criado pela Imobiliária Lemos · Fundada em 2002</p>
+              <p className="text-white/60 text-xs">Criado pela Imobiliária Lemos · Fundada em 2002</p>
             </div>
           </div>
         </div>

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -7,6 +7,7 @@ import { HeroBackground } from './HeroBackground'
 import { SmartQuizButton, SmartQuizModal } from './SmartQuiz'
 import { PresentationSection } from './PresentationSection'
 import { getThemeById } from './themes/site-themes'
+import { Reveal } from '@/components/public/Reveal'
 
 export const metadata: Metadata = {
   title: 'AgoraEncontrei — Marketplace Imobiliário de Franca/SP | Imobiliária Lemos',
@@ -385,8 +386,8 @@ export default async function HomePage() {
 
           {/* Título — responsivo */}
           <h1
-            className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-3 sm:mb-4 leading-[1.15]"
-            style={{ fontFamily: 'Georgia, serif', textShadow: '0 2px 12px rgba(0,0,0,0.4)' }}
+            className="text-5xl sm:text-6xl lg:text-7xl font-bold text-white mb-3 sm:mb-4 leading-[1.05] tracking-[-0.02em]"
+            style={{ fontFamily: theme.typography.heroFont, textShadow: '0 2px 12px rgba(0,0,0,0.4)' }}
           >
             Encontre o imóvel
             <br />
@@ -457,11 +458,11 @@ export default async function HomePage() {
                 Responda 5 perguntas rápidas e nossa IA encontra os imóveis perfeitos para o seu perfil — em menos de 2 minutos.
               </p>
               <SmartQuizButton />
-              <p className="text-gray-400 text-xs mt-3">Gratuito · 2 minutos · Sem compromisso</p>
+              <p className="text-gray-500 text-xs mt-3">Gratuito · 2 minutos · Sem compromisso</p>
             </div>
             <div className="hidden lg:block absolute" style={{ display: 'none' }} />
             <div className="bg-white px-8 py-10 flex flex-col justify-center border-t lg:border-t-0 lg:border-l border-gray-200">
-              <h2 className="text-2xl sm:text-3xl font-bold mb-3" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>
+              <h2 className="text-2xl sm:text-3xl font-bold mb-3" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
                 Quer saber quanto vale seu imóvel?
               </h2>
               <p className="text-gray-500 text-sm mb-8 max-w-sm leading-relaxed">
@@ -487,7 +488,7 @@ export default async function HomePage() {
           <p className="text-xs sm:text-sm font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--site-accent-color, #C9A84C)' }}>
             Para imobiliárias e corretores
           </p>
-          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-3" style={{ fontFamily: 'Georgia, serif' }}>
+          <h2 className="text-2xl sm:text-3xl font-bold text-white mb-3" style={{ fontFamily: '"Playfair Display", Georgia, serif' }}>
             Seja um Parceiro do AgoraEncontrei
           </h2>
           <p className="text-white/70 text-sm sm:text-base mb-6 max-w-2xl mx-auto leading-relaxed">
@@ -518,7 +519,7 @@ export default async function HomePage() {
       {/* ── 4. MARKETPLACE ────────────────────────────────────────────────── */}
       <section style={{ backgroundColor: 'var(--site-primary-color, #1B2B5B)' }} className="py-20">
         <div className="max-w-5xl mx-auto px-4 sm:px-6">
-          <div className="text-center mb-12">
+          <Reveal className="text-center mb-12">
             <p
               className="text-[11px] font-semibold uppercase tracking-[0.2em] mb-3"
               style={{ color: 'var(--site-accent-color, #C9A84C)' }}
@@ -527,17 +528,17 @@ export default async function HomePage() {
             </p>
             <h2
               className="text-2xl sm:text-3xl font-bold text-white leading-snug"
-              style={{ fontFamily: 'Georgia, serif' }}
+              style={{ fontFamily: '"Playfair Display", Georgia, serif' }}
             >
               O Marketplace Imobiliário de{' '}
               <span style={{ color: 'var(--site-accent-color, #C9A84C)' }}>Franca e Região</span>
             </h2>
-            <p className="text-white/50 text-sm mt-4 max-w-2xl mx-auto leading-relaxed">
+            <p className="text-white/60 text-sm mt-4 max-w-2xl mx-auto leading-relaxed">
               O AgoraEncontrei é a plataforma mais avançada para compra, venda e locação de imóveis
               em Franca/SP e região. Aberto para corretores, proprietários e investidores
               anunciarem com tecnologia de ponta.
             </p>
-          </div>
+          </Reveal>
 
           {/* Feature cards — clickable links */}
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-12">
@@ -599,7 +600,7 @@ export default async function HomePage() {
                 style={{ backgroundColor: 'rgba(255,255,255,0.06)', border: '1px solid rgba(201,168,76,0.15)' }}
               >
                 {feat.icon}
-                <p className="text-white font-semibold text-sm mb-1" style={{ fontFamily: 'Georgia, serif' }}>
+                <p className="text-white font-semibold text-sm mb-1" style={{ fontFamily: '"Playfair Display", Georgia, serif' }}>
                   {feat.label}
                 </p>
                 <p className="text-white/40 text-xs leading-relaxed">{feat.desc}</p>
@@ -640,15 +641,15 @@ export default async function HomePage() {
       */}
       {siteSettings.partnersShowcaseEnabled === true && (
       <section className="max-w-6xl mx-auto px-4 sm:px-6 py-16">
-        <div className="text-center mb-10">
+        <Reveal className="text-center mb-10">
           <p className="text-sm font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--site-accent-color, #C9A84C)' }}>
             Marketplace Imobiliário
           </p>
-          <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>
+          <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
             Nossas Imobiliárias Parceiras
           </h2>
           <p className="text-gray-500 text-sm mt-1">Imobiliárias e profissionais parceiros anunciando no marketplace</p>
-        </div>
+        </Reveal>
 
         <div className="flex flex-wrap justify-center gap-6">
           {/* Card Imobiliária Lemos */}
@@ -669,7 +670,7 @@ export default async function HomePage() {
                 className="w-full h-full object-contain drop-shadow-xl"
               />
             </div>
-            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>Imobiliária Lemos</h3>
+            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Imobiliária Lemos</h3>
             <p className="text-xs text-gray-500 mb-1">Franca — SP</p>
             <p className="text-xs font-semibold mb-4" style={{ color: '#C9A84C' }}>Desde 2002 · +22 anos de tradição</p>
             <p className="text-xs text-gray-500 leading-relaxed mb-5">
@@ -694,7 +695,7 @@ export default async function HomePage() {
             <div className="w-28 h-28 rounded-full flex items-center justify-center mb-4 border-4 border-dashed" style={{ borderColor: '#C9A84C', backgroundColor: 'rgba(201,168,76,0.08)' }}>
               <span className="text-5xl font-bold" style={{ color: '#C9A84C' }}>+</span>
             </div>
-            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>Seja um Parceiro</h3>
+            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Seja um Parceiro</h3>
             <p className="text-xs text-gray-500 mb-4">Sua imobiliária aqui</p>
             <p className="text-xs text-gray-500 leading-relaxed mb-5">
               Anuncie seus imóveis no maior marketplace imobiliário de Franca. Tecnologia de ponta, sem custo inicial.
@@ -719,12 +720,12 @@ export default async function HomePage() {
       {/* ── 4. CATEGORIAS (tipos de imóvel com ícones SVG profissionais) ──── */}
       <section style={{ backgroundColor: 'var(--site-background-color, #f8f6f1)' }} className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
-          <div className="text-center mb-10">
-            <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>
+          <Reveal className="text-center mb-10">
+            <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
               O que você procura?
             </h2>
             <p className="text-gray-500 text-sm mt-1">Selecione o tipo de imóvel e explore as opções</p>
-          </div>
+          </Reveal>
 
           <div className="grid grid-cols-4 sm:grid-cols-4 lg:grid-cols-8 gap-3">
             {CATEGORIES.map(cat => {
@@ -757,12 +758,12 @@ export default async function HomePage() {
       {featured.length > 0 && (
         <section className="max-w-7xl mx-auto px-4 sm:px-6 py-16">
           <div className="flex items-center justify-between mb-8">
-            <div>
-              <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>
+            <Reveal direction="right">
+              <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
                 Imóveis em Destaque
               </h2>
               <p className="text-gray-500 text-sm mt-0.5">Imóveis selecionados pela nossa equipe para você</p>
-            </div>
+            </Reveal>
             <Link
               href="/imoveis"
               className="flex items-center gap-2 text-sm font-semibold hover:gap-3 transition-all"
@@ -857,7 +858,7 @@ export default async function HomePage() {
             { label: 'Famílias atendidas', value: '5.000+' },
           ].map(stat => (
             <div key={stat.label} className="text-center">
-              <p className="text-2xl font-bold" style={{ color: 'var(--site-accent-color, #C9A84C)', fontFamily: 'Georgia, serif' }}>
+              <p className="text-2xl font-bold" style={{ color: 'var(--site-accent-color, #C9A84C)', fontFamily: '"Playfair Display", Georgia, serif' }}>
                 {stat.value}
               </p>
               <p className="text-gray-500 text-xs mt-0.5">{stat.label}</p>
@@ -865,7 +866,7 @@ export default async function HomePage() {
           ))}
         </div>
         <div className="text-center mb-6">
-          <h2 className="text-xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: 'Georgia, serif' }}>Siga-nos nas Redes Sociais</h2>
+          <h2 className="text-xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Siga-nos nas Redes Sociais</h2>
           <p className="text-gray-500 text-sm mt-1">Acompanhe os melhores imóveis, dicas e novidades</p>
         </div>
         <div className="flex flex-wrap justify-center gap-4">

--- a/apps/web/src/app/(public)/themes/site-themes.ts
+++ b/apps/web/src/app/(public)/themes/site-themes.ts
@@ -106,9 +106,9 @@ export const themeClassicBlue: SiteTheme = {
     buttonBorder: 'transparent',
   },
   typography: {
-    heroFont: 'Georgia, serif',
+    heroFont: '"Playfair Display", Georgia, serif',
     bodyFont: 'Inter, sans-serif',
-    heroSize: 'text-4xl sm:text-5xl lg:text-6xl',
+    heroSize: 'text-5xl sm:text-6xl lg:text-7xl',
     heroWeight: 'font-bold',
     sectionTitleSize: 'text-2xl',
     sectionTitleWeight: 'font-bold',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -63,8 +63,9 @@
 }
 
 /* ── Fix: ensure form inputs on light-background pages have dark text ──────── */
-/* Root <html> has class="dark" for dashboard, but public/portal pages use    */
-/* light backgrounds. This forces dark text on inputs in those contexts.       */
+/* The root <html> is light; `.dark` is scoped to the dashboard layout wrapper. */
+/* These rules guard public/portal inputs against inherited light-on-light text */
+/* and remain harmless where no `.dark` ancestor exists.                        */
 /* Dashboard dark-themed inputs override this with their own text-white.       */
 
 /* Public pages (all wrapped in <main id="main-content">) */
@@ -116,10 +117,10 @@ input[style*="background"], textarea[style*="background"] {
 .dark main.bg-gray-950 input:not([type="checkbox"]):not([type="radio"]),
 .dark main.bg-gray-950 textarea,
 .dark main.bg-gray-950 select,
-html.dark input[class*="bg-white/5"]:not([type="checkbox"]):not([type="radio"]),
-html.dark textarea[class*="bg-white/5"],
-html.dark input[class*="border-white"]:not([type="checkbox"]):not([type="radio"]),
-html.dark textarea[class*="border-white"] {
+.dark input[class*="bg-white/5"]:not([type="checkbox"]):not([type="radio"]),
+.dark textarea[class*="bg-white/5"],
+.dark input[class*="border-white"]:not([type="checkbox"]):not([type="radio"]),
+.dark textarea[class*="border-white"] {
   color: #ffffff !important;
   color-scheme: dark;
   -webkit-text-fill-color: #ffffff !important;
@@ -135,7 +136,7 @@ html.dark textarea[class*="border-white"] {
 .dark .bg-gray-950 input:-webkit-autofill,
 .dark .bg-gray-950 input:-webkit-autofill:hover,
 .dark .bg-gray-950 input:-webkit-autofill:focus,
-html.dark input:-webkit-autofill {
+.dark input:-webkit-autofill {
   -webkit-text-fill-color: #ffffff !important;
   -webkit-box-shadow: 0 0 0 1000px rgba(255,255,255,0.05) inset !important;
   box-shadow: 0 0 0 1000px rgba(255,255,255,0.05) inset !important;
@@ -150,8 +151,8 @@ html.dark input:-webkit-autofill {
 .dark .bg-gray-950 input[type="date"],
 .dark .bg-gray-950 input[type="datetime-local"],
 .dark .bg-gray-950 input[type="time"],
-html.dark input[type="date"],
-html.dark input[type="datetime-local"] {
+.dark input[type="date"],
+.dark input[type="datetime-local"] {
   color-scheme: dark;
 }
 /* Select dropdown content (Radix popover on dark) */
@@ -179,4 +180,19 @@ html.dark input[type="datetime-local"] {
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+}
+
+/* ── Accessibility: honor prefers-reduced-motion ──────────────────────────── */
+/* Users who request reduced motion get near-instant transitions/animations.  */
+/* Framer Motion reveals already opt out via useReducedMotion; this is the     */
+/* CSS-side net for hover transforms and other tailwind transitions.           */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -333,15 +333,17 @@ const jsonLdWebsite = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // Root stays light by default; the dashboard scopes `.dark` on its own
+  // layout wrapper. Public, portal and auth areas render light.
   return (
-    <html lang="pt-BR" suppressHydrationWarning className="dark">
+    <html lang="pt-BR" suppressHydrationWarning>
       <head>
         {/* ── Preconnect para recursos externos críticos (melhora LCP/FCP) ── */}
         <link rel="preconnect" href="https://api-production-669c.up.railway.app" />
         <link rel="preconnect" href="https://agoraencontrei-media.s3.us-east-1.amazonaws.com" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Playfair+Display:ital,wght@0,400..900;1,400..700&display=swap" rel="stylesheet" />
         <link rel="dns-prefetch" href="https://tiles.openfreemap.org" />
         <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
         <link rel="dns-prefetch" href="https://cdnuso.com" />

--- a/apps/web/src/components/public/Reveal.tsx
+++ b/apps/web/src/components/public/Reveal.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { motion, useReducedMotion, type Variant } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+type Direction = 'up' | 'down' | 'left' | 'right' | 'none'
+
+interface RevealProps {
+  children: ReactNode
+  /** Slide direction the element travels from. Default: 'up'. */
+  direction?: Direction
+  /** Animation delay in seconds (use to cascade siblings). Default: 0. */
+  delay?: number
+  /** Travel distance in px. Default: 24. */
+  distance?: number
+  /** Duration in seconds. Default: 0.6. */
+  duration?: number
+  className?: string
+  /** Render as a different element when nesting matters (default: div). */
+  as?: 'div' | 'section' | 'li' | 'span'
+}
+
+const OFFSETS: Record<Direction, { x: number; y: number }> = {
+  up: { x: 0, y: 1 },
+  down: { x: 0, y: -1 },
+  left: { x: 1, y: 0 },
+  right: { x: -1, y: 0 },
+  none: { x: 0, y: 0 },
+}
+
+/**
+ * Scroll-reveal wrapper: fades + slides its children into view the first time
+ * they enter the viewport. Respects `prefers-reduced-motion` (renders content
+ * statically with no transform) so it never harms accessibility.
+ */
+export function Reveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  distance = 24,
+  duration = 0.6,
+  className,
+  as = 'div',
+}: RevealProps) {
+  const reduceMotion = useReducedMotion()
+  const MotionTag = motion[as]
+
+  if (reduceMotion) {
+    const Tag = as
+    return <Tag className={className}>{children}</Tag>
+  }
+
+  const offset = OFFSETS[direction]
+  const hidden: Variant = {
+    opacity: 0,
+    x: offset.x * distance,
+    y: offset.y * distance,
+  }
+  const visible: Variant = { opacity: 1, x: 0, y: 0 }
+
+  return (
+    <MotionTag
+      className={className}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.15, margin: '0px 0px -10% 0px' }}
+      variants={{ hidden, visible }}
+      transition={{ duration, delay, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </MotionTag>
+  )
+}
+
+export default Reveal

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,14 +4,14 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-none motion-reduce:transition-none motion-reduce:hover:translate-y-0',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0',
+        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:shadow-md hover:-translate-y-0.5 active:translate-y-0',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },


### PR DESCRIPTION
…t, theming)

Implements the prioritized visual improvements for the public marketplace:

1. Accessibility/contrast: bump low-opacity white text on the navy footer and top-bar (text-white/40→/60, /50→/70, /30→/55) and one gray-400→500 helper on a light section, to meet WCAG AA for small text.

2. Scroll-reveal: new reusable <Reveal> component (framer-motion whileInView, once + reduced-motion aware). Applied to key homepage section headers so content fades/slides in on scroll instead of appearing all at once.

3. Typography: load Playfair Display and adopt it as the active theme's heading font (cascades to section titles via theme.typography.heroFont). Replace hardcoded Georgia headings with the Playfair stack. Strengthen the hero hierarchy (text-5xl→7xl, tighter leading/tracking).

4. Dark-mode consistency: stop forcing `class="dark"` on the root <html>. The dashboard already scopes `.dark` on its own layout wrapper, so the global flag was only forcing the big pile of public-page override hacks. Root now renders light; rescope globals.css `html.dark` selectors to `.dark` so dashboard input fixes still match.

5. Micro-interactions: shared Button now lifts (-translate-y-0.5) with a softer shadow on hover and settles on active; honors reduced-motion.

Also adds a global prefers-reduced-motion safety net in globals.css.

Note: a user-facing light/dark toggle still needs a dedicated dark-variant pass on the public components (they use hardcoded light values, not theme vars) plus visual QA — tracked as follow-up.


Claude-Session: https://claude.ai/code/session_0138bGcmpAwC53fJsfQoY5ji