### PR TITLE
feat(voz): transcrição de áudio ao vivo na busca IA, Tomás chat, Copilot e dashboard

### DIFF
--- a/apps/web/src/app/(public)/HeroSearchForm.tsx
+++ b/apps/web/src/app/(public)/HeroSearchForm.tsx
@@ -219,7 +219,10 @@ export function HeroSearchForm() {
                 style={{ borderColor: aiQuery ? '#143A1F' : '#e5e7eb' }}
                 autoFocus
               />
-              <VoiceInputButton onResult={text => { setAiQuery(text); setTimeout(handleAiSearch, 300) }} />
+              <VoiceInputButton
+                onInterim={text => setAiQuery(text)}
+                onResult={text => { setAiQuery(text); setTimeout(handleAiSearch, 300) }}
+              />
               <button
                 type="button"
                 onClick={handleAiSearch}

--- a/apps/web/src/app/(public)/imoveis/PropertyFiltersForm.tsx
+++ b/apps/web/src/app/(public)/imoveis/PropertyFiltersForm.tsx
@@ -93,6 +93,7 @@ export function PropertyFiltersForm({ initialValues }: Props) {
           />
           <span className="absolute right-2 top-1/2 -translate-y-1/2">
             <VoiceInputButton
+              onInterim={text => setSearchValue(text)}
               onResult={text => {
                 setSearchValue(text)
                 setTimeout(() => formRef.current?.requestSubmit(), 300)

--- a/apps/web/src/components/tomas/TomasCommandBar.tsx
+++ b/apps/web/src/components/tomas/TomasCommandBar.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback } from 'react'
 import { Send, Loader2, Sparkles, MapPin, Bed, Car, FileText, MessageSquare, Calendar } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth.store'
+import { VoiceInputButton } from '@/components/ui/VoiceInputButton'
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -121,6 +122,12 @@ export default function TomasCommandBar() {
               if (e.key === 'Enter') runCommand()
             }}
             disabled={loading}
+          />
+          {/* Voz com transcrição ao vivo: texto aparece enquanto fala, depois envia. */}
+          <VoiceInputButton
+            dark
+            onInterim={(t) => setQuery(t)}
+            onResult={(t) => { setQuery(t); setTimeout(() => runCommand(t), 200) }}
           />
           <button
             onClick={() => runCommand()}

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -15,6 +15,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { MessageCircle, X, Send, Mic, MicOff, Loader2, MapPin, Bed, Car, ChevronRight, AlertCircle } from 'lucide-react'
 import { useBodyScrollLock } from '@/lib/use-body-scroll-lock'
+import { useLiveDictation } from '@/components/ui/useLiveDictation'
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -393,9 +394,16 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
 
   // ── Open state: chat panel ────────────────────────────────────────────────
 
-  const isRecording = audioState === 'recording'
-  const isAudioBusy = audioState === 'requesting' || audioState === 'stopping' || audioState === 'uploading'
-  const isAudioError = audioState === 'error'
+  // Ditado por voz com transcrição AO VIVO (Web Speech + fallback Whisper).
+  // O texto aparece no campo enquanto a pessoa fala; ao terminar, é enviado.
+  const dictation = useLiveDictation({
+    onInterim: (t) => setInput(t),
+    onResult: (t) => { setInput(''); void sendMessage(t) },
+  })
+  const isRecording = dictation.isRecording
+  const isAudioBusy = dictation.isProcessing
+  const isAudioError = dictation.isError
+  const audioErrorMsg = dictation.errorMsg
 
   return (
     <div
@@ -591,10 +599,10 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
       </div>
 
       {/* Audio error feedback */}
-      {audioError && (
+      {audioErrorMsg && (
         <div className="mx-3 mb-1 flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2 flex-shrink-0">
           <AlertCircle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />
-          <span className="text-xs text-red-400/80">{audioError}</span>
+          <span className="text-xs text-red-400/80">{audioErrorMsg}</span>
         </div>
       )}
 
@@ -612,7 +620,7 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
           {/* Microphone button — FUNCTIONAL */}
           <button
             type="button"
-            onClick={isRecording ? stopRecording : startRecording}
+            onClick={isRecording ? dictation.stop : dictation.start}
             disabled={isAudioBusy || loading}
             className={`rounded-lg p-2 transition-all flex-shrink-0 ${
               isRecording

--- a/apps/web/src/components/ui/SearchInputWithVoice.tsx
+++ b/apps/web/src/components/ui/SearchInputWithVoice.tsx
@@ -50,7 +50,9 @@ export const SearchInputWithVoice = forwardRef<HTMLInputElement, SearchInputWith
           {...props}
         />
         <span className="absolute right-2 top-1/2 -translate-y-1/2">
-          <VoiceInputButton onResult={handleVoice} dark={dark} />
+          {/* onInterim = atualização ao vivo do campo enquanto a pessoa fala;
+              onResult = texto final (mesmo handler, idempotente). */}
+          <VoiceInputButton onResult={handleVoice} onInterim={handleVoice} dark={dark} />
         </span>
       </div>
     )

--- a/apps/web/src/components/ui/VoiceInputButton.tsx
+++ b/apps/web/src/components/ui/VoiceInputButton.tsx
@@ -1,307 +1,35 @@
 'use client'
-import { useState, useRef, useCallback, useEffect } from 'react'
 import { Mic, MicOff, Loader2, AlertCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+import { useLiveDictation } from './useLiveDictation'
 
 interface VoiceInputButtonProps {
+  /** Transcrição FINAL — chamada uma vez quando o usuário termina de falar. */
   onResult: (text: string) => void
+  /** Transcrição PARCIAL ao vivo — chamada continuamente enquanto a pessoa fala
+   *  (modo Web Speech). Use para mostrar o texto em tempo real no input. */
+  onInterim?: (text: string) => void
   onFilters?: (filters: Record<string, string>) => void
-  /** Token JWT para endpoints autenticados (opcional — default é o endpoint público /voice-search). */
   token?: string | null
-  /** Quando true, usa /api/v1/public/voice-search (sem auth). Default true para manter compat. */
   publicEndpoint?: boolean
-  /** Se o caller quiser ser notificado de mensagem de erro para exibir em tooltip externo. */
   onError?: (msg: string) => void
   className?: string
-  dark?: boolean  // dark background variant (dashboard)
+  dark?: boolean
 }
 
-type RecordingState = 'idle' | 'recording' | 'processing' | 'error'
-
-// Voice Activity Detection — silence threshold and duration.
-// When the RMS of the mic drops below SILENCE_RMS for SILENCE_MS ms in a
-// row, we auto-stop and submit. Chosen empirically for desktop/mobile
-// microphones in a moderately noisy office.
-const SILENCE_RMS = 0.02
-const SILENCE_MS = 1500
-// Hard cap so the recorder can't run forever if the user forgets.
-const MAX_RECORDING_MS = 60_000
-// Minimum active speech before we even try to auto-stop — avoids
-// killing a recording that hasn't really started (e.g. user is thinking).
-const MIN_ACTIVE_MS = 600
-// Below this blob size we assume nothing was captured and surface the
-// error explicitly (old version failed silently here).
-const MIN_BLOB_BYTES = 300
-
 /**
- * VoiceInputButton — usa MediaRecorder + Whisper (OpenAI).
- *
- * Melhorias recentes:
- *  • Voice Activity Detection: quando o usuário para de falar por
- *    ~1.5s, o recorder para e envia automaticamente.
- *  • Mensagens de erro explícitas e persistentes (permissão negada,
- *    nada captado, falha no Whisper) em vez do antigo "vermelho e
- *    some em 3s sem explicação".
- *  • Timeout-duro aumentado de 10s para 60s — frases longas não são
- *    cortadas no meio.
- *  • Feedback visual do nível de áudio durante a gravação.
- *
- * Funciona em Safari iOS 14.3+, Chrome, Firefox, Edge e todos os
- * navegadores modernos. A antiga SpeechRecognition NÃO funciona
- * consistentemente no Safari/iOS.
+ * VoiceInputButton — botão de microfone com TRANSCRIÇÃO AO VIVO (custo zero).
+ * Usa Web Speech API (tempo real) quando disponível, com fallback Whisper.
+ * Toda a lógica fica em useLiveDictation (compartilhado com Tomás chat/copilot).
  */
 export function VoiceInputButton({
-  onResult, onFilters, token, publicEndpoint = true, onError,
-  className, dark = false,
+  onResult, onInterim, onFilters, token, publicEndpoint = true, onError, className, dark = false,
 }: VoiceInputButtonProps) {
-  const [state, setState] = useState<RecordingState>('idle')
-  const [supported, setSupported] = useState(true)
-  const [errorMsg, setErrorMsg] = useState<string | null>(null)
-  const [level, setLevel] = useState(0) // 0-1 RMS para feedback visual
-
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
-  const chunksRef = useRef<Blob[]>([])
-  const streamRef = useRef<MediaStream | null>(null)
-  const hardStopRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const audioCtxRef = useRef<AudioContext | null>(null)
-  const rafRef = useRef<number | null>(null)
-  const silenceStartRef = useRef<number | null>(null)
-  const speakStartRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && !window.MediaRecorder) {
-      setSupported(false)
-    }
-    return () => {
-      cleanupAll()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  function cleanupAll() {
-    if (hardStopRef.current) { clearTimeout(hardStopRef.current); hardStopRef.current = null }
-    if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null }
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach(t => t.stop())
-      streamRef.current = null
-    }
-    if (audioCtxRef.current) {
-      audioCtxRef.current.close().catch(() => {})
-      audioCtxRef.current = null
-    }
-    silenceStartRef.current = null
-    speakStartRef.current = null
-  }
-
-  const flashError = useCallback((msg: string) => {
-    setErrorMsg(msg)
-    setState('error')
-    onError?.(msg)
-    // Keep the message readable — doesn't auto-hide. Resets next time
-    // the user clicks to start again.
-  }, [onError])
-
-  const stop = useCallback(() => {
-    if (hardStopRef.current) { clearTimeout(hardStopRef.current); hardStopRef.current = null }
-    if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null }
-    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
-      try { mediaRecorderRef.current.stop() } catch { /* already stopped */ }
-    }
-  }, [])
-
-  const start = useCallback(async () => {
-    if (state === 'recording') { stop(); return }
-    if (state === 'processing') return
-
-    // Reset error / level state before new attempt.
-    setErrorMsg(null)
-    setLevel(0)
-    chunksRef.current = []
-    silenceStartRef.current = null
-    speakStartRef.current = null
-    setState('recording')
-
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-        } as MediaTrackConstraints,
-      })
-      streamRef.current = stream
-
-      // Pick the first supported MIME; empty string = browser default.
-      const mimeTypes = [
-        'audio/webm;codecs=opus',
-        'audio/webm',
-        'audio/ogg;codecs=opus',
-        'audio/ogg',
-        'audio/mp4',
-        '',
-      ]
-      const mimeType = mimeTypes.find(t => !t || MediaRecorder.isTypeSupported(t)) ?? ''
-      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
-      mediaRecorderRef.current = recorder
-
-      recorder.ondataavailable = (e) => {
-        if (e.data.size > 0) chunksRef.current.push(e.data)
-      }
-
-      recorder.onerror = () => {
-        cleanupAll()
-        flashError('Erro no microfone. Tente novamente.')
-      }
-
-      recorder.onstop = async () => {
-        // Para cleanup independente da causa (auto-stop, user-stop, error)
-        cleanupAll()
-        setState('processing')
-
-        try {
-          const audioBlob = new Blob(chunksRef.current, { type: mimeType || 'audio/webm' })
-          if (audioBlob.size < MIN_BLOB_BYTES) {
-            flashError('Não consegui captar áudio. Fale mais próximo do microfone e tente de novo.')
-            return
-          }
-
-          const ext = mimeType.includes('mp4') ? 'm4a'
-            : mimeType.includes('ogg') ? 'ogg'
-            : 'webm'
-
-          const formData = new FormData()
-          formData.append('audio', audioBlob, `voice.${ext}`)
-
-          // Public endpoint by default — homepage/Tomás public search.
-          // Authenticated one is /api/v1/agents/voice, requer token no
-          // header. Decidido pelo publicEndpoint prop.
-          const endpoint = publicEndpoint
-            ? `${API_URL}/api/v1/public/voice-search`
-            : `${API_URL}/api/v1/agents/voice`
-          const headers: Record<string, string> = {}
-          if (!publicEndpoint && token) headers.Authorization = `Bearer ${token}`
-
-          const res = await fetch(endpoint, {
-            method: 'POST',
-            headers,
-            body: formData,
-          })
-
-          if (!res.ok) {
-            const payload = await res.json().catch(() => ({})) as { message?: string; error?: string }
-            flashError(
-              res.status === 401 ? 'Sessão expirou. Faça login novamente.' :
-              res.status === 413 ? 'Áudio muito longo. Grave uma fala mais curta.' :
-              payload.message || payload.error || `Falha ao processar áudio (HTTP ${res.status}).`,
-            )
-            return
-          }
-
-          const data = await res.json() as { transcript?: string; filters?: Record<string, string>; reason?: string }
-
-          if (!data.transcript || data.transcript.trim().length === 0) {
-            flashError(
-              data.reason === 'not_configured'
-                ? 'Busca por voz indisponível no momento. Você pode digitar normalmente.'
-                : 'Não consegui entender o que foi dito. Tente falar mais devagar e mais próximo do microfone.',
-            )
-            return
-          }
-
-          onResult(data.transcript)
-          if (onFilters && data.filters && Object.keys(data.filters).length > 0) {
-            onFilters(data.filters)
-          }
-
-          setState('idle')
-        } catch (e: any) {
-          flashError(e?.message ? `Erro: ${e.message}` : 'Erro ao processar áudio. Tente novamente.')
-        }
-      }
-
-      recorder.start()
-
-      // ── Voice Activity Detection ────────────────────────────────────────
-      // Criamos um AudioContext + AnalyserNode paralelo só para medir o
-      // nível RMS em tempo real. Se ficar abaixo de SILENCE_RMS por
-      // SILENCE_MS, paramos automaticamente e enviamos — resolve o
-      // pedido "reconhecer quando a pessoa acabar de falar e já
-      // reproduzir a escrita e buscar automaticamente na sequência".
-      try {
-        const AudioCtor = (window as any).AudioContext || (window as any).webkitAudioContext
-        if (AudioCtor) {
-          const ctx: AudioContext = new AudioCtor()
-          audioCtxRef.current = ctx
-          const source = ctx.createMediaStreamSource(stream)
-          const analyser = ctx.createAnalyser()
-          analyser.fftSize = 1024
-          source.connect(analyser)
-          const buf = new Float32Array(analyser.fftSize)
-
-          const tick = () => {
-            if (!mediaRecorderRef.current || mediaRecorderRef.current.state !== 'recording') return
-            analyser.getFloatTimeDomainData(buf)
-            // RMS do frame atual
-            let sum = 0
-            for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i]
-            const rms = Math.sqrt(sum / buf.length)
-            setLevel(Math.min(1, rms * 4)) // escala visual
-
-            const now = performance.now()
-            if (rms > SILENCE_RMS) {
-              if (speakStartRef.current == null) speakStartRef.current = now
-              silenceStartRef.current = null
-            } else {
-              if (silenceStartRef.current == null) silenceStartRef.current = now
-              const silentFor = now - silenceStartRef.current
-              const hasStartedSpeaking = speakStartRef.current != null
-              const spokeLongEnough = hasStartedSpeaking && (now - (speakStartRef.current ?? now)) > MIN_ACTIVE_MS
-              if (spokeLongEnough && silentFor >= SILENCE_MS) {
-                // User stopped speaking → stop recording.
-                stop()
-                return
-              }
-            }
-            rafRef.current = requestAnimationFrame(tick)
-          }
-          rafRef.current = requestAnimationFrame(tick)
-        }
-      } catch {
-        // VAD is a nice-to-have; if AudioContext fails (old browser,
-        // autoplay policy) we still rely on the hard timeout below.
-      }
-
-      // Hard stop at MAX_RECORDING_MS to prevent forever-running mics.
-      hardStopRef.current = setTimeout(() => {
-        if (mediaRecorderRef.current?.state === 'recording') {
-          mediaRecorderRef.current.stop()
-        }
-      }, MAX_RECORDING_MS)
-
-    } catch (err: unknown) {
-      cleanupAll()
-      const e = err as { name?: string; message?: string } | undefined
-      const permissionDenied = e?.name === 'NotAllowedError' || e?.name === 'PermissionDeniedError'
-        || (e?.message || '').toLowerCase().includes('permission')
-      const noMic = e?.name === 'NotFoundError' || (e?.message || '').toLowerCase().includes('not found')
-
-      if (permissionDenied) {
-        flashError('Permissão do microfone negada. Libere o acesso nas configurações do navegador.')
-      } else if (noMic) {
-        flashError('Nenhum microfone foi encontrado. Conecte um e tente novamente.')
-      } else {
-        setSupported(false)
-      }
-    }
-  }, [state, stop, onResult, onFilters, flashError, token, publicEndpoint])
+  const { supported, errorMsg, level, isRecording, isProcessing, isError, start, stop } = useLiveDictation({
+    onResult, onInterim, onFilters, onError, token, publicEndpoint,
+  })
 
   if (!supported) return null
-
-  const isRecording = state === 'recording'
-  const isProcessing = state === 'processing'
-  const isError = state === 'error'
 
   return (
     <div className="relative inline-flex items-center">
@@ -313,7 +41,7 @@ export function VoiceInputButton({
           isRecording   ? 'Clique para parar (ou pare de falar)' :
           isProcessing  ? 'Transcrevendo áudio…' :
           isError       ? (errorMsg ?? 'Erro') :
-                          'Buscar por voz'
+                          'Falar (transcrição ao vivo)'
         }
         className={cn(
           'flex-shrink-0 flex items-center justify-center w-8 h-8 min-w-[44px] min-h-[44px] rounded-full transition-all duration-200 select-none relative',
@@ -336,12 +64,9 @@ export function VoiceInputButton({
           ? <MicOff className="w-3.5 h-3.5 text-white" />
           : <Mic className="w-3.5 h-3.5" />
         }
-        {/* Mic level indicator — shows a ring that scales with the
-            current RMS so the user has feedback that the mic is
-            actually capturing their voice. */}
         {isRecording && (
           <span
-            className="absolute inset-0 rounded-full pointer-events-none"
+            className="absolute inset-0 rounded-full pointer-events-none animate-pulse"
             style={{
               boxShadow: `0 0 0 ${Math.round(2 + level * 8)}px rgba(239,68,68,${0.15 + level * 0.3})`,
               transition: 'box-shadow 80ms linear',
@@ -351,16 +76,13 @@ export function VoiceInputButton({
         )}
       </button>
 
-      {/* Error bubble — explicit, persistent until next click. */}
       {isError && errorMsg && (
         <div
           role="status"
           className={cn(
             'absolute top-full mt-1 left-0 whitespace-normal w-64 z-30',
             'flex items-start gap-1.5 text-xs rounded-lg px-2.5 py-1.5 shadow-lg',
-            dark
-              ? 'bg-red-500/15 border border-red-500/40 text-red-200'
-              : 'bg-red-50 border border-red-200 text-red-700',
+            dark ? 'bg-red-500/15 border border-red-500/40 text-red-200' : 'bg-red-50 border border-red-200 text-red-700',
           )}
         >
           <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />

--- a/apps/web/src/components/ui/useLiveDictation.ts
+++ b/apps/web/src/components/ui/useLiveDictation.ts
@@ -1,0 +1,292 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+export type DictationState = 'idle' | 'recording' | 'processing' | 'error'
+
+export interface UseLiveDictationOptions {
+  /** Transcrição FINAL — uma vez, quando a pessoa termina de falar. */
+  onResult: (text: string) => void
+  /** Transcrição PARCIAL ao vivo — chamada continuamente enquanto fala. */
+  onInterim?: (text: string) => void
+  /** Filtros extraídos (só no fallback Whisper da busca). */
+  onFilters?: (filters: Record<string, string>) => void
+  onError?: (msg: string) => void
+  token?: string | null
+  publicEndpoint?: boolean
+}
+
+// VAD (fallback Whisper)
+const SILENCE_RMS = 0.02
+const SILENCE_MS = 1500
+const MAX_RECORDING_MS = 60_000
+const MIN_ACTIVE_MS = 600
+const MIN_BLOB_BYTES = 300
+// Modo ao vivo (Web Speech): encerra após este tempo sem novas palavras.
+const LIVE_SILENCE_MS = 1600
+
+function getSpeechRecognitionCtor(): any | null {
+  if (typeof window === 'undefined') return null
+  return (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition || null
+}
+
+/**
+ * useLiveDictation — ditado por voz com TRANSCRIÇÃO AO VIVO e custo zero.
+ *
+ * 1) Se o navegador suporta a Web Speech API, transcreve em tempo real
+ *    (onInterim enquanto fala, onResult ao terminar). Sem backend.
+ * 2) Senão, cai no MediaRecorder + Whisper (OpenAI): grava, detecta silêncio,
+ *    envia e devolve o texto.
+ *
+ * Compartilhado por VoiceInputButton, TomasWidget e TomasCommandBar.
+ */
+export function useLiveDictation(opts: UseLiveDictationOptions) {
+  const { onResult, onInterim, onFilters, onError, token, publicEndpoint = true } = opts
+
+  const [state, setState] = useState<DictationState>('idle')
+  const [supported, setSupported] = useState(true)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [level, setLevel] = useState(0)
+
+  // callbacks sempre atualizados sem re-criar os handlers
+  const cbRef = useRef(opts)
+  cbRef.current = opts
+
+  // Whisper/MediaRecorder
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const streamRef = useRef<MediaStream | null>(null)
+  const hardStopRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const audioCtxRef = useRef<AudioContext | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const silenceStartRef = useRef<number | null>(null)
+  const speakStartRef = useRef<number | null>(null)
+
+  // Web Speech
+  const recognitionRef = useRef<any>(null)
+  const liveFinalRef = useRef('')
+  const liveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const liveGotSpeechRef = useRef(false)
+
+  const cleanupAll = useCallback(() => {
+    if (hardStopRef.current) { clearTimeout(hardStopRef.current); hardStopRef.current = null }
+    if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null }
+    if (streamRef.current) { streamRef.current.getTracks().forEach(t => t.stop()); streamRef.current = null }
+    if (audioCtxRef.current) { audioCtxRef.current.close().catch(() => {}); audioCtxRef.current = null }
+    silenceStartRef.current = null
+    speakStartRef.current = null
+  }, [])
+
+  const cleanupLive = useCallback(() => {
+    if (liveTimerRef.current) { clearTimeout(liveTimerRef.current); liveTimerRef.current = null }
+    if (recognitionRef.current) {
+      try { recognitionRef.current.onresult = null; recognitionRef.current.onerror = null; recognitionRef.current.onend = null } catch { /* noop */ }
+      try { recognitionRef.current.abort() } catch { /* noop */ }
+      recognitionRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.MediaRecorder && !getSpeechRecognitionCtor()) {
+      setSupported(false)
+    }
+    return () => { cleanupAll(); cleanupLive() }
+  }, [cleanupAll, cleanupLive])
+
+  const flashError = useCallback((msg: string) => {
+    setErrorMsg(msg)
+    setState('error')
+    cbRef.current.onError?.(msg)
+  }, [])
+
+  // ── Fallback Whisper ────────────────────────────────────────────────────────
+  const stopWhisper = useCallback(() => {
+    if (hardStopRef.current) { clearTimeout(hardStopRef.current); hardStopRef.current = null }
+    if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null }
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      try { mediaRecorderRef.current.stop() } catch { /* já parou */ }
+    }
+  }, [])
+
+  const startWhisper = useCallback(async () => {
+    setErrorMsg(null); setLevel(0)
+    chunksRef.current = []; silenceStartRef.current = null; speakStartRef.current = null
+    setState('recording')
+
+    if (typeof window === 'undefined' || !window.MediaRecorder) {
+      flashError('Seu navegador não suporta gravação de voz. Você pode digitar normalmente.')
+      return
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true } as MediaTrackConstraints,
+      })
+      streamRef.current = stream
+      const mimeTypes = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus', 'audio/ogg', 'audio/mp4', '']
+      const mimeType = mimeTypes.find(t => !t || MediaRecorder.isTypeSupported(t)) ?? ''
+      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
+      mediaRecorderRef.current = recorder
+
+      recorder.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data) }
+      recorder.onerror = () => { cleanupAll(); flashError('Erro no microfone. Tente novamente.') }
+      recorder.onstop = async () => {
+        cleanupAll(); setState('processing')
+        try {
+          const audioBlob = new Blob(chunksRef.current, { type: mimeType || 'audio/webm' })
+          if (audioBlob.size < MIN_BLOB_BYTES) { flashError('Não consegui captar áudio. Fale mais próximo do microfone e tente de novo.'); return }
+          const ext = mimeType.includes('mp4') ? 'm4a' : mimeType.includes('ogg') ? 'ogg' : 'webm'
+          const formData = new FormData()
+          formData.append('audio', audioBlob, `voice.${ext}`)
+          const endpoint = publicEndpoint ? `${API_URL}/api/v1/public/voice-search` : `${API_URL}/api/v1/agents/voice`
+          const headers: Record<string, string> = {}
+          if (!publicEndpoint && token) headers.Authorization = `Bearer ${token}`
+          const res = await fetch(endpoint, { method: 'POST', headers, body: formData })
+          if (!res.ok) {
+            const payload = await res.json().catch(() => ({})) as { message?: string; error?: string }
+            flashError(
+              res.status === 401 ? 'Sessão expirou. Faça login novamente.' :
+              res.status === 413 ? 'Áudio muito longo. Grave uma fala mais curta.' :
+              payload.message || payload.error || `Falha ao processar áudio (HTTP ${res.status}).`,
+            )
+            return
+          }
+          const data = await res.json() as { transcript?: string; filters?: Record<string, string>; reason?: string }
+          if (!data.transcript || !data.transcript.trim()) {
+            flashError(data.reason === 'not_configured'
+              ? 'Busca por voz indisponível no momento. Você pode digitar normalmente.'
+              : 'Não consegui entender o que foi dito. Tente falar mais devagar e mais próximo do microfone.')
+            return
+          }
+          cbRef.current.onResult(data.transcript)
+          if (cbRef.current.onFilters && data.filters && Object.keys(data.filters).length > 0) cbRef.current.onFilters(data.filters)
+          setState('idle')
+        } catch (e: any) {
+          flashError(e?.message ? `Erro: ${e.message}` : 'Erro ao processar áudio. Tente novamente.')
+        }
+      }
+      recorder.start()
+
+      try {
+        const AudioCtor = (window as any).AudioContext || (window as any).webkitAudioContext
+        if (AudioCtor) {
+          const ctx: AudioContext = new AudioCtor()
+          audioCtxRef.current = ctx
+          const source = ctx.createMediaStreamSource(stream)
+          const analyser = ctx.createAnalyser()
+          analyser.fftSize = 1024
+          source.connect(analyser)
+          const buf = new Float32Array(analyser.fftSize)
+          const tick = () => {
+            if (!mediaRecorderRef.current || mediaRecorderRef.current.state !== 'recording') return
+            analyser.getFloatTimeDomainData(buf)
+            let sum = 0
+            for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i]
+            const rms = Math.sqrt(sum / buf.length)
+            setLevel(Math.min(1, rms * 4))
+            const now = performance.now()
+            if (rms > SILENCE_RMS) {
+              if (speakStartRef.current == null) speakStartRef.current = now
+              silenceStartRef.current = null
+            } else {
+              if (silenceStartRef.current == null) silenceStartRef.current = now
+              const silentFor = now - silenceStartRef.current
+              const spokeLongEnough = speakStartRef.current != null && (now - (speakStartRef.current ?? now)) > MIN_ACTIVE_MS
+              if (spokeLongEnough && silentFor >= SILENCE_MS) { stopWhisper(); return }
+            }
+            rafRef.current = requestAnimationFrame(tick)
+          }
+          rafRef.current = requestAnimationFrame(tick)
+        }
+      } catch { /* VAD opcional */ }
+
+      hardStopRef.current = setTimeout(() => {
+        if (mediaRecorderRef.current?.state === 'recording') mediaRecorderRef.current.stop()
+      }, MAX_RECORDING_MS)
+    } catch (err: unknown) {
+      cleanupAll()
+      const e = err as { name?: string; message?: string } | undefined
+      const permissionDenied = e?.name === 'NotAllowedError' || e?.name === 'PermissionDeniedError' || (e?.message || '').toLowerCase().includes('permission')
+      const noMic = e?.name === 'NotFoundError' || (e?.message || '').toLowerCase().includes('not found')
+      if (permissionDenied) flashError('Permissão do microfone negada. Libere o acesso nas configurações do navegador.')
+      else if (noMic) flashError('Nenhum microfone foi encontrado. Conecte um e tente novamente.')
+      else flashError('Não foi possível iniciar a gravação. Tente novamente.')
+    }
+  }, [cleanupAll, flashError, publicEndpoint, stopWhisper, token])
+
+  // ── Modo ao vivo (Web Speech) ───────────────────────────────────────────────
+  const stopLive = useCallback(() => {
+    if (liveTimerRef.current) { clearTimeout(liveTimerRef.current); liveTimerRef.current = null }
+    if (recognitionRef.current) { try { recognitionRef.current.stop() } catch { /* já parou */ } }
+  }, [])
+
+  const startLive = useCallback((SR: any): boolean => {
+    let recognition: any
+    try { recognition = new SR() } catch { return false }
+    recognition.lang = 'pt-BR'
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.maxAlternatives = 1
+    recognitionRef.current = recognition
+    liveFinalRef.current = ''
+    liveGotSpeechRef.current = false
+    setErrorMsg(null); setState('recording')
+
+    const armSilenceTimer = () => {
+      if (liveTimerRef.current) clearTimeout(liveTimerRef.current)
+      liveTimerRef.current = setTimeout(() => { stopLive() }, LIVE_SILENCE_MS)
+    }
+
+    recognition.onresult = (e: any) => {
+      let interim = ''
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const r = e.results[i]
+        const txt = r[0]?.transcript ?? ''
+        if (r.isFinal) liveFinalRef.current += txt
+        else interim += txt
+      }
+      liveGotSpeechRef.current = true
+      const live = (liveFinalRef.current + interim).replace(/\s+/g, ' ').trim()
+      if (live) cbRef.current.onInterim?.(live)
+      armSilenceTimer()
+    }
+    recognition.onerror = (e: any) => {
+      const err = e?.error
+      if (err === 'not-allowed' || err === 'service-not-allowed') {
+        cleanupLive(); flashError('Permissão do microfone negada. Libere o acesso nas configurações do navegador.'); return
+      }
+      if (err === 'no-speech') return
+      if ((err === 'network' || err === 'audio-capture') && !liveGotSpeechRef.current) {
+        cleanupLive(); void startWhisper(); return
+      }
+    }
+    recognition.onend = () => {
+      const text = liveFinalRef.current.replace(/\s+/g, ' ').trim()
+      cleanupLive()
+      if (text) { cbRef.current.onResult(text); setState('idle') }
+      else if (liveGotSpeechRef.current) setState('idle')
+      else flashError('Não consegui entender o que foi dito. Fale mais perto do microfone e tente de novo.')
+    }
+    try { recognition.start(); return true } catch { cleanupLive(); return false }
+  }, [cleanupLive, flashError, startWhisper, stopLive])
+
+  // ── API pública do hook ─────────────────────────────────────────────────────
+  const start = useCallback(() => {
+    if (state === 'recording') { stopLive(); stopWhisper(); return }
+    if (state === 'processing') return
+    setErrorMsg(null)
+    const SR = getSpeechRecognitionCtor()
+    if (SR && startLive(SR)) return
+    void startWhisper()
+  }, [state, startLive, startWhisper, stopLive, stopWhisper])
+
+  const stop = useCallback(() => { stopLive(); stopWhisper() }, [stopLive, stopWhisper])
+
+  return {
+    state, supported, errorMsg, level,
+    isRecording: state === 'recording',
+    isProcessing: state === 'processing',
+    isError: state === 'error',
+    start, stop,
+  }
+}


### PR DESCRIPTION
## Contexto

A gravação de voz era **batch**: gravava, esperava o silêncio, subia o áudio para o Whisper (OpenAI) e só então mostrava o texto. O pedido é **transcrever ao vivo enquanto a pessoa fala**, em todos os lugares, para facilitar o dia a dia — e **sem custo adicional**.

## Solução: Web Speech API (tempo real, custo zero) + fallback Whisper

Novo hook **`useLiveDictation`** (fonte única da lógica de voz):
- Se o navegador suporta a **Web Speech API** (Chrome, Edge, Android, Safari iOS 14.5+), usa o reconhecimento **nativo em tempo real** — o texto aparece no campo **enquanto a pessoa fala** (`onInterim`) e o resultado final dispara `onResult`. Não usa backend, custo zero.
- Caso contrário (Firefox, Safari antigo, ou erro de rede no serviço de fala), cai no **MediaRecorder + Whisper** já existente.
- Auto-encerra após ~1,6s de silêncio e já dispara a ação na sequência.

## Onde foi ligado

- `VoiceInputButton` virou um wrapper fino sobre o hook e ganhou `onInterim`.
- **Busca com IA** (`HeroSearchForm`): texto ao vivo no campo, busca ao terminar.
- **Filtros do mapa** (`PropertyFiltersForm`): idem.
- **Todas as buscas do dashboard** (via `SearchInputWithVoice`): ~12 telas (leads, contatos, contratos, inbox, LemosBank, etc.) — transcrição ao vivo automática.
- **Tomás chat** (`TomasWidget`): o texto é digitado no campo enquanto a pessoa fala e é enviado ao terminar (substitui o gravador batch próprio).
- **Tomás Copilot** (`TomasCommandBar`): ganhou botão de voz com transcrição ao vivo (antes era só texto).

## Testes

- `tsc --noEmit` (web): **sem erros** nos arquivos alterados; total permanece nos 10 erros pré-existentes (arquivos não tocados). Zero erros novos.

## Observação

O reconhecimento ao vivo da Web Speech API depende do navegador; onde não houver, o fallback Whisper mantém a transcrição funcionando (desde que `OPENAI_API_KEY` esteja configurada). Nada quebra se faltar — degrada com mensagem clara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7)_