### PR TITLE
ci(deploy): aplica prisma migrate deploy automaticamente no start da API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,8 @@ RUN pnpm --filter @agoraencontrei/api build
 
 EXPOSE 3100
 
-CMD ["node", "apps/api/dist/server.js"]
+# Aplica migrations pendentes (DATABASE_URL vem do ambiente do Railway) antes
+# de subir a API. Não-fatal: se o migrate falhar (ex.: drift do
+# _prisma_migrations) a API ainda inicializa, coerente com o fail-open do
+# projeto; a migration pode então ser aplicada manualmente.
+CMD ["sh", "-c", "pnpm --filter @agoraencontrei/database migrate:deploy || echo '[deploy] prisma migrate deploy falhou — subindo a API mesmo assim'; node apps/api/dist/server.js"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -19,4 +19,8 @@ cmds = [
 ]
 
 [start]
-cmd = "node apps/api/dist/server.js"
+# Aplica migrations pendentes contra o banco (DATABASE_URL já vem do ambiente
+# do Railway) ANTES de subir a API. Não-fatal: se o migrate falhar (ex.: drift
+# do _prisma_migrations), a API ainda inicializa — coerente com o fail-open do
+# projeto — e a migration pode ser aplicada manualmente.
+cmd = "pnpm --filter @agoraencontrei/database migrate:deploy || echo '[deploy] prisma migrate deploy falhou — subindo a API mesmo assim'; node apps/api/dist/server.js"


### PR DESCRIPTION
## Contexto

Depois do merge do #229 (site do tenant dinâmico + checkout de pacotes Asaas + quotas), a migration `20260630000006_add_tenant_addons` ficava pendente: a pipeline de deploy rodava apenas `prisma generate`, e **nada aplicava as migrations no banco**. Sem a tabela `tenant_addons`, o endpoint de add-on falha ao gravar em produção.

## O que muda

Adiciona `prisma migrate deploy` ao comando de start da API, nos dois caminhos de build que o Railway pode usar:

- **`Dockerfile`** — `CMD` agora roda `migrate deploy` antes de `node apps/api/dist/server.js`.
- **`nixpacks.toml`** — `[start].cmd` idem.

Detalhes:
- Usa a `DATABASE_URL` que **já vem do ambiente do Railway** (a mesma que a API usa para conectar). **Nenhuma credencial é versionada.**
- **Não-fatal**: se o `migrate deploy` falhar (ex.: drift do `_prisma_migrations`), a API ainda inicializa — coerente com a filosofia fail-open do projeto — e a migration pode ser aplicada manualmente.
- A migration em questão usa `CREATE TABLE IF NOT EXISTS`, então é idempotente e segura para reexecução.

## Efeito

A partir deste deploy, migrations pendentes (esta e futuras) passam a ser aplicadas automaticamente ao subir a API — fechando a lacuna que exigia rodar `migrate deploy` à mão.

## Verificação pós-deploy

Confirmar nos logs do Railway a linha do Prisma aplicando a migration, ou checar no banco que a tabela `tenant_addons` existe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7)_