### PR TITLE
feat(web): modernização visual do site público + dark mode

### DIFF
--- a/apps/web/src/app/(public)/imoveis/LoadMoreProperties.tsx
+++ b/apps/web/src/app/(public)/imoveis/LoadMoreProperties.tsx
@@ -39,13 +39,13 @@ function PriceDisplay({ price, priceRent, purpose }: { price: number | null; pri
         </div>
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-gray-500">Locação</span>
-          <span className="text-sm font-bold" style={{ color: '#1B2B5B' }}>{fmt.format(Number(priceRent))}/mês</span>
+          <span className="text-sm font-bold" style={{ color: 'var(--ae-heading)' }}>{fmt.format(Number(priceRent))}/mês</span>
         </div>
       </div>
     )
   }
-  if (hasRent) return <p className="text-base font-bold mt-3" style={{ color: '#1B2B5B' }}>{fmt.format(Number(priceRent))}/mês</p>
-  if (hasSale) return <p className="text-base font-bold mt-3" style={{ color: '#1B2B5B' }}>{fmt.format(Number(price))}</p>
+  if (hasRent) return <p className="text-base font-bold mt-3" style={{ color: 'var(--ae-heading)' }}>{fmt.format(Number(priceRent))}/mês</p>
+  if (hasSale) return <p className="text-base font-bold mt-3" style={{ color: 'var(--ae-heading)' }}>{fmt.format(Number(price))}</p>
   return <p className="text-sm font-medium mt-3 text-gray-500">Consulte</p>
 }
 

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -40,9 +40,16 @@ const FOOTER_SERVICOS = [
   { href: '/anunciar', label: 'Cadastre seu Imóvel' },
 ]
 
+// No-flash theme bootstrap: resolves the saved theme (cookie → localStorage →
+// system preference) and applies the `.ae-light` / `.ae-dark` class to the
+// wrapper before first paint. Scoped to the public layout only.
+const AE_THEME_SCRIPT = `(function(){try{var m=document.cookie.match(/(?:^|; )ae-theme=([^;]+)/);var t=m?m[1]:null;if(!t){try{t=localStorage.getItem('ae-theme')}catch(e){}}if(!t){t=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light'}var el=document.currentScript.parentElement;el.classList.remove('ae-light','ae-dark');el.classList.add(t==='dark'?'ae-dark':'ae-light')}catch(e){}})();`
+
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen" style={{ backgroundColor: '#f8f6f1' }}>
+    <div id="ae-root" suppressHydrationWarning className="min-h-screen ae-light" style={{ backgroundColor: 'var(--ae-surface)' }}>
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+      <script dangerouslySetInnerHTML={{ __html: AE_THEME_SCRIPT }} />
       {/* Top info bar */}
       <div style={{ backgroundColor: '#1B2B5B' }} className="hidden lg:block">
         <div className="max-w-7xl mx-auto px-6 h-9 flex items-center justify-between text-xs text-white/70">

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -443,10 +443,10 @@ export default async function HomePage() {
 
       {/* ── SMART QUIZ + CTA AVALIAÇÃO ─────────────────────────────────── */}
       <SmartQuizModal>
-      <section style={{ backgroundColor: theme.colors.secondary }} className="py-14">
+      <section style={{ backgroundColor: 'var(--site-secondary-color, #f8f6f1)' }} className="py-14">
         <div className="max-w-5xl mx-auto px-4 sm:px-6">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-0 rounded-3xl overflow-hidden shadow-xl border border-gray-200/60">
-            <div className="px-8 py-10 flex flex-col justify-center" style={{ backgroundColor: theme.colors.secondary }}>
+            <div className="px-8 py-10 flex flex-col justify-center" style={{ backgroundColor: 'var(--site-secondary-color, #f8f6f1)' }}>
               <div className="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-bold mb-5 w-fit" style={{ backgroundColor: theme.colors.badge, color: theme.colors.badgeText }}>
                 <Sparkles className="w-3.5 h-3.5" />
                 Busca Inteligente com IA
@@ -462,7 +462,7 @@ export default async function HomePage() {
             </div>
             <div className="hidden lg:block absolute" style={{ display: 'none' }} />
             <div className="bg-white px-8 py-10 flex flex-col justify-center border-t lg:border-t-0 lg:border-l border-gray-200">
-              <h2 className="text-2xl sm:text-3xl font-bold mb-3" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
+              <h2 className="text-2xl sm:text-3xl font-bold mb-3" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>
                 Quer saber quanto vale seu imóvel?
               </h2>
               <p className="text-gray-500 text-sm mb-8 max-w-sm leading-relaxed">
@@ -472,7 +472,7 @@ export default async function HomePage() {
                 <Link href="/avaliacao" className="px-7 py-3 rounded-xl text-sm font-bold transition-all hover:brightness-110 text-center" style={{ backgroundColor: 'var(--site-accent-color, #C9A84C)', color: 'var(--site-primary-color, #1B2B5B)' }}>
                   Avaliação imediata
                 </Link>
-                <a href="https://wa.me/5516981010004?text=Olá! Gostaria de uma avaliação imediata do meu imóvel." target="_blank" rel="noreferrer" className="px-7 py-3 rounded-xl text-sm font-bold border-2 transition-all hover:bg-[#1B2B5B] hover:text-white text-center" style={{ borderColor: 'var(--site-primary-color, #1B2B5B)', color: 'var(--site-primary-color, #1B2B5B)' }}>
+                <a href="https://wa.me/5516981010004?text=Olá! Gostaria de uma avaliação imediata do meu imóvel." target="_blank" rel="noreferrer" className="px-7 py-3 rounded-xl text-sm font-bold border-2 transition-all hover:bg-[#1B2B5B] hover:text-white text-center" style={{ borderColor: 'var(--ae-heading)', color: 'var(--ae-heading)' }}>
                   Falar pelo WhatsApp
                 </a>
               </div>
@@ -645,7 +645,7 @@ export default async function HomePage() {
           <p className="text-sm font-semibold uppercase tracking-widest mb-2" style={{ color: 'var(--site-accent-color, #C9A84C)' }}>
             Marketplace Imobiliário
           </p>
-          <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
+          <h2 className="text-2xl font-bold" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>
             Nossas Imobiliárias Parceiras
           </h2>
           <p className="text-gray-500 text-sm mt-1">Imobiliárias e profissionais parceiros anunciando no marketplace</p>
@@ -670,7 +670,7 @@ export default async function HomePage() {
                 className="w-full h-full object-contain drop-shadow-xl"
               />
             </div>
-            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Imobiliária Lemos</h3>
+            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>Imobiliária Lemos</h3>
             <p className="text-xs text-gray-500 mb-1">Franca — SP</p>
             <p className="text-xs font-semibold mb-4" style={{ color: '#C9A84C' }}>Desde 2002 · +22 anos de tradição</p>
             <p className="text-xs text-gray-500 leading-relaxed mb-5">
@@ -695,7 +695,7 @@ export default async function HomePage() {
             <div className="w-28 h-28 rounded-full flex items-center justify-center mb-4 border-4 border-dashed" style={{ borderColor: '#C9A84C', backgroundColor: 'rgba(201,168,76,0.08)' }}>
               <span className="text-5xl font-bold" style={{ color: '#C9A84C' }}>+</span>
             </div>
-            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Seja um Parceiro</h3>
+            <h3 className="text-xl font-bold mb-1" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>Seja um Parceiro</h3>
             <p className="text-xs text-gray-500 mb-4">Sua imobiliária aqui</p>
             <p className="text-xs text-gray-500 leading-relaxed mb-5">
               Anuncie seus imóveis no maior marketplace imobiliário de Franca. Tecnologia de ponta, sem custo inicial.
@@ -721,7 +721,7 @@ export default async function HomePage() {
       <section style={{ backgroundColor: 'var(--site-background-color, #f8f6f1)' }} className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <Reveal className="text-center mb-10">
-            <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
+            <h2 className="text-2xl font-bold" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>
               O que você procura?
             </h2>
             <p className="text-gray-500 text-sm mt-1">Selecione o tipo de imóvel e explore as opções</p>
@@ -738,9 +738,9 @@ export default async function HomePage() {
                 >
                   <div
                     className="w-14 h-14 rounded-xl flex items-center justify-center transition-all duration-200 group-hover:scale-110"
-                    style={{ backgroundColor: 'rgba(27,43,91,0.06)', color: '#1B2B5B' }}
+                    style={{ backgroundColor: 'rgba(27,43,91,0.06)', color: 'var(--ae-heading)' }}
                   >
-                    <div className="group-hover:text-[#C9A84C] transition-colors duration-200" style={{ color: 'var(--site-primary-color, #1B2B5B)' }}>
+                    <div className="group-hover:text-[#C9A84C] transition-colors duration-200" style={{ color: 'var(--ae-heading)' }}>
                       {CategoryIcons[cat.iconKey]}
                     </div>
                   </div>
@@ -759,7 +759,7 @@ export default async function HomePage() {
         <section className="max-w-7xl mx-auto px-4 sm:px-6 py-16">
           <div className="flex items-center justify-between mb-8">
             <Reveal direction="right">
-              <h2 className="text-2xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>
+              <h2 className="text-2xl font-bold" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>
                 Imóveis em Destaque
               </h2>
               <p className="text-gray-500 text-sm mt-0.5">Imóveis selecionados pela nossa equipe para você</p>
@@ -838,7 +838,7 @@ export default async function HomePage() {
                       </span>
                     )}
                   </div>
-                  <p className="text-base font-bold mt-3" style={{ color: 'var(--site-primary-color, #1B2B5B)' }}>
+                  <p className="text-base font-bold mt-3" style={{ color: 'var(--ae-heading)' }}>
                     {formatPrice(p)}
                   </p>
                 </div>
@@ -866,7 +866,7 @@ export default async function HomePage() {
           ))}
         </div>
         <div className="text-center mb-6">
-          <h2 className="text-xl font-bold" style={{ color: 'var(--site-primary-color, #1B2B5B)', fontFamily: '"Playfair Display", Georgia, serif' }}>Siga-nos nas Redes Sociais</h2>
+          <h2 className="text-xl font-bold" style={{ color: 'var(--ae-heading)', fontFamily: '"Playfair Display", Georgia, serif' }}>Siga-nos nas Redes Sociais</h2>
           <p className="text-gray-500 text-sm mt-1">Acompanhe os melhores imóveis, dicas e novidades</p>
         </div>
         <div className="flex flex-wrap justify-center gap-4">

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -228,6 +228,17 @@ html {
 #ae-root.ae-dark .border-gray-100,
 #ae-root.ae-dark .border-gray-200,
 #ae-root.ae-dark .border-gray-300 { border-color: var(--ae-border) !important; }
+/* Light section/utility backgrounds used across the internal public pages. */
+#ae-root.ae-dark .bg-gray-50,
+#ae-root.ae-dark .bg-gray-100,
+#ae-root.ae-dark .bg-\[\#f8f6f1\] { background-color: var(--ae-surface) !important; }
+#ae-root.ae-dark .bg-gray-200 { background-color: #20242c !important; }
+/* Navy heading text written as a Tailwind arbitrary value (text-[#1B2B5B]) is
+   the dominant title pattern on internal pages → remap to a readable token.
+   NOTE: inline `style={{ color: '#1B2B5B' }}` is deliberately NOT remapped — it
+   is syntactically identical to navy-on-gold buttons, so it needs per-surface
+   handling (see --ae-heading conversions) rather than a blanket override. */
+#ae-root.ae-dark .text-\[\#1B2B5B\] { color: var(--ae-heading) !important; }
 /* Inputs on dark public surfaces: dark field, light text. */
 #ae-root.ae-dark input:not([type='checkbox']):not([type='radio']),
 #ae-root.ae-dark textarea,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -182,6 +182,63 @@ html {
   text-size-adjust: 100%;
 }
 
+/* ── Public site theming (light/dark) ─────────────────────────────────────── */
+/* The scope lives on the public layout wrapper (#ae-root.ae-light/.ae-dark),  */
+/* set server-side + by a no-flash inline script and toggled from the navbar.  */
+/* Dark mode only flips background-type tokens + a curated set of hardcoded     */
+/* light utilities; the gold accent and navy chrome are intentionally kept.    */
+#ae-root {
+  --ae-surface: #f8f6f1;                       /* page background */
+  --ae-card: #ffffff;                          /* cards / panels  */
+  --ae-heading: var(--site-primary-color, #1B2B5B); /* titles on light surfaces */
+  --ae-body: #4b5563;                          /* gray-600 body   */
+  --ae-muted: #6b7280;                         /* gray-500 muted  */
+  --ae-border: #e5e7eb;                        /* gray-200 border */
+  background-color: var(--ae-surface);
+  transition: background-color 0.3s ease;
+}
+
+#ae-root.ae-dark {
+  --ae-surface: #0e1117;
+  --ae-card: #171a21;
+  --ae-heading: #f3f4f6;
+  --ae-body: #c7ccd4;
+  --ae-muted: #9aa1ab;
+  --ae-border: rgba(255, 255, 255, 0.08);
+  /* Flip the background-only site tokens so var()-driven sections darken.      */
+  /* (--site-primary-color / --site-accent-color are left intact: they are     */
+  /*  reused for navy chrome backgrounds and the gold accent.)                  */
+  --site-background-color: #0e1117;
+  --site-secondary-color: #0e1117;
+  --site-card-bg: #171a21;
+  --site-card-border: rgba(255, 255, 255, 0.08);
+  --site-wave: #0e1117;
+  color-scheme: dark;
+}
+
+/* Map common hardcoded light utilities onto the dark surfaces. The #ae-root id */
+/* keeps these above the light-page input fixes (#main-content …) in cascade.   */
+#ae-root.ae-dark .bg-white { background-color: var(--ae-card) !important; }
+#ae-root.ae-dark .text-gray-900,
+#ae-root.ae-dark .text-gray-800 { color: var(--ae-heading) !important; }
+#ae-root.ae-dark .text-gray-700,
+#ae-root.ae-dark .text-gray-600 { color: var(--ae-body) !important; }
+#ae-root.ae-dark .text-gray-500,
+#ae-root.ae-dark .text-gray-400 { color: var(--ae-muted) !important; }
+#ae-root.ae-dark .border-gray-100,
+#ae-root.ae-dark .border-gray-200,
+#ae-root.ae-dark .border-gray-300 { border-color: var(--ae-border) !important; }
+/* Inputs on dark public surfaces: dark field, light text. */
+#ae-root.ae-dark input:not([type='checkbox']):not([type='radio']),
+#ae-root.ae-dark textarea,
+#ae-root.ae-dark select {
+  background-color: var(--ae-card) !important;
+  color: var(--ae-heading) !important;
+  border-color: var(--ae-border) !important;
+}
+#ae-root.ae-dark input::placeholder,
+#ae-root.ae-dark textarea::placeholder { color: var(--ae-muted) !important; }
+
 /* ── Accessibility: honor prefers-reduced-motion ──────────────────────────── */
 /* Users who request reduced motion get near-instant transitions/animations.  */
 /* Framer Motion reveals already opt out via useReducedMotion; this is the     */

--- a/apps/web/src/components/public/Navbar.tsx
+++ b/apps/web/src/components/public/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 import { useBodyScrollLock } from '@/lib/use-body-scroll-lock'
+import { ThemeToggle } from './ThemeToggle'
 import {
   Menu, X, ChevronDown, ChevronRight,
   LayoutDashboard, UserCheck, Users, CreditCard,
@@ -239,6 +240,9 @@ export function Navbar() {
                 </div>
               )}
             </div>
+
+            {/* Light/dark toggle (public site) */}
+            <ThemeToggle className="flex items-center justify-center p-2 rounded-lg text-white/80 hover:text-white hover:bg-white/10 transition-colors border border-white/20" />
 
             <a
               href="https://wa.me/5516981010004?text=Olá! Vim pelo site e gostaria de mais informações."

--- a/apps/web/src/components/public/ThemeToggle.tsx
+++ b/apps/web/src/components/public/ThemeToggle.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+const ROOT_ID = 'ae-root'
+
+/**
+ * Public-site light/dark toggle. The theme is a scoped class (`ae-light` /
+ * `ae-dark`) on the public layout wrapper (#ae-root), set server-side + by a
+ * no-flash inline script. This button flips that class and persists the choice
+ * in a cookie (read on the next SSR pass) and localStorage. It deliberately
+ * does NOT touch the dashboard, which owns its own always-dark `.dark` scope.
+ */
+export function ThemeToggle({ className }: { className?: string }) {
+  const [dark, setDark] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const root = document.getElementById(ROOT_ID)
+    if (!root) {
+      setMounted(true)
+      return
+    }
+    // Re-assert the persisted theme on mount. On full page loads the inline
+    // no-flash script already applied it; this also covers App Router soft
+    // navigations (e.g. dashboard → public) where that script does not re-run.
+    let saved: string | null = null
+    const m = document.cookie.match(/(?:^|; )ae-theme=([^;]+)/)
+    saved = m ? m[1] : null
+    if (!saved) {
+      try {
+        saved = localStorage.getItem('ae-theme')
+      } catch {
+        /* storage blocked */
+      }
+    }
+    if (!saved) {
+      saved = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    const isDark = saved === 'dark'
+    root.classList.toggle('ae-dark', isDark)
+    root.classList.toggle('ae-light', !isDark)
+    setDark(isDark)
+    setMounted(true)
+  }, [])
+
+  const toggle = () => {
+    const root = document.getElementById(ROOT_ID)
+    if (!root) return
+    const next = !root.classList.contains('ae-dark')
+    root.classList.toggle('ae-dark', next)
+    root.classList.toggle('ae-light', !next)
+    try {
+      document.cookie = `ae-theme=${next ? 'dark' : 'light'}; path=/; max-age=31536000; samesite=lax`
+      localStorage.setItem('ae-theme', next ? 'dark' : 'light')
+    } catch {
+      /* storage blocked — class toggle alone still works for this session */
+    }
+    setDark(next)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={dark ? 'Ativar modo claro' : 'Ativar modo escuro'}
+      title={dark ? 'Modo claro' : 'Modo escuro'}
+      className={
+        className ??
+        'flex items-center justify-center p-2 rounded-lg text-white/80 hover:text-white hover:bg-white/10 transition-colors'
+      }
+    >
+      {/* Before mount we render the moon to match the light-default SSR output;
+          after mount the icon reflects the real state. */}
+      {mounted && dark ? <Sun className="w-4 h-4" aria-hidden="true" /> : <Moon className="w-4 h-4" aria-hidden="true" />}
+    </button>
+  )
+}
+
+export default ThemeToggle


### PR DESCRIPTION
## Resumo

Implementa as melhorias visuais priorizadas para o marketplace público e adiciona um modo claro/escuro real, sem reconstruir o site. Todas as mudanças são no `apps/web` e ficam restritas ao site público — o dashboard (que já tem seu próprio `.dark`) não é afetado.

> ⚠️ **Precisa de QA visual antes do merge.** O ambiente desta sessão não consegue renderizar a app (o `pnpm install` trava no download das engines do Prisma pelo proxy). As validações feitas foram typecheck isolado dos componentes novos, parse/JSX check de todos os arquivos editados e checagem de balanceamento de chaves no CSS.

## O que mudou

### 1. Acessibilidade / contraste (WCAG AA)
- Texto branco de baixa opacidade no rodapé e top-bar (navy) elevado para passar AA em texto pequeno (`text-white/40→/60`, `/50→/70`, `/30→/55`).
- Um `text-gray-400→500` numa seção clara.

### 2. Scroll-reveal
- Novo componente reutilizável `components/public/Reveal.tsx` (framer-motion `whileInView`, `once`, respeita `prefers-reduced-motion`).
- Aplicado aos cabeçalhos das seções principais da home.

### 3. Tipografia (Playfair Display + hierarquia)
- Playfair Display carregado e adotado como fonte de títulos do tema ativo (cascateia via `theme.typography.heroFont`).
- Georgia hardcoded substituído pela stack Playfair; H1 do hero reforçado (`text-5xl→7xl`, leading/tracking mais justos).

### 4. Inconsistência do dark mode (correção arquitetural)
- Removido o `className="dark"` forçado no `<html>` raiz. O dashboard já escopa `.dark` no próprio wrapper, então o flag global só forçava os overrides `!important` das páginas públicas.
- Os 7 seletores `html.dark` do `globals.css` foram reescopados para `.dark`.

### 5. Micro-interações
- `Button` compartilhado com elevação (`-translate-y-0.5`) + sombra suave no hover, assentando no `active`; respeita reduced-motion.
- Net global de `prefers-reduced-motion` no `globals.css`.

### 6. Toggle claro/escuro público (dark mode real)
- Tema como classe escopada no wrapper público (`#ae-root.ae-light/.ae-dark`), aplicada por script inline sem flash (`cookie → localStorage → preferência do sistema`), com `suppressHydrationWarning`. Sem `next-themes` e sem renderização dinâmica — páginas públicas continuam estáticas.
- `components/public/ThemeToggle.tsx` na navbar; persiste em cookie (1 ano) + localStorage e reafirma o tema no mount (cobre soft navigation do App Router).
- Camada de superfícies dark em `globals.css` com tokens semânticos (`--ae-surface/-card/-heading/-body/-muted/-border`); flip dos tokens de fundo (`--site-background-color`, `-secondary-color`, `-card-bg`, `-wave`) mantendo o dourado e o navy do chrome intactos.

### 7. Cobertura dark nas páginas internas
- Override global ampliado para os padrões reais medidos: `bg-gray-50/100/200`, `bg-[#f8f6f1]` e a classe arbitrária de título navy `text-[#1B2B5B]` (~360 usos).
- Card de imóvel (`LoadMoreProperties`): preço de locação inline roteado por `--ae-heading`, preservando badges navy-on-gold/navy-on-white.

## Decisão técnica
O `style={{ color: '#1B2B5B' }}` **inline** (512 usos) é ambíguo — a mesma string serve para título-em-card (clarear no escuro) e texto navy-em-botão-dourado (manter navy). Tratado por superfície nas áreas de maior valor (home + card), não por regra cega. Sub-páginas profundas podem ter títulos navy inline isolados a converter — item de QA.

## Validação
- ✅ Typecheck isolado de `Reveal`, `ThemeToggle`, `button` (exit 0).
- ✅ Parse/JSX check de todos os `.tsx` editados.
- ✅ `globals.css` com chaves balanceadas.
- ✅ Modo claro inalterado (regras novas escopadas em `#ae-root.ae-dark`; `--ae-heading` no claro = navy idêntico).
- ⚠️ Typecheck do projeto inteiro não executado (Prisma engines bloqueadas no proxy) — recomendo `pnpm typecheck` no merge.

## Como testar (QA)
1. `pnpm install && pnpm typecheck`
2. Rodar a web e conferir no claro e no escuro: home, `/imoveis` (listagem), `/imoveis/[slug]` (detalhe), `/parceiros/planos`, blog.
3. Toggle na navbar: alternar tema, recarregar (sem flash), navegar entre páginas (persistência).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138bGcmpAwC53fJsfQoY5ji)_