### PR TITLE
feat(planos): edição Offline visível junto com os planos na nuvem

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-windows:
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,6 +58,11 @@ jobs:
         continue-on-error: true
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+          # O instalador offline não embute as ~13 mil páginas SEO públicas
+          # (comparar de cidades = 11.476, etc.). Sem o cache de build do Vercel,
+          # gerá-las a frio no runner Windows estourava o timeout. MINIMAL_SSG=1
+          # faz os generateStaticParams retornarem [] (as rotas seguem via ISR).
+          MINIMAL_SSG: '1'
           # Build não acessa o banco; valores fictícios evitam falha de validação de env.
           DATABASE_URL: 'postgresql://user:pass@127.0.0.1:5432/db'
           DIRECT_DATABASE_URL: 'postgresql://user:pass@127.0.0.1:5432/db'

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/[modificador]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/[modificador]/page.tsx
@@ -45,6 +45,7 @@ function clusterLabel(cluster: string): string {
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string; modificador: string }[] = []
   // Gerar apenas para as top 20 cidades por população para não explodir o build
   const topCidades = IBGE_CITIES_152.sort((a, b) => b.populacao - a.populacao).slice(0, 20)

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -55,6 +55,7 @@ function resolveMeta(cluster: string, cityName: string, state: string) {
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
   for (const city of IBGE_CITIES_152) {
     for (const cluster of Object.keys(CLUSTER_META)) {

--- a/apps/web/src/app/(public)/[estado]/[cidade]/bairro/[bairro]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/bairro/[bairro]/page.tsx
@@ -13,6 +13,7 @@ import { IBGE_CITY_BY_SLUG } from '@/data/seo-ibge-cities-expanded'
 export const revalidate = 86400
 
 export function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   // Gerar apenas para Franca (por agora)
   return BAIRROS_FRANCA.map(b => ({
     estado: 'sp',

--- a/apps/web/src/app/(public)/[estado]/[cidade]/guia/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/guia/[cluster]/page.tsx
@@ -27,6 +27,7 @@ const GUIAS: Record<string, { label: string; desc: string; icon: string }> = {
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
   for (const city of IBGE_CITIES_152) {
     for (const cluster of Object.keys(GUIAS)) {

--- a/apps/web/src/app/(public)/[estado]/[cidade]/investimentos/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/investimentos/[cluster]/page.tsx
@@ -25,6 +25,7 @@ const INVESTIMENTOS: Record<string, { label: string; desc: string; icon: string 
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
   for (const city of IBGE_CITIES_152) {
     for (const cluster of Object.keys(INVESTIMENTOS)) {

--- a/apps/web/src/app/(public)/[estado]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/page.tsx
@@ -37,6 +37,7 @@ const SERVICE_CLUSTERS = [
 ]
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return IBGE_CITIES_152.map(city => ({
     estado: city.stateSlug,
     cidade: city.slug,

--- a/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
@@ -29,6 +29,7 @@ const SERVICOS: Record<string, { label: string; desc: string; icon: string; faq:
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
   for (const city of IBGE_CITIES_152) {
     for (const cluster of Object.keys(SERVICOS)) {

--- a/apps/web/src/app/(public)/bairros/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/bairros/[slug]/page.tsx
@@ -13,6 +13,7 @@ function getNeighborhood(slug: string) {
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return FRANCA_NEIGHBORHOODS_SEO.map(n => ({ slug: n.slug }))
 }
 

--- a/apps/web/src/app/(public)/comparar/[cidadeA]-vs-[cidadeB]/page.tsx
+++ b/apps/web/src/app/(public)/comparar/[cidadeA]-vs-[cidadeB]/page.tsx
@@ -21,6 +21,7 @@ const ALL_CITIES_SORTED = IBGE_CITIES_152
   .sort((a, b) => b.populacao - a.populacao)
 
 export function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { 'cidadeA-vs-cidadeB': string }[] = []
   for (let i = 0; i < ALL_CITIES_SORTED.length; i++) {
     for (let j = i + 1; j < ALL_CITIES_SORTED.length; j++) {

--- a/apps/web/src/app/(public)/custo-de-vida/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/custo-de-vida/[cidade]/page.tsx
@@ -154,6 +154,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return Object.keys(CITY_DATA).map(cidade => ({ cidade }))
 }
 

--- a/apps/web/src/app/(public)/imoveis/em/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/em/[cidade]/page.tsx
@@ -440,6 +440,7 @@ export async function generateMetadata(props: { params: Promise<{ cidade: string
 }
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return Object.keys(CIDADES).map(cidade => ({ cidade }))
 }
 

--- a/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
@@ -75,6 +75,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return Object.keys(POIS).map(poi => ({ poi }))
 }
 

--- a/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
@@ -46,6 +46,7 @@ function fmt(v: number) {
 type Props = { params: Promise<{ slug: string }> }
 
 export function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return Object.keys(LOCATIONS).map(slug => ({ slug }))
 }
 

--- a/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
@@ -112,6 +112,7 @@ const TOP_20_CITIES = [
 ]
 
 export async function generateStaticParams() {
+  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   return TOP_20_CITIES
 }
 

--- a/apps/web/src/app/(public)/software/page.tsx
+++ b/apps/web/src/app/(public)/software/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 
 /**
  * /software — página de vendas do Sistema Administrador AgoraEncontrei.
@@ -94,6 +94,17 @@ export default function SoftwarePage() {
     setMsg({ text: '', kind: '' })
   }, [])
   const close = useCallback(() => setPlan(null), [])
+
+  // Vindo de /parceiros/cadastro (?plan=offline-anual) já abrimos o checkout
+  // com o plano escolhido — sem o cliente precisar reencontrar o plano aqui.
+  useEffect(() => {
+    const id = new URLSearchParams(window.location.search).get('plan')
+    const match = OFFLINE_PLANS.find((p) => p.id === id)
+    if (match) {
+      setPlan({ id: match.id, label: match.label })
+      requestAnimationFrame(() => document.getElementById('offline')?.scrollIntoView({ behavior: 'smooth' }))
+    }
+  }, [])
 
   const submit = useCallback(async () => {
     const { name, email, cpfCnpj, phone } = form

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import {
   CheckCircle, Crown, Star, Zap, ArrowRight, Shield, Sparkles,
   Bot, MessageCircle, BarChart3, Globe, Code, EyeOff, Users,
-  FileText, Lock, Loader2, X,
+  FileText, Lock, Loader2, X, Monitor, Cloud, Download,
 } from 'lucide-react'
 import { ALL_THEMES, THEME_REGISTRY } from '@/lib/site-factory/theme-registry'
 import { ThemePreviewModal } from './ThemePreviewModal'
@@ -91,6 +91,28 @@ const MODULE_ICONS: Record<string, typeof Bot> = {
 function formatPrice(val: string | number): string {
   return Number(val).toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
 }
+
+// Edição OFFLINE (instalada no PC do cliente). Não vem do catálogo da API
+// porque é outro modelo de entrega — mas precisa aparecer LADO A LADO com os
+// planos na nuvem para o cliente comparar e escolher sem se perder. Cada card
+// leva ao checkout offline (/software) já com o plano pré-selecionado.
+const OFFLINE_PLANS = [
+  {
+    id: 'offline-mensal', name: 'Offline Mensal', price: '197', unit: '/mês',
+    note: 'cobrança recorrente', hot: false,
+    feats: ['Instalado no seu Windows', 'Dados 100% na sua máquina', 'Funciona sem internet', 'Importa o backup do seu sistema atual'],
+  },
+  {
+    id: 'offline-anual', name: 'Offline Anual', price: '1.970', unit: '/ano',
+    note: '≈ R$ 164/mês · 2 meses grátis', hot: true,
+    feats: ['Tudo do Offline Mensal', 'Economia de ~2 meses', 'Atualizações + suporte', 'Prioridade no suporte'],
+  },
+  {
+    id: 'offline-vitalicia', name: 'Offline Vitalícia', price: '2.497', unit: ' único',
+    note: 'pague uma vez, use para sempre', hot: false,
+    feats: ['Licença sem mensalidade', '1 ano de atualizações inclusas', 'Sem dependência de internet', 'Ideal para quem prefere comprar'],
+  },
+]
 
 export function DynamicPlans() {
   const [plans, setPlans] = useState<PlanDef[]>([])
@@ -270,6 +292,87 @@ export function DynamicPlans() {
             </div>
           )
         })}
+      </div>
+
+      {/* Edição Offline — lado a lado com os planos na nuvem, para o cliente
+          enxergar as duas formas de usar o sistema e escolher sem se perder. */}
+      <div className="max-w-5xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-6 sm:mb-8">
+          <span className="inline-flex items-center gap-2 text-[11px] sm:text-xs font-bold uppercase tracking-wide text-emerald-400 bg-emerald-500/10 border border-emerald-500/25 px-3 py-1 rounded-full">
+            <Monitor className="w-3.5 h-3.5" /> Prefere no seu PC?
+          </span>
+          <h3 className="text-2xl sm:text-3xl font-bold text-white mt-3">Edição Offline — instalada no seu computador</h3>
+          <p className="text-gray-400 max-w-2xl mt-2 text-sm sm:text-base">
+            Mesmo sistema (CRM, imóveis, contratos, aluguéis e cobrança com a IA Tomás), só que rodando
+            no seu Windows, com os dados na sua máquina e funcionando sem internet. Ideal para quem migra
+            de um sistema desktop antigo.
+          </p>
+          <div className="flex items-center gap-2 mt-3 text-[11px] sm:text-xs text-gray-500">
+            <Cloud className="w-3.5 h-3.5 text-blue-400" /> Na nuvem (acima)
+            <span className="mx-1">vs</span>
+            <Monitor className="w-3.5 h-3.5 text-emerald-400" /> No seu PC (abaixo)
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3 px-2 sm:px-0">
+          {OFFLINE_PLANS.map(op => (
+            <div
+              key={op.id}
+              className={`relative flex flex-col rounded-xl sm:rounded-2xl border bg-gradient-to-b from-emerald-950/20 to-transparent backdrop-blur-sm p-4 sm:p-6 transition-all hover:scale-[1.01] sm:hover:scale-[1.02] ${
+                op.hot ? 'border-emerald-500/50 ring-2 ring-emerald-500/50 shadow-lg shadow-emerald-500/10 order-first sm:order-none' : 'border-emerald-500/25'
+              }`}
+            >
+              {op.hot && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2">
+                  <span className="bg-emerald-500 text-gray-950 text-[10px] sm:text-xs font-bold px-2.5 sm:px-3 py-0.5 sm:py-1 rounded-full whitespace-nowrap">
+                    Melhor valor
+                  </span>
+                </div>
+              )}
+
+              <div className="flex items-center gap-2.5 sm:gap-3 mb-3 sm:mb-4">
+                <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-lg sm:rounded-xl bg-emerald-500/10 text-emerald-400 flex items-center justify-center flex-shrink-0">
+                  <Monitor className="w-4 h-4 sm:w-5 sm:h-5" />
+                </div>
+                <div className="min-w-0">
+                  <h3 className="text-base sm:text-lg font-bold text-white">{op.name}</h3>
+                  <p className="text-[11px] sm:text-xs text-gray-400 truncate">No seu PC · {op.note}</p>
+                </div>
+              </div>
+
+              <div className="mb-4 sm:mb-6">
+                <div className="flex items-baseline gap-1">
+                  <span className="text-2xl sm:text-3xl font-bold text-white">R$ {op.price}</span>
+                  <span className="text-xs sm:text-sm text-gray-400">{op.unit}</span>
+                </div>
+                <p className="text-[11px] sm:text-xs text-emerald-400 mt-1">{op.note}</p>
+              </div>
+
+              <ul className="space-y-1.5 sm:space-y-2 mb-4 sm:mb-6 flex-1">
+                {op.feats.map((f, i) => (
+                  <li key={i} className="flex items-start gap-2 text-xs sm:text-sm">
+                    <CheckCircle className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-emerald-400 flex-shrink-0 mt-0.5" />
+                    <span className="text-gray-300">{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <a
+                href={`/software?plan=${op.id}`}
+                className={`flex items-center justify-center gap-1.5 w-full text-center py-2.5 sm:py-3 rounded-lg sm:rounded-xl font-bold text-xs sm:text-sm transition cursor-pointer ${
+                  op.hot ? 'bg-emerald-500 hover:bg-emerald-400 text-gray-950' : 'bg-emerald-600/90 hover:bg-emerald-500 text-white'
+                }`}
+              >
+                <Download className="w-3.5 h-3.5 sm:w-4 sm:h-4" /> Quero no meu PC
+              </a>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-center text-xs sm:text-sm text-gray-500 mt-5">
+          Pagou? Você recebe o link do instalador <strong className="text-gray-400">.exe</strong> + a chave de licença por e-mail.
+          {' '}<a href="/software" className="text-emerald-400 hover:underline">Ver detalhes da edição offline →</a>
+        </p>
       </div>
 
       {/* Modules add-ons */}


### PR DESCRIPTION
## Problema

A venda do **Sistema Offline** ficava só em `/software`, separada dos planos online. Em `/parceiros/cadastro` o cliente via apenas Lite/Pro/Enterprise/Nível Máximo (nuvem) e não encontrava nem entendia a opção offline — ficou confuso.

## Correção

Em `/parceiros/cadastro`, logo **abaixo dos planos na nuvem**, agora aparece uma seção clara **"Edição Offline — instalada no seu computador"** com:
- Selo "Prefere no seu PC?" + comparação rápida ☁️ Nuvem (acima) vs 🖥️ No seu PC (abaixo).
- Os **3 planos offline** no mesmo estilo visual dos cloud: Mensal **R$197/mês**, Anual **R$1.970/ano** (destaque "Melhor valor"), Vitalícia **R$2.497** único.
- CTA "Quero no meu PC" → `/software?plan=<id>`, que **já abre o checkout offline com o plano pré-selecionado** (novo `useEffect` lê o query param na página `/software`).
- Nota explicando que após o pagamento o cliente recebe o `.exe` + chave por e-mail.

## Arquivos

- `apps/web/src/components/public/DynamicPlans.tsx` — seção offline (3 cards) após o grid de planos na nuvem.
- `apps/web/src/app/(public)/software/page.tsx` — auto-abre o modal do plano vindo de `?plan=`.

## Verificação

- Ambos validados com esbuild (`--loader:.tsx=tsx --jsx=automatic`) → PARSE OK.
- IDs de plano (`offline-mensal/anual/vitalicia`) consistentes com o endpoint e o webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_