### PR TITLE
fix(desktop): empacotamento da API offline (extraResources) — completa o #226

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -95,14 +95,15 @@ jobs:
       - name: Verify API packed into app
         shell: bash
         run: |
-          APP="apps/desktop/dist/win-unpacked/resources/app"
-          echo "--- conteúdo de server/api ---"; ls "$APP/server/api" 2>/dev/null || echo '  (server/api ausente!)'
-          test -f "$APP/server/api/dist/server.js"            && echo "✓ dist/server.js"        || { echo "✗ dist/server.js";  exit 1; }
-          test -d "$APP/server/api/node_modules/fastify"      && echo "✓ fastify"               || { echo "✗ fastify";        exit 1; }
-          test -d "$APP/server/api/node_modules/@prisma/client" && echo "✓ @prisma/client"      || { echo "✗ @prisma/client"; exit 1; }
-          ls "$APP/server/api/node_modules/.prisma/client/"*query_engine-windows*.node >/dev/null 2>&1 && echo "✓ engine windows" || { echo "✗ engine windows"; exit 1; }
-          test -d "$APP/server/web/apps/web/.next"            && echo "✓ web .next"             || { echo "✗ web .next";      exit 1; }
-          echo "Tamanho do app empacotado:"; du -sh "$APP" 2>/dev/null || true
+          # server/ vai como extraResources → fica em resources/server (NÃO em resources/app).
+          SRV="apps/desktop/dist/win-unpacked/resources/server"
+          echo "--- conteúdo de server/api ---"; ls "$SRV/api" 2>/dev/null || echo '  (server/api ausente!)'
+          test -f "$SRV/api/dist/server.js"            && echo "✓ dist/server.js"        || { echo "✗ dist/server.js";  exit 1; }
+          test -d "$SRV/api/node_modules/fastify"      && echo "✓ fastify"               || { echo "✗ fastify";        exit 1; }
+          test -d "$SRV/api/node_modules/@prisma/client" && echo "✓ @prisma/client"      || { echo "✗ @prisma/client"; exit 1; }
+          ls "$SRV/api/node_modules/.prisma/client/"*query_engine-windows*.node >/dev/null 2>&1 && echo "✓ engine windows" || { echo "✗ engine windows"; exit 1; }
+          test -d "$SRV/web/apps/web/.next"            && echo "✓ web .next"             || { echo "✗ web .next";      exit 1; }
+          echo "Tamanho do app empacotado (resources):"; du -sh "apps/desktop/dist/win-unpacked/resources" 2>/dev/null || true
 
       - name: Upload .exe artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -89,6 +89,21 @@ jobs:
       - name: Build installer (electron-builder)
         run: pnpm --filter @agoraencontrei/desktop dist
 
+      # Confirma que a API (node_modules + engine do Prisma) REALMENTE entrou no
+      # app empacotado — o electron-builder pode descartar node_modules aninhados.
+      # Falha o build (sem publicar) se faltar, evitando um instalador inútil.
+      - name: Verify API packed into app
+        shell: bash
+        run: |
+          APP="apps/desktop/dist/win-unpacked/resources/app"
+          echo "--- conteúdo de server/api ---"; ls "$APP/server/api" 2>/dev/null || echo '  (server/api ausente!)'
+          test -f "$APP/server/api/dist/server.js"            && echo "✓ dist/server.js"        || { echo "✗ dist/server.js";  exit 1; }
+          test -d "$APP/server/api/node_modules/fastify"      && echo "✓ fastify"               || { echo "✗ fastify";        exit 1; }
+          test -d "$APP/server/api/node_modules/@prisma/client" && echo "✓ @prisma/client"      || { echo "✗ @prisma/client"; exit 1; }
+          ls "$APP/server/api/node_modules/.prisma/client/"*query_engine-windows*.node >/dev/null 2>&1 && echo "✓ engine windows" || { echo "✗ engine windows"; exit 1; }
+          test -d "$APP/server/web/apps/web/.next"            && echo "✓ web .next"             || { echo "✗ web .next";      exit 1; }
+          echo "Tamanho do app empacotado:"; du -sh "$APP" 2>/dev/null || true
+
       - name: Upload .exe artifact
         uses: actions/upload-artifact@v4
         with:

--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -19,6 +19,10 @@ const LOCAL_URL = process.env.AGORA_LOCAL_URL || `http://127.0.0.1:${WEB_PORT}`
 
 let mainWindow = null
 
+// O servidor embarcado vai como extraResources → no app instalado fica em
+// process.resourcesPath/server; em dev (não empacotado) fica em ./server.
+const SERVER_DIR = app.isPackaged ? path.join(process.resourcesPath, 'server') : path.join(__dirname, 'server')
+
 // Rede de segurança: um erro num processo filho (Postgres/servidor) jamais pode
 // derrubar o processo principal com o diálogo cru "A JavaScript error occurred".
 // Mostramos uma mensagem amigável e seguimos — o app continua de pé.
@@ -138,7 +142,7 @@ async function startEmbeddedServer() {
 
   // 2) Schema: enquanto o banco não estiver marcado como pronto, aplicamos o SQL
   //    das migrations direto (sem CLI Prisma) e gravamos o marcador no sucesso.
-  const prismaDir = path.join(__dirname, 'server', 'prisma')
+  const prismaDir = path.join(SERVER_DIR, 'prisma')
   if (!ready) {
     await applySchema(pg, prismaDir)
     fs.writeFileSync(readyMarker, JSON.stringify({ at: new Date().toISOString() }))
@@ -147,7 +151,7 @@ async function startEmbeddedServer() {
   // 3) API Fastify embarcada (se empacotada em ./server/api).
   //    JWT_SECRET/COOKIE_SECRET são obrigatórios (≥32 chars) — sem eles a API
   //    sai na validação de env. Como o app é local-only, segredos fixos servem.
-  const apiDir = path.join(__dirname, 'server', 'api')
+  const apiDir = path.join(SERVER_DIR, 'api')
   const apiEntry = findApiEntry(apiDir)
   if (apiEntry) {
     spawnNode(apiEntry, apiDir, {
@@ -165,7 +169,7 @@ async function startEmbeddedServer() {
   }
 
   // 4) Web Next standalone (se empacotado em ./server/web).
-  const webDir = path.join(__dirname, 'server', 'web')
+  const webDir = path.join(SERVER_DIR, 'web')
   const webEntry = findWebEntry(webDir)
   if (!webEntry) {
     throw new Error('Servidor web não encontrado no pacote (server/web). Reinstale o aplicativo.')

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,8 @@
     "npmRebuild": false,
     "directories": { "output": "dist" },
     "asar": false,
-    "files": ["main.js", "preload.js", "license.js", "db.js", "renderer/**", "server/**", "node_modules/**"],
+    "files": ["main.js", "preload.js", "license.js", "db.js", "renderer/**", "node_modules/**"],
+    "extraResources": [{ "from": "server", "to": "server" }],
     "win": {
       "target": ["nsis"]
     },


### PR DESCRIPTION
## Contexto
O PR #226 foi merjado **antes** destes 3 commits, então o `main` ficou sem a parte que efetivamente coloca a API **dentro** do `.exe`.

> O instalador publicado (`desktop-latest`, ~292 MB) **já está correto** — foi gerado pelo build do branch, que contém estas correções. Este PR só leva as mesmas correções ao `main`.

## O que entra (3 commits)
- **`server/ via extraResources`** — o electron-builder descartava `node_modules` aninhados quando `server/` ia em `files`. Agora `server/` vai como `extraResources` (cópia verbatim → `resources/server`) e o `main.js` resolve via `process.resourcesPath/server` quando empacotado (`SERVER_DIR`). É o que faz fastify + Prisma + engine do Windows ficarem **dentro** do instalador.
- **verificação anti-regressão (2 commits)** — passo de CI que inspeciona `dist/win-unpacked/resources/server` e **falha o build** se faltar fastify/@prisma/client/engine do Windows/.next.

## Verificação
- Build do `.exe` #23 verde de ponta a ponta; `.exe` cresceu de 220 → **292 MB** (a API entrou de verdade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)