### PR TITLE
fix(landing): formulário offline usa mesma origem (proxy do Next)

### DIFF
--- a/public/software/index.html
+++ b/public/software/index.html
@@ -166,7 +166,7 @@
 </div></footer>
 
 <script>
-  var API = 'https://api.agoraencontrei.com.br';
+  var API = ''; // mesma origem: Next faz rewrite de /api/v1/* para a API (evita api.* e CORS)
   var modal = document.getElementById('modal');
   var msg = document.getElementById('m-msg');
   var currentPlan = null;


### PR DESCRIPTION
O formulário de compra offline da landing chamava `https://api.agoraencontrei.com.br` direto, mas o navegador acessa a API via **proxy de mesma origem** (`rewrites` do Next: `/api/v1/*` → API). O domínio `api.*` público dá 404 no browser. Corrigido para usar a mesma origem (`/api/v1/...`), igual ao resto do site — assim o checkout offline funciona e sem CORS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_