### PR TITLE
fix: 5 regressões do beac077 (site de parceiro vazio, modal crash, ordenação, filtros)

### DIFF
--- a/apps/api/src/routes/properties/index.ts
+++ b/apps/api/src/routes/properties/index.ts
@@ -237,14 +237,21 @@ export default async function propertiesRoutes(app: FastifyInstance) {
       }
     }
 
-    // Full-text search
+    // Full-text search — vai em where.AND para NÃO sobrescrever o where.OR do
+    // filtro hasImages (antes, search + hasImages juntos descartavam o filtro
+    // de fotos, retornando imóveis sem imagem).
     if (q.search) {
-      where.OR = [
-        { title:        { contains: q.search, mode: 'insensitive' } },
-        { description:  { contains: q.search, mode: 'insensitive' } },
-        { neighborhood: { contains: q.search, mode: 'insensitive' } },
-        { city:         { contains: q.search, mode: 'insensitive' } },
-        { reference:    { contains: q.search, mode: 'insensitive' } },
+      where.AND = [
+        ...(Array.isArray(where.AND) ? where.AND : []),
+        {
+          OR: [
+            { title:        { contains: q.search, mode: 'insensitive' } },
+            { description:  { contains: q.search, mode: 'insensitive' } },
+            { neighborhood: { contains: q.search, mode: 'insensitive' } },
+            { city:         { contains: q.search, mode: 'insensitive' } },
+            { reference:    { contains: q.search, mode: 'insensitive' } },
+          ],
+        },
       ]
     }
 

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -332,7 +332,9 @@ export default async function publicRoutes(app: FastifyInstance) {
       app.prisma.property.findMany({
         where,
         select: PUBLIC_PROPERTY_SELECT,
-        orderBy: [{ isFeatured: 'desc' }, orderBy],
+        // Hierarquia: Super Destaque (isPremium) > Destaque (isFeatured) > ordem
+        // pedida. beac077 removeu o isPremium daqui, tirando os Premium do topo.
+        orderBy: [{ isPremium: 'desc' }, { isFeatured: 'desc' }, orderBy],
         skip,
         take: limit,
       }),
@@ -1093,7 +1095,10 @@ export default async function publicRoutes(app: FastifyInstance) {
       presentationTitle:      siteConfig.presentationTitle      ?? null,
       presentationSubtitle:   siteConfig.presentationSubtitle   ?? null,
     };
-    await cacheSet(app.redis, cacheKey, siteSettingsResult, 600); // 10 min cache
+    // Config editável pelo admin: cache curto (60s) + invalidação no save.
+    // beac077 reverteu isto para 600s; se a invalidação falhar (Redis fora),
+    // 10 min é tempo demais para a home refletir a mudança.
+    await cacheSet(app.redis, cacheKey, siteSettingsResult, 60);
     return reply.send(siteSettingsResult);
   })
 

--- a/apps/web/src/app/_tenant/[slug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/page.tsx
@@ -68,7 +68,10 @@ async function getTenantProperties(tenantSlug: string, limit = 9): Promise<Prope
     const res = await fetch(url, { next: { revalidate: 120 } })
     if (!res.ok) return []
     const data = await res.json()
-    return data.data?.items || data.items || []
+    // A rota /api/v1/public/properties responde { data: [...], meta }.
+    // `data.data` JÁ é o array — o acesso anterior (data.data?.items) dava
+    // sempre undefined, fazendo TODO site de parceiro renderizar vazio.
+    return Array.isArray(data?.data) ? data.data : (Array.isArray(data?.items) ? data.items : [])
   } catch {
     return []
   }

--- a/apps/web/src/components/public/DynamicPlans.tsx
+++ b/apps/web/src/components/public/DynamicPlans.tsx
@@ -738,19 +738,24 @@ export function DynamicPlans() {
                   })}
                 </div>
 
-                {previewKey && (
-                  <ThemePreviewModal
-                    themes={ALL_THEMES}
-                    index={Math.max(0, ALL_THEMES.findIndex(t => t.key === previewKey))}
-                    onIndexChange={(i) => setPreviewKey(ALL_THEMES[i].key)}
-                    selectedKey={checkoutForm.layoutType}
-                    onChoose={(th) => {
-                      setCheckoutForm(f => ({ ...f, layoutType: th.key, primaryColor: th.accentHex }))
-                      setPreviewKey(null)
-                    }}
-                    onClose={() => setPreviewKey(null)}
-                  />
-                )}
+                {previewKey && (() => {
+                  // O ThemePreviewModal foi reescrito e espera { theme, selected,
+                  // onChoose, onClose }. O caller passava a assinatura antiga
+                  // (themes/index/onIndexChange/selectedKey) → theme = undefined →
+                  // TypeError ao abrir o modal. Alinhado ao contrato atual.
+                  const previewTheme = ALL_THEMES.find(t => t.key === previewKey) ?? ALL_THEMES[0]
+                  return (
+                    <ThemePreviewModal
+                      theme={previewTheme}
+                      selected={checkoutForm.layoutType === previewTheme.key}
+                      onChoose={() => {
+                        setCheckoutForm(f => ({ ...f, layoutType: previewTheme.key, primaryColor: previewTheme.accentHex }))
+                        setPreviewKey(null)
+                      }}
+                      onClose={() => setPreviewKey(null)}
+                    />
+                  )
+                })()}
 
                 {/* Cor principal — ajuste fino */}
                 <div className="mt-3 flex items-center gap-2">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1494,7 +1494,8 @@ export const masterApi = {
     request<{ success: boolean; data: any }>(`/api/v1/master/repasse-queue?${toQS(params)}`, { token }),
 
   systemHealth: () =>
-    request<{ status: 'green' | 'yellow' | 'red'; checks: Record<string, { status: string; message: string }>; timestamp: string }>('/api/v1/health/system'),
+    // A rota real é /health/system (healthRoutes tem prefixo /health, não /api/v1).
+    request<{ status: 'green' | 'yellow' | 'red'; checks: Record<string, { status: string; message: string }>; timestamp: string }>('/health/system'),
 }
 
 // ── Outbound / Growth Engine ────────────────────────────────────────────────


### PR DESCRIPTION
## Contexto
Auditoria completa pós-incidente (2 agentes varrendo API + Web). Além do crash de boot já corrigido (#243), encontrei 5 regressões introduzidas ontem no commit `beac077`. Todas confirmadas no código e corrigidas.

## Correções

**Web (runtime):**
- **Site de parceiro sempre vazio** — `_tenant/[slug]/page.tsx`: a rota `/public/properties` responde `{ data: [array], meta }`, mas o código lia `data.data?.items` (sempre `undefined`) → todo site de parceiro mostrava "Imóveis em breve". Corrigido para usar o array direto. *(Era exatamente o bug que o beac077 dizia corrigir.)*
- **ThemePreviewModal quebra ao abrir** — `DynamicPlans.tsx`: o modal foi reescrito com props `{ theme, selected, onChoose, onClose }`, mas o caller passava a assinatura antiga → `theme` undefined → `TypeError` ao clicar em "Ver prévia" no checkout de planos. Caller alinhado.
- **Widget de saúde do painel master 404** — `lib/api.ts`: `systemHealth` chamava `/api/v1/health/system`; a rota real é `/health/system`.

**API (comportamento):**
- **Ordenação Premium** — `public/index.ts`: restaura `{ isPremium: 'desc' }` no orderBy da listagem pública (Super Destaque > Destaque > ordem). beac077 removeu, tirando os imóveis Premium do topo (impacto de monetização). TTL do cache de site-settings volta a 60s.
- **Filtro "com fotos" ignorado** — `properties/index.ts`: a busca textual gravava `where.OR` e sobrescrevia o `where.OR` do filtro `hasImages`; com os dois juntos o filtro de fotos era descartado. Busca movida para `where.AND`.

## Validação
- API sobe localmente (Postgres+Redis Docker): `/health` 200, `/health/system` 200
- `/api/v1/properties?search=casa&hasImages=true` → 200 (fix da colisão OR)
- Arquivos web alterados sem erros de tsc; erros em `properties/index.ts:454/588` são pré-existentes (confirmado com/sem o diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_