### PR TITLE
fix(web): darken inline light backgrounds in public dark mode (QA pass)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -239,6 +239,18 @@ html {
    is syntactically identical to navy-on-gold buttons, so it needs per-surface
    handling (see --ae-heading conversions) rather than a blanket override. */
 #ae-root.ae-dark .text-\[\#1B2B5B\] { color: var(--ae-heading) !important; }
+/* Inline light backgrounds (set via the `style` attribute) cannot be reached by
+   class overrides, so they stay bright in dark mode. A `background-color` match
+   is unambiguous (unlike text color), so a case-insensitive substring selector
+   safely darkens them. Verified against the deployed HTML: e.g. the /avaliacao
+   section + form option cards and the home social buttons use inline #fff. */
+#ae-root.ae-dark [style*="background-color:#fff" i],
+#ae-root.ae-dark [style*="background-color: #fff" i] { background-color: var(--ae-card) !important; }
+#ae-root.ae-dark [style*="background-color:#f8f6f1" i],
+#ae-root.ae-dark [style*="background-color: #f8f6f1" i],
+#ae-root.ae-dark [style*="background-color:#f8f5f0" i],
+#ae-root.ae-dark [style*="background-color:#fafafa" i],
+#ae-root.ae-dark [style*="background-color:#f9fafb" i] { background-color: var(--ae-surface) !important; }
 /* Inputs on dark public surfaces: dark field, light text. */
 #ae-root.ae-dark input:not([type='checkbox']):not([type='radio']),
 #ae-root.ae-dark textarea,


### PR DESCRIPTION
## Resumo

Follow-up de **QA visual** do dark mode público (PR #220). Renderizando as páginas **já em produção** em modo escuro (HTML real + CSS ao vivo, com `.ae-dark` forçado via Playwright em `file://`), encontrei blocos **brancos/creme** que a camada de override por classe não alcança: fundos definidos via atributo `style` inline.

## Bug encontrado (evidência)
Fundos claros inline não viravam escuro — ex.: a seção e os cards de opção do `/avaliacao`, os botões sociais da home, callouts da página de detalhe. Auditoria sobre o HTML implantado: `avaliacao` 11+4, `home` 3+1, `detalhe` 2, `parceiros/planos` 1 (zero nas páginas já limpas).

## Correção
Override escopado e case-insensitive por substring de atributo (um match em `background-color` é inequívoco — diferente de cor de texto — então é seguro):

```
#fff/#ffffff                     -> var(--ae-card)
#f8f6f1/#f8f5f0/#fafafa/#f9fafb  -> var(--ae-surface)
```

Modo claro **inalterado** (regras escopadas em `#ae-root.ae-dark`).

## Teste (A/B render)
Renderizei `/avaliacao` em dark **sem** e **com** o fix:
- **Sem fix:** seção creme + pílulas brancas ("Casa", "Apartamento"…) sobre o card escuro.
- **Com fix:** todas as superfícies escurecem de forma coesa; texto permanece legível.

Também verifiquei estaticamente que os seletores atingem só os elementos certos (sem over-match) e que o CSS é válido (chaves balanceadas).

> Observação: screenshots pixel-a-pixel via navegador headless **não** funcionam pelo proxy de política deste ambiente (rede bloqueada para o browser); por isso o teste foi feito renderizando o HTML real localmente via `file://` com o CSS ao vivo embutido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138bGcmpAwC53fJsfQoY5ji)_