### PR TITLE
perf(desktop): instalador menor e mais rápido (exclui arquivos inúteis em runtime)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,8 +20,24 @@
     "npmRebuild": false,
     "directories": { "output": "dist" },
     "asar": false,
-    "files": ["main.js", "preload.js", "license.js", "db.js", "renderer/**", "node_modules/**"],
-    "extraResources": [{ "from": "server", "to": "server" }],
+    "files": [
+      "main.js", "preload.js", "license.js", "db.js", "renderer/**", "node_modules/**",
+      "!**/*.map", "!**/*.d.ts", "!**/*.md", "!**/*.markdown",
+      "!**/__tests__/**", "!**/.github/**"
+    ],
+    "extraResources": [{
+      "from": "server",
+      "to": "server",
+      "filter": [
+        "**/*",
+        "!**/*.map", "!**/*.d.ts",
+        "!**/*.md", "!**/*.markdown",
+        "!**/LICENSE*", "!**/LICENCE*", "!**/CHANGELOG*", "!**/README*", "!**/AUTHORS*",
+        "!**/.github/**", "!**/__tests__/**", "!**/.nyc_output/**", "!**/coverage/**",
+        "!**/libquery_engine-*", "!**/*query_engine-debian*", "!**/*query_engine-linux*",
+        "!**/*query_engine-darwin*", "!**/*.dylib", "!**/*.so.node"
+      ]
+    }],
     "win": {
       "target": ["nsis"]
     },


### PR DESCRIPTION
## Problema
A instalação do `.exe` estava **lenta**. O servidor embarcado (node_modules de API + Web) tem **milhares de arquivos pequenos**, e o Windows + antivírus escaneiam cada um, tornando a extração demorada.

## Correção
Filtra do empacotamento (electron-builder `files` + `extraResources.filter`) o que **não é usado em runtime**:
- `*.map` (source maps) e `*.d.ts` (tipos)
- `*.md`, `README*`, `LICENSE*`, `CHANGELOG*`, `AUTHORS*`
- `__tests__/`, `.github/`, `coverage/`, `.nyc_output/`
- **engines do Prisma de outros SOs** (linux/mac/debian) — mantém só o do **Windows**

## Segurança
Verificado por script que **nenhum arquivo crítico** é excluído: `dist/server.js`, `fastify`, `@prisma/client`, `query_engine-windows.dll.node`, `.next`, `all-migrations.sql` — todos mantidos. O passo "Verify API packed" do CI continua válido.

## Efeito
Menos megabytes e, principalmente, **menos arquivos** → extração e varredura do antivírus muito mais rápidas, sem mudar o comportamento do app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf9XtBsWo5HmHSprTowyQz)_