### PR TITLE
fix(landing): CTA do software aponta para a página de assinatura correta

### DIFF
--- a/public/software/index.html
+++ b/public/software/index.html
@@ -308,11 +308,11 @@
 </footer>
 
 <script>
-  // CHECKOUT REAL: a página /parceiros/planos já implementa o fluxo completo
+  // CHECKOUT REAL: /parceiros/cadastro renderiza DynamicPlans (planos do software
   // (catálogo via /api/v1/public/catalog → formulário subdomínio+nome →
   //  POST /api/v1/billing/saas/checkout → assinatura Asaas). Aqui apenas
   //  encaminhamos o lead para lá, levando o plano escolhido como hint (#plano).
-  var CHECKOUT_URL = '/parceiros/planos';
+  var CHECKOUT_URL = '/parceiros/cadastro';
   document.querySelectorAll('[data-plan]').forEach(function(el){
     el.setAttribute('href', CHECKOUT_URL + '#' + el.getAttribute('data-plan'));
   });


### PR DESCRIPTION
Durante o teste E2E descobri que a landing `public/software` enviava os CTAs para `/parceiros/planos` (planos de **especialista** Prime/VIP), e não para `/parceiros/cadastro`, que é onde o `DynamicPlans` renderiza os planos do **software** (Simples/Premium/Super) e dispara `POST /billing/saas/checkout`. Corrigido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_