### PR TITLE
feat(voz): Tomás fala as respostas no chat e no Copilot (TTS grátis)

### DIFF
--- a/apps/web/src/components/tomas/TomasCommandBar.tsx
+++ b/apps/web/src/components/tomas/TomasCommandBar.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
-import { Send, Loader2, Sparkles, MapPin, Bed, Car, FileText, MessageSquare, Calendar } from 'lucide-react'
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { Send, Loader2, Sparkles, MapPin, Bed, Car, FileText, MessageSquare, Calendar, Volume2, VolumeX } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth.store'
 import { VoiceInputButton } from '@/components/ui/VoiceInputButton'
+import { TomasVoiceController } from './tomas_voice_controller'
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -53,10 +54,33 @@ export default function TomasCommandBar() {
   const inputRef = useRef<HTMLInputElement>(null)
   const { accessToken } = useAuthStore()
 
+  // ── TTS: Tomás lê as respostas (Web Speech API, grátis) ────────────────────
+  const [speakEnabled, setSpeakEnabled] = useState(false)
+  const speakEnabledRef = useRef(false)
+  const voiceRef = useRef<TomasVoiceController | null>(null)
+
+  useEffect(() => {
+    voiceRef.current = new TomasVoiceController({ lang: 'pt-BR', rate: 1.02 })
+    try { setSpeakEnabled(localStorage.getItem('tomas_voice_on') === '1') } catch { /* noop */ }
+    return () => { voiceRef.current?.destroy(); voiceRef.current = null }
+  }, [])
+  useEffect(() => { speakEnabledRef.current = speakEnabled }, [speakEnabled])
+
+  const toggleSpeak = useCallback(() => {
+    setSpeakEnabled(prev => {
+      const next = !prev
+      try { localStorage.setItem('tomas_voice_on', next ? '1' : '0') } catch { /* noop */ }
+      if (next) voiceRef.current?.enqueue({ text: 'Voz ativada.', source: 'system', priority: true })
+      else voiceRef.current?.cancel()
+      return next
+    })
+  }, [])
+
   const runCommand = useCallback(async (prefilled?: string) => {
     const text = (prefilled ?? query).trim()
     if (!text || loading) return
 
+    voiceRef.current?.cancel()
     setQuery('')
     setLoading(true)
     setResponse(null)
@@ -79,6 +103,9 @@ export default function TomasCommandBar() {
       const data: TomasResponse = await res.json()
       setResponse(data)
       setHistory(prev => [...prev, { query: text, response: data }].slice(-10))
+      if (speakEnabledRef.current && data.message) {
+        voiceRef.current?.enqueue({ text: data.message, source: 'assistant_final' })
+      }
     } catch {
       setResponse({
         chatId: '',
@@ -107,6 +134,17 @@ export default function TomasCommandBar() {
           <div className="text-sm font-semibold text-white">Tomás Copilot</div>
           <div className="text-xs text-gray-500">Pergunte ou peça algo ao Tomás</div>
         </div>
+        <button
+          onClick={toggleSpeak}
+          className={`ml-auto rounded-lg p-1.5 transition-colors ${
+            speakEnabled ? 'text-yellow-500 hover:bg-gray-800' : 'text-gray-500 hover:bg-gray-800 hover:text-white'
+          }`}
+          title={speakEnabled ? 'Desativar voz do Tomás' : 'Ativar voz do Tomás (ele lê as respostas)'}
+          aria-label={speakEnabled ? 'Desativar voz do Tomás' : 'Ativar voz do Tomás'}
+          aria-pressed={speakEnabled}
+        >
+          {speakEnabled ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
+        </button>
       </div>
 
       {/* Input */}

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -13,9 +13,10 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { MessageCircle, X, Send, Mic, MicOff, Loader2, MapPin, Bed, Car, ChevronRight, AlertCircle } from 'lucide-react'
+import { MessageCircle, X, Send, Mic, MicOff, Loader2, MapPin, Bed, Car, ChevronRight, AlertCircle, Volume2, VolumeX } from 'lucide-react'
 import { useBodyScrollLock } from '@/lib/use-body-scroll-lock'
 import { useLiveDictation } from '@/components/ui/useLiveDictation'
+import { TomasVoiceController } from './tomas_voice_controller'
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -105,6 +106,34 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
   const audioStreamRef = useRef<MediaStream | null>(null)
   const audioTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // ── TTS: Tomás fala as respostas (Web Speech API, grátis) ──────────────────
+  const [speakEnabled, setSpeakEnabled] = useState(false)
+  const speakEnabledRef = useRef(false)
+  const voiceRef = useRef<TomasVoiceController | null>(null)
+
+  useEffect(() => {
+    voiceRef.current = new TomasVoiceController({ lang: 'pt-BR', rate: 1.02 })
+    try { setSpeakEnabled(localStorage.getItem('tomas_voice_on') === '1') } catch { /* noop */ }
+    return () => { voiceRef.current?.destroy(); voiceRef.current = null }
+  }, [])
+
+  useEffect(() => { speakEnabledRef.current = speakEnabled }, [speakEnabled])
+
+  const toggleSpeak = useCallback(() => {
+    setSpeakEnabled(prev => {
+      const next = !prev
+      try { localStorage.setItem('tomas_voice_on', next ? '1' : '0') } catch { /* noop */ }
+      if (next) {
+        // "Aquece" a síntese DENTRO do gesto do usuário — libera o áudio no
+        // iOS/Chrome para as próximas falas e confirma que está ativo.
+        voiceRef.current?.enqueue({ text: 'Voz ativada.', source: 'system', priority: true })
+      } else {
+        voiceRef.current?.cancel()
+      }
+      return next
+    })
+  }, [])
+
   // ── Viewport height fix for mobile keyboard ───────────────────────────────
   useEffect(() => {
     if (!open) return
@@ -179,6 +208,9 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
     const content = (prefilled ?? input).trim()
     if (!content || loading) return
 
+    // Nova pergunta do usuário interrompe qualquer fala em andamento.
+    voiceRef.current?.cancel()
+
     const userMsg: ChatMessage = { role: 'user', content }
     const nextMessages = [...messages, userMsg]
     setMessages(nextMessages)
@@ -207,14 +239,13 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
       setMessages(prev => [...prev, { role: 'assistant', content: data.message }])
       setActions(data.actions || [])
       setShortlist(data.shortlist || [])
+      if (speakEnabledRef.current && data.message) {
+        voiceRef.current?.enqueue({ text: data.message, source: 'assistant_final' })
+      }
     } catch {
-      setMessages(prev => [
-        ...prev,
-        {
-          role: 'assistant',
-          content: 'Tive uma dificuldade aqui, mas continuo com você. Me diga novamente o que precisa.',
-        },
-      ])
+      const fallback = 'Tive uma dificuldade aqui, mas continuo com você. Me diga novamente o que precisa.'
+      setMessages(prev => [...prev, { role: 'assistant', content: fallback }])
+      if (speakEnabledRef.current) voiceRef.current?.enqueue({ text: fallback, source: 'assistant_final' })
     } finally {
       setLoading(false)
     }
@@ -429,12 +460,28 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
             </div>
           </div>
         </div>
-        <button
-          onClick={() => setOpen(false)}
-          className="rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-800 hover:text-white"
-        >
-          <X className="h-4 w-4" />
-        </button>
+        <div className="flex items-center gap-1">
+          {/* Toggle: Tomás fala as respostas (voz grátis do navegador) */}
+          <button
+            onClick={toggleSpeak}
+            className={`rounded-lg p-1.5 transition-colors ${
+              speakEnabled
+                ? 'text-yellow-500 hover:bg-gray-800'
+                : 'text-gray-500 hover:bg-gray-800 hover:text-white'
+            }`}
+            title={speakEnabled ? 'Desativar voz do Tomás' : 'Ativar voz do Tomás (ele lê as respostas)'}
+            aria-label={speakEnabled ? 'Desativar voz do Tomás' : 'Ativar voz do Tomás'}
+            aria-pressed={speakEnabled}
+          >
+            {speakEnabled ? <Volume2 className="h-4 w-4" /> : <VolumeX className="h-4 w-4" />}
+          </button>
+          <button
+            onClick={() => setOpen(false)}
+            className="rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-800 hover:text-white"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
       </div>
 
       {/* Messages */}


### PR DESCRIPTION
## Contexto

Fase 1 do plano de **resposta por voz do Tomás**, **sem custo adicional**. Aproveita o `TomasVoiceController` que já existia no código (Web Speech API / `speechSynthesis` — voz nativa do navegador, grátis), que até então só era usado no chat premium.

## O que muda

- **`TomasWidget`** (chat público flutuante) e **`TomasCommandBar`** (Tomás Copilot do dashboard) ganham um **toggle 🔊** no cabeçalho. A preferência fica salva no `localStorage` (compartilhada entre os dois).
- Com a voz ativa, **cada resposta do Tomás é lida em voz alta** (voz pt-BR do navegador, escolhida automaticamente pelo controller).
- Ao **enviar uma nova pergunta**, a fala em andamento é interrompida (`cancel`).
- O toggle **"aquece" a síntese dentro do gesto do usuário** (fala um curto "Voz ativada."), o que libera o áudio no iOS Safari/Chrome para as falas seguintes.

## Custo

Zero. Usa o `window.speechSynthesis` do navegador — não chama nenhuma API paga. Se o aparelho não tiver voz pt-BR, o controller cai numa voz disponível; se não houver síntese, nada quebra (degrada em silêncio).

## Próximo passo opcional (Fase 2)

Para uma **voz de marca consistente** em todos os aparelhos, plugar um TTS self-hosted (Piper) ou pago com free tier (OpenAI TTS/ElevenLabs) no mesmo ponto de `enqueue` — sem mudar a UI.

## Testes

- `tsc --noEmit` (web): sem erros nos arquivos alterados; total permanece nos 10 erros pré-existentes. Zero erros novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7)_