### PR TITLE
fix(api): CAUSA RAIZ do 502 — restaura export invalidateSiteSettingsCache

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -218,6 +218,21 @@ async function cacheSet(redis: FastifyInstance['redis'], key: string, value: unk
   memCacheSet(key, value, ttl)
 }
 
+/**
+ * Invalida o cache do /site-settings de uma empresa (Redis + memória).
+ * Deve ser chamado pelo admin sempre que salvar a config do site, para a
+ * mudança (ex.: imagem do hero) refletir na hora em vez de esperar o TTL.
+ *
+ * IMPORTANTE: esta função é importada por routes/users e routes/system-config.
+ * Removê-la faz o boot da API inteiro falhar com um SyntaxError de ESM
+ * ("does not provide an export named ..."), derrubando o servidor (502).
+ */
+export async function invalidateSiteSettingsCache(redis: FastifyInstance['redis'], companyId: string): Promise<void> {
+  const key = `pub:site-settings:v1:${companyId}`
+  _memCache.delete(key)
+  if (redis) { try { await redis.del(key) } catch { /* ignore */ } }
+}
+
 export default async function publicRoutes(app: FastifyInstance) {
   // No auth required — public endpoints
 


### PR DESCRIPTION
## Causa raiz confirmada (reproduzida localmente)

O 502 da API em produção era um **crash de boot**, não o `migrate deploy` (o `apps/api/railway.json` define `startCommand: node dist/server.js`, que sobrescreve o CMD do Dockerfile — o Railway nunca rodou o migrate).

O commit `beac077` removeu o export `invalidateSiteSettingsCache` de `routes/public/index.ts`, mas `routes/users` e `routes/system-config` **continuam importando-o**. Em ESM, um named-import inexistente é um `SyntaxError` no carregamento do módulo → o processo morre no boot **antes do `listen`** → Railway crash-loop → 502. Login e mapa dependem da API, então ambos travavam.

## Reprodução local (Postgres + Redis em Docker)

- **Antes:** boot aborta com `SyntaxError: does not provide an export named 'invalidateSiteSettingsCache'`
- **Depois:** API sobe — `/health` 200 (`db: connected`), `listen` OK
  - `POST /auth/login` credenciais erradas → **401**
  - registro → **201**; login em conta ativa → **200** com `accessToken` + `refreshToken`
  - `map-clusters`, `auctions/map`, `public/properties` → **200** (com headers de browser)

## Mudança

Restaura a função exportada `invalidateSiteSettingsCache` em `routes/public/index.ts` (invalida o cache de site-settings no Redis + memória), com comentário alertando que removê-la derruba o boot inteiro.

> Observação: este PR complementa o #242 (que alinhou o start-command e recriou `tenant_addons`). Aquele não bastava porque o `railway.json` já usava `node dist/server.js`; **este** é o fix que efetivamente reativa a API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_