### PR TITLE
fix(api): reconstrói PEM da LICENSE_PRIVATE_KEY (tolera quebras removidas pelo env)

### DIFF
--- a/apps/api/src/services/license.service.ts
+++ b/apps/api/src/services/license.service.ts
@@ -29,18 +29,32 @@ export function isLicensingConfigured(): boolean {
  * envolto em aspas ou com espaços. Sem isso, `createPrivateKey` falha com
  * "invalid PEM". Aqui aceitamos:
  *   - PEM com quebras de linha reais (ideal)
- *   - PEM em linha única com `\n` literais (caso comum em env vars)
+ *   - PEM em linha única com `\n` literais
+ *   - PEM com quebras REMOVIDAS (base64 colado/espaçado) — caso comum em env vars
  *   - valor entre aspas / com espaços nas pontas
+ *
+ * Estratégia: extrai o corpo base64 entre os marcadores BEGIN/END, descarta
+ * QUALQUER caractere que não seja base64 e reconstrói um PEM limpo (linhas de
+ * 64). Assim funciona independentemente de como o painel achatou o valor.
  */
 export function loadLicensePrivateKey(): crypto.KeyObject {
   let raw = (env.LICENSE_PRIVATE_KEY || '').trim()
   if (!raw) throw new Error('LICENSE_PRIVATE_KEY não configurada')
-  // remove aspas externas que alguns painéis adicionam
+  // aspas externas que alguns painéis adicionam
   if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
     raw = raw.slice(1, -1).trim()
   }
-  // \n / \r\n literais → quebras reais (env vars costumam achatar o PEM)
+  // \n / \r\n literais → quebras reais
   raw = raw.replace(/\\r\\n/g, '\n').replace(/\\n/g, '\n').replace(/\\r/g, '\n')
+
+  // Reconstrói o PEM a partir do corpo, tolerando qualquer espaçamento.
+  const m = raw.match(/-----BEGIN ([A-Z0-9 ]+?)-----([\s\S]*?)-----END \1-----/)
+  if (m) {
+    const label = m[1].trim()
+    const body = m[2].replace(/[^A-Za-z0-9+/=]/g, '') // só base64
+    const wrapped = (body.match(/.{1,64}/g) || []).join('\n')
+    raw = `-----BEGIN ${label}-----\n${wrapped}\n-----END ${label}-----\n`
+  }
   return crypto.createPrivateKey(raw)
 }
 


### PR DESCRIPTION
## Contexto

Mesmo após o #232, o endpoint `/license-pubkey` em produção continuou acusando `LICENSE_PRIVATE_KEY inválida`. O #232 só convertia `\n` literais — mas alguns painéis de variável de ambiente **removem as quebras de linha por completo** (base64 colado ou separado por espaços), e aí `createPrivateKey` ainda falha.

## Correção (bulletproof)

`loadLicensePrivateKey()` agora **reconstrói o PEM**: extrai o corpo base64 entre `-----BEGIN-----` / `-----END-----`, descarta qualquer caractere não-base64 e remonta linhas de 64. Funciona independentemente de como o valor foi achatado.

## Testes — 7/7 formas de mutilação

| Formato | Resultado |
|---|---|
| PEM com quebras reais | ✅ |
| `\n` literal | ✅ |
| **quebras removidas (tudo colado)** | ✅ |
| **quebras viraram espaço** | ✅ |
| entre aspas | ✅ |
| `\n` + aspas | ✅ |
| header colado + body espaçado | ✅ |

Todas batem com a chave pública embutida no app. `esbuild` OK.

## Pós-merge
`GET /api/v1/billing/saas/license-pubkey` deve passar a retornar a chave pública — confirmo o pareamento com a embutida no app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_