### PR TITLE
fix: crash ao abrir o chat do Tomás + imagem do hero não refletia ao salvar

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -220,6 +220,17 @@ async function cacheSet(redis: FastifyInstance['redis'], key: string, value: unk
   memCacheSet(key, value, ttl)
 }
 
+/**
+ * Invalida o cache do /site-settings de uma empresa (Redis + memória).
+ * Deve ser chamado pelo admin sempre que salvar a config do site, para a
+ * mudança (ex.: imagem do hero) refletir na hora em vez de esperar o TTL.
+ */
+export async function invalidateSiteSettingsCache(redis: FastifyInstance['redis'], companyId: string): Promise<void> {
+  const key = `pub:site-settings:v1:${companyId}`
+  _memCache.delete(key)
+  if (redis) { try { await redis.del(key) } catch { /* ignore */ } }
+}
+
 export default async function publicRoutes(app: FastifyInstance) {
   // No auth required — public endpoints
 
@@ -985,6 +996,8 @@ export default async function publicRoutes(app: FastifyInstance) {
 
     const siteSettingsResult = {
       // ── Legado (compatibilidade) ──────────────────────────────────────
+      // O painel "Configurações do site" (users/site-settings) grava estes
+      // campos no topo de settings; por isso o topo tem precedência.
       heroVideoUrl:  settings.heroVideoUrl  ?? siteConfig.heroVideoUrl  ?? null,
       heroVideoType: settings.heroVideoType ?? siteConfig.heroVideoType ?? 'youtube',
       logoUrl:       settings.logoUrl       ?? company.logoUrl          ?? null,
@@ -1080,7 +1093,7 @@ export default async function publicRoutes(app: FastifyInstance) {
       presentationTitle:      siteConfig.presentationTitle      ?? null,
       presentationSubtitle:   siteConfig.presentationSubtitle   ?? null,
     };
-    await cacheSet(app.redis, cacheKey, siteSettingsResult, 600); // 10 min cache
+    await cacheSet(app.redis, cacheKey, siteSettingsResult, 60); // 60s — config é editável no admin, cache curto + invalidação no save
     return reply.send(siteSettingsResult);
   })
 

--- a/apps/api/src/routes/system-config/index.ts
+++ b/apps/api/src/routes/system-config/index.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify'
 import { createAuditLog } from '../../services/audit.service.js'
+import { invalidateSiteSettingsCache } from '../public/index.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DEFAULT SYSTEM CONFIG — todas as configurações padrão do sistema
@@ -569,6 +570,10 @@ export default async function systemConfigRoutes(app: FastifyInstance) {
       where: { id: req.user.cid },
       data:  { settings: { ...currentSettings, systemConfig: newConfig } },
     })
+
+    // Invalida o cache público do /site-settings para a mudança (ex.: imagem
+    // do hero) refletir na home imediatamente, sem esperar o TTL.
+    await invalidateSiteSettingsCache(app.redis, req.user.cid).catch(() => {})
 
     await createAuditLog({
       prisma: app.prisma as any,

--- a/apps/api/src/routes/users/index.ts
+++ b/apps/api/src/routes/users/index.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { createAuditLog } from '../../services/audit.service.js'
 import { assertWithinPlanQuota, PlanLimitError } from '../../services/plan-gating.service.js'
+import { invalidateSiteSettingsCache } from '../public/index.js'
 
 const UpdateUserBody = z.object({
   name: z.string().min(2).max(100).optional(),
@@ -263,6 +264,11 @@ export default async function usersRoutes(app: FastifyInstance) {
     const newSettings = { ...currentSettings, ...updates }
 
     await app.prisma.company.update({ where: { id: req.user.cid }, data: { settings: newSettings } })
+
+    // Invalida o cache público do /site-settings para a mudança (ex.: imagem
+    // do hero) refletir na home imediatamente, sem esperar o TTL.
+    await invalidateSiteSettingsCache(app.redis, req.user.cid).catch(() => {})
+
     return reply.send({ success: true, settings: newSettings })
   })
 

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -251,6 +251,18 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
     }
   }, [input, loading, messages, chatId, visitorId, propertyContext])
 
+  // Ditado por voz com transcrição AO VIVO (Web Speech + fallback Whisper).
+  // IMPORTANTE: hooks devem ficar ANTES de qualquer return condicional
+  // (estado fechado/aberto) para não violar as Regras dos Hooks.
+  const dictation = useLiveDictation({
+    onInterim: (t) => setInput(t),
+    onResult: (t) => { setInput(''); void sendMessage(t) },
+  })
+  const isRecording = dictation.isRecording
+  const isAudioBusy = dictation.isProcessing
+  const isAudioError = dictation.isError
+  const audioErrorMsg = dictation.errorMsg
+
   // ── Audio recording functions ─────────────────────────────────────────────
 
   function stopAudioStream() {
@@ -424,17 +436,6 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
   }
 
   // ── Open state: chat panel ────────────────────────────────────────────────
-
-  // Ditado por voz com transcrição AO VIVO (Web Speech + fallback Whisper).
-  // O texto aparece no campo enquanto a pessoa fala; ao terminar, é enviado.
-  const dictation = useLiveDictation({
-    onInterim: (t) => setInput(t),
-    onResult: (t) => { setInput(''); void sendMessage(t) },
-  })
-  const isRecording = dictation.isRecording
-  const isAudioBusy = dictation.isProcessing
-  const isAudioError = dictation.isError
-  const audioErrorMsg = dictation.errorMsg
 
   return (
     <div


### PR DESCRIPTION
Dois bugs, sendo o primeiro **crítico em produção**.

## 1. 🔴 Crash ao abrir o chat do Tomás (regressão)

Ao clicar para abrir o chat, a página quebrava. Causa: na transcrição ao vivo (#235), o hook `useLiveDictation` ficou **depois** do `if (!open) return` do estado fechado do `TomasWidget`. Assim o número de hooks mudava entre fechado e aberto, **violando as Regras dos Hooks** → React derruba a página.

**Correção:** o hook (e os flags derivados) foram movidos para **antes** de qualquer return condicional, junto dos demais hooks no topo do componente. Verifiquei que **nenhum** hook fica após o return.

## 2. Imagem do hero salva no admin não trocava na home

Salvar a imagem em Configurações do site dava "salvo", mas a home não mudava. Causa: o endpoint público `/site-settings` **cacheava o resultado por 10 min no Redis** e **nada invalidava** esse cache ao salvar.

**Correção:**
- Exporta `invalidateSiteSettingsCache` (Redis + memória) de `public/index`.
- Invalida o cache ao salvar nos **dois** caminhos do admin: `PATCH /users/site-settings` (página principal de configurações) e `PATCH /system-config`.
- Reduz o TTL do `/site-settings` de 600s → **60s** (config é editável; cache curto + invalidação no save).

> Observação: a página de configurações grava o hero no campo legado top-level (`settings.heroVideoUrl`), que o read já prefere — então a imagem nova passa a aparecer assim que o cache é invalidado.

## Testes
- `tsc --noEmit` (web e api): sem erros nos arquivos alterados.
- Verificação estática: todos os hooks do `TomasWidget` agora antes do return condicional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7)_