### PR TITLE
fix(deploy): API fora do ar (502) — remove migrate deploy do boot + escopo seguro de tenant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,12 @@ RUN pnpm --filter @agoraencontrei/api build
 
 EXPOSE 3100
 
-# Aplica migrations pendentes (DATABASE_URL vem do ambiente do Railway) antes
-# de subir a API. Não-fatal: se o migrate falhar (ex.: drift do
-# _prisma_migrations) a API ainda inicializa, coerente com o fail-open do
-# projeto; a migration pode então ser aplicada manualmente.
-CMD ["sh", "-c", "pnpm --filter @agoraencontrei/database migrate:deploy || echo '[deploy] prisma migrate deploy falhou — subindo a API mesmo assim'; node apps/api/dist/server.js"]
+# Sobe a API direto. NÃO rodar `prisma migrate deploy` aqui: o banco de
+# produção nunca teve histórico de migrations (schema mantido por `db push` +
+# runMigrations() idempotente em runtime), então `migrate deploy` fica preso no
+# advisory lock / erro de drift ANTES do node iniciar — a API nunca liga na
+# porta e o Railway responde 502 ("Application failed to respond"). O schema é
+# garantido pelo runMigrations() dentro do bootstrap (CREATE TABLE IF NOT
+# EXISTS ...), idempotente e time-boxed. Migrations Prisma, quando necessárias,
+# devem ser aplicadas num passo controlado — nunca bloqueando o boot.
+CMD ["node", "apps/api/dist/server.js"]

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -232,25 +232,26 @@ export default async function publicRoutes(app: FastifyInstance) {
     }
     const filters = _parsed.data
 
-    // Resolve companyId for tenant filtering
-    // If tenantSlug is provided, look up the tenant to get its companyId
-    let tenantCompanyId: string | undefined = filters.companyId
-    if (!tenantCompanyId && filters.tenantSlug) {
-      try {
-        const tenant = await (app.prisma as any).tenant?.findUnique?.({
-          where: { subdomain: filters.tenantSlug },
-          select: { companyId: true },
-        }).catch(() => null)
-        if (tenant?.companyId) tenantCompanyId = tenant.companyId
-      } catch { /* ignore */ }
+    // Tenant scoping: quando companyId ou tenantSlug é informado, restringe a
+    // listagem àquele parceiro (sites clone de tenant). Caso contrário o
+    // endpoint é marketplace e mostra imóveis de todas as empresas.
+    let scopedCompanyId: string | undefined = filters.companyId
+    if (!scopedCompanyId && filters.tenantSlug) {
+      const tenant = await (app.prisma as any).tenant?.findUnique?.({
+        where: { subdomain: filters.tenantSlug },
+        select: { companyId: true },
+      }).catch(() => null)
+      // tenantSlug informado mas inexistente → escopa para NADA em vez de vazar
+      // o marketplace inteiro sob o domínio de um parceiro.
+      scopedCompanyId = tenant?.companyId ?? '__no_such_tenant__'
     }
 
     // Show properties from ALL companies (marketplace) or filter by tenant company
     const where: any = {
       status: 'ACTIVE',
       authorizedPublish: true,
-      // When tenantCompanyId is set, show only that company's properties
-      ...(tenantCompanyId && { companyId: tenantCompanyId }),
+      // When scopedCompanyId is set, show only that company's properties
+      ...(scopedCompanyId && { companyId: scopedCompanyId }),
       ...(filters.ids && { id: { in: filters.ids.split(',').map(s => s.trim()).filter(Boolean) } }),
       ...(filters.search && {
         OR: [
@@ -334,10 +335,12 @@ export default async function publicRoutes(app: FastifyInstance) {
         })
       : items
 
-    // Fallback: when no results found, relax filters progressively to show similar properties
+    // Fallback: when no results found, relax filters progressively to show
+    // similar properties. Pulado para requisições com escopo de tenant — um
+    // site de parceiro nunca pode cair no inventário de outra empresa.
     let fallbackItems: any[] = []
     let isFallback = false
-    if (total === 0 && page === 1) {
+    if (total === 0 && page === 1 && !scopedCompanyId) {
       isFallback = true
       const baseWhere = { companyId: company.id, status: 'ACTIVE' as const, authorizedPublish: true }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -665,6 +665,30 @@ async function runMigrations(prisma: any) {
     )`,
     `CREATE INDEX IF NOT EXISTS auction_ai_auction_idx ON auction_ai_analyses("auctionId")`,
     `CREATE INDEX IF NOT EXISTS auction_ai_risk_idx ON auction_ai_analyses("riskLevel")`,
+
+    // Add-ons de tenant (checkout de módulos avulsos / quota stacking).
+    // Antes só existia via `prisma migrate deploy`, que travava o boot; criada
+    // aqui de forma idempotente para o schema ficar completo sem migrate.
+    `CREATE TABLE IF NOT EXISTS tenant_addons (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "tenantId" TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      "packageSlug" TEXT NOT NULL,
+      label TEXT NOT NULL,
+      quantity INTEGER NOT NULL,
+      price DECIMAL(10,2) NOT NULL,
+      "billingType" TEXT NOT NULL DEFAULT 'recurring',
+      status TEXT NOT NULL DEFAULT 'pending_payment',
+      "asaasChargeId" TEXT,
+      "activatedAt" TIMESTAMPTZ,
+      "expiresAt" TIMESTAMPTZ,
+      "cancelledAt" TIMESTAMPTZ,
+      metadata JSONB NOT NULL DEFAULT '{}',
+      "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`,
+    `CREATE INDEX IF NOT EXISTS tenant_addons_tenant_status_idx ON tenant_addons("tenantId", status)`,
+    `CREATE INDEX IF NOT EXISTS tenant_addons_asaas_charge_idx ON tenant_addons("asaasChargeId")`,
   ]
   for (const sql of saasMigrations) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -19,8 +19,10 @@ cmds = [
 ]
 
 [start]
-# Aplica migrations pendentes contra o banco (DATABASE_URL já vem do ambiente
-# do Railway) ANTES de subir a API. Não-fatal: se o migrate falhar (ex.: drift
-# do _prisma_migrations), a API ainda inicializa — coerente com o fail-open do
-# projeto — e a migration pode ser aplicada manualmente.
-cmd = "pnpm --filter @agoraencontrei/database migrate:deploy || echo '[deploy] prisma migrate deploy falhou — subindo a API mesmo assim'; node apps/api/dist/server.js"
+# Sobe a API direto. NÃO rodar `prisma migrate deploy` aqui: o banco de produção
+# nunca teve histórico de migrations (schema mantido por `db push` +
+# runMigrations() idempotente em runtime), então `migrate deploy` fica preso no
+# advisory lock / erro de drift ANTES do node iniciar — a API nunca liga na porta
+# e o Railway responde 502. O schema é garantido pelo runMigrations() dentro do
+# bootstrap (CREATE TABLE IF NOT EXISTS ...), idempotente e time-boxed.
+cmd = "node apps/api/dist/server.js"


### PR DESCRIPTION
## Problema

Após as mudanças de ontem, o login ficava só carregando/atualizando e o mapa demorava demais. **Causa raiz: a API no Railway estava respondendo `502 — Application failed to respond` (~15s) de forma consistente** — o processo não ligava na porta. Login e mapa dependem 100% dessa API, então ambos travavam.

Diagnóstico (produção):
```
GET https://api-production-669c.up.railway.app/health
try 1: HTTP 502 | 15.9s
try 2: HTTP 502 | 15.8s
try 3: HTTP 502 | 15.7s
```

## Causa

O commit `05f6fa7` adicionou `prisma migrate deploy` ao comando de start (Dockerfile + nixpacks), **antes** do `node`. O banco de produção nunca teve histórico de migrations (schema mantido por `db push` + `runMigrations()` idempotente em runtime), então `migrate deploy` fica preso no advisory lock / erro de drift e **a API nunca sobe**. O `|| echo` só cobre saída com erro, não o travamento.

## Correções

- **Dockerfile + nixpacks**: start volta a ser apenas `node apps/api/dist/server.js` (estado que funcionava antes de ontem). O schema continua garantido pelo `runMigrations()` no bootstrap — idempotente e time-boxed (20s).
- **server.ts**: `tenant_addons` (+índices) adicionada ao `runMigrations()` raw-SQL, preservando o benefício do commit revertido sem o migrate que travava o boot.
- **public/index.ts**: restaura o escopo seguro de tenant. O refactor de ontem passou a exibir imóveis de todas as empresas quando `tenantSlug` era inválido (vazamento do marketplace no domínio do parceiro) — volta ao sentinela `__no_such_tenant__` e reativa o guard do fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_