### PR TITLE
fix: excluir usuário, pagamento "link não encontrado" e imagem do hero (systemConfig)

### DIFF
--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -19,6 +19,7 @@ import {
   findOrCreateCustomer,
   createSubscription,
   createCharge,
+  getSubscriptionInvoiceUrl,
   type AsaasBillingType,
 } from '../../services/asaas.service.js'
 import { isSubdomainAvailable } from '../../services/tenant.service.js'
@@ -306,6 +307,9 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
         },
       }).catch(() => {})
 
+      // Link pagável real = invoiceUrl da 1ª cobrança da assinatura.
+      const invoiceUrl = await getSubscriptionInvoiceUrl(subscription.id)
+
       return reply.status(201).send({
         success: true,
         data: {
@@ -317,7 +321,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           asaasSubscriptionId: subscription.id,
           // Client deve redirecionar para a página de sucesso (que mostra
           // próximos passos) e em paralelo abrir o link do Asaas.
-          paymentUrl: `https://www.asaas.com/c/${subscription.id}`,
+          paymentUrl: invoiceUrl,
           successUrl: `/checkout/sucesso?ref=${encodeURIComponent(body.subdomain)}`,
           loginUrl: '/login',
           // Não devolvemos a senha — ela vai pelo e-mail/WhatsApp do
@@ -445,6 +449,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       const dueDate = nextDue.toISOString().split('T')[0]
 
       let chargeId: string
+      let paymentUrl: string | null = null
 
       if (mod.billingType === 'recurring') {
         // Create recurring subscription for the module
@@ -458,6 +463,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           externalReference: `module:${tenant.id}:${mod.slug}`,
         })
         chargeId = sub.id
+        paymentUrl = await getSubscriptionInvoiceUrl(sub.id)
       } else {
         // Create one-time charge
         const charge = await createCharge({
@@ -469,6 +475,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           externalReference: `module:${tenant.id}:${mod.slug}`,
         })
         chargeId = charge.id
+        paymentUrl = charge.invoiceUrl ?? null
       }
 
       // 6. Create activation record in pending_payment status
@@ -509,7 +516,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           price,
           billingType: mod.billingType,
           asaasChargeId: chargeId,
-          paymentUrl: `https://www.asaas.com/c/${chargeId}`,
+          paymentUrl,
           message: 'Cobrança gerada! O módulo será ativado após confirmação do pagamento.',
         },
       })
@@ -582,6 +589,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       const dueDate = nextDue.toISOString().split('T')[0]
 
       let chargeId: string
+      let paymentUrl: string | null = null
       if (pkg.billingType === 'recurring') {
         const sub = await createSubscription({
           customer: asaasCustomerId,
@@ -593,6 +601,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           externalReference: `addon:${addon.id}`,
         })
         chargeId = sub.id
+        paymentUrl = await getSubscriptionInvoiceUrl(sub.id)
       } else {
         const charge = await createCharge({
           customer: asaasCustomerId,
@@ -603,6 +612,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           externalReference: `addon:${addon.id}`,
         })
         chargeId = charge.id
+        paymentUrl = charge.invoiceUrl ?? null
       }
 
       // 3. Vincula a cobrança ao add-on.
@@ -633,7 +643,7 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
           price: pkg.price,
           billingType: pkg.billingType,
           asaasChargeId: chargeId,
-          paymentUrl: `https://www.asaas.com/c/${chargeId}`,
+          paymentUrl,
           message: 'Cobrança gerada! O pacote será ativado após a confirmação do pagamento.',
         },
       })

--- a/apps/api/src/routes/system-config/index.ts
+++ b/apps/api/src/routes/system-config/index.ts
@@ -566,9 +566,19 @@ export default async function systemConfigRoutes(app: FastifyInstance) {
     const currentConfig   = currentSettings.systemConfig ?? {}
     const newConfig       = deepMerge(currentConfig, updates)
 
+    // Espelha os campos de mídia da seção "site" para o topo LEGADO de
+    // settings. A home lê o legado com precedência; sem esse espelho, uma
+    // imagem trocada aqui (systemConfig.site) não aparecia porque um valor
+    // antigo no topo a mascarava. Mantém as duas fontes sempre sincronizadas.
+    const newSite = (newConfig as any).site ?? {}
+    const heroMirror: Record<string, any> = {}
+    for (const field of ['heroVideoUrl', 'heroVideoType', 'heroImageUrl', 'logoUrl'] as const) {
+      if (newSite[field] !== undefined) heroMirror[field] = newSite[field]
+    }
+
     await app.prisma.company.update({
       where: { id: req.user.cid },
-      data:  { settings: { ...currentSettings, systemConfig: newConfig } },
+      data:  { settings: { ...currentSettings, ...heroMirror, systemConfig: newConfig } },
     })
 
     // Invalida o cache público do /site-settings para a mudança (ex.: imagem

--- a/apps/api/src/services/asaas.service.ts
+++ b/apps/api/src/services/asaas.service.ts
@@ -375,6 +375,27 @@ export async function getSubscription(subscriptionId: string): Promise<AsaasSubs
   return asaasFetch<AsaasSubscription>(`/subscriptions/${subscriptionId}`)
 }
 
+/** Lista os pagamentos (cobranças) gerados por uma assinatura. */
+export async function getSubscriptionPayments(subscriptionId: string): Promise<{ data: AsaasCharge[] }> {
+  return asaasFetch<{ data: AsaasCharge[] }>(`/subscriptions/${subscriptionId}/payments`)
+}
+
+/**
+ * Retorna o link de fatura pagável (invoiceUrl) do 1º pagamento de uma
+ * assinatura. A assinatura em si NÃO tem um link pagável — quem tem é a
+ * cobrança gerada por ela. Sem isso, montávamos uma URL /c/{id} inválida e o
+ * Asaas mostrava "Link de pagamento não encontrado".
+ */
+export async function getSubscriptionInvoiceUrl(subscriptionId: string): Promise<string | null> {
+  try {
+    const res = await getSubscriptionPayments(subscriptionId)
+    const first = res?.data?.[0]
+    return first?.invoiceUrl ?? null
+  } catch {
+    return null
+  }
+}
+
 export async function cancelSubscription(subscriptionId: string): Promise<{ deleted: boolean }> {
   return asaasFetch(`/subscriptions/${subscriptionId}`, { method: 'DELETE' })
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -36,8 +36,12 @@ async function request<T>(
 ): Promise<T> {
   const { token, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, ...fetchOptions } = options
 
+  // Só declara Content-Type: application/json quando REALMENTE há corpo.
+  // Um DELETE (ou GET) sem body com esse header faz o Fastify rejeitar com
+  // "Body cannot be empty when content-type is set to 'application/json'".
+  const hasBody = fetchOptions.body != null
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+    ...(hasBody && { 'Content-Type': 'application/json' }),
     ...(token && { Authorization: `Bearer ${token}` }),
     ...(fetchOptions.headers as Record<string, string>),
   }


### PR DESCRIPTION
Três bugs reportados (com prints), todos corrigidos.

## 1. Excluir usuário → "Body cannot be empty when content-type is 'application/json'"
O cliente web enviava `Content-Type: application/json` em **toda** requisição, inclusive DELETE/GET sem corpo — e o Fastify rejeita corpo vazio com esse content-type.
**Fix:** o header só é enviado quando há corpo. (`apps/web/src/lib/api.ts`)

## 2. Pagamento → Asaas "Link de pagamento não encontrado"
O checkout montava o link como `https://www.asaas.com/c/{id}`, mas `/c/` é formato de **payment link**, não de assinatura/cobrança — por isso o Asaas não encontrava.
**Fix:**
- `asaas.service`: `getSubscriptionPayments` + `getSubscriptionInvoiceUrl` (pega o `invoiceUrl` da 1ª cobrança da assinatura — o link pagável real).
- `saas-checkout`: checkout de plano, `/module` e `/addon` passam a devolver o `invoiceUrl` real (cobrança one-time via `charge.invoiceUrl`; assinatura via a 1ª cobrança). O frontend já trata `paymentUrl` nulo com segurança.

## 3. Imagem do hero não trocava (painel de config do sistema)
Complementa o #239 (que corrigiu o cache). O painel de config do sistema grava o hero em `systemConfig.site`, mas a home lê o topo legado com precedência — um valor antigo ali mascarava a imagem nova.
**Fix:** ao salvar, os campos de mídia (`heroVideoUrl`/`heroVideoType`/`heroImageUrl`/`logoUrl`) são espelhados para o topo legado, mantendo as duas fontes sincronizadas. (`system-config`)

## Fora deste PR (infra, não código)
- **Biblioteca de logos** (`ENOTFOUND image-processor.railway.internal`): o microserviço `apps/image-processor` **não está no ar** no Railway. Precisa ser deployado como serviço próprio com private networking; é a marca d'água das fotos de imóveis, separada do hero.

## Testes
`tsc --noEmit` (web e api): sem erros nos arquivos alterados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jWKHcicGcH5vw5s98fS7)_