### PR TITLE
fix: link Asaas de parceiro + agendamento de visita + documento IA (PDF)

### DIFF
--- a/apps/api/src/routes/specialists/payments.ts
+++ b/apps/api/src/routes/specialists/payments.ts
@@ -117,6 +117,32 @@ async function createAporteCharge(payload: {
   })
 }
 
+// Retorna a 1ª cobrança gerada por uma assinatura. Logo após criar a assinatura,
+// o Asaas pode levar um instante para gerar a cobrança — por isso o retry. Sem
+// isso o link de pagamento vinha vazio/errado ("link não encontrado").
+async function getSubscriptionFirstPayment(subscriptionId: string, retries = 5, delayMs = 800) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await asaasFetch<{ data?: Array<{ id: string; invoiceUrl?: string; bankSlipUrl?: string }> }>(
+        `/subscriptions/${subscriptionId}/payments`,
+      )
+      const first = res?.data?.[0]
+      if (first?.id) return first
+    } catch { /* tenta de novo */ }
+    if (i < retries - 1) await new Promise((r) => setTimeout(r, delayMs))
+  }
+  return null
+}
+
+// QR Code / copia-e-cola do PIX de uma cobrança.
+async function getPixQrCode(paymentId: string) {
+  try {
+    return await asaasFetch<{ encodedImage?: string; payload?: string }>(`/payments/${paymentId}/pixQrCode`)
+  } catch {
+    return null
+  }
+}
+
 export async function specialistPaymentRoutes(app: FastifyInstance) {
   // ── POST /checkout — Inicia assinatura para um especialista ──────────────
   app.post('/checkout', async (req, reply) => {
@@ -210,17 +236,37 @@ export async function specialistPaymentRoutes(app: FastifyInstance) {
         },
       })
 
+      // Link PAGÁVEL real = invoiceUrl da 1ª cobrança da assinatura (a assinatura
+      // em si não tem link pagável). A URL /c/{subscriptionId} usada antes é
+      // formato de payment link — o Asaas mostrava "link não encontrado".
+      const firstPayment = await getSubscriptionFirstPayment(subscription.id)
+      const invoiceUrl: string | null = firstPayment?.invoiceUrl ?? null
+      const bankSlipUrl: string | null = firstPayment?.bankSlipUrl ?? null
+      let pixQrCode: string | null = null
+      let pixCopiaECola: string | null = null
+      if (billingType === 'PIX' && firstPayment?.id) {
+        const pix = await getPixQrCode(firstPayment.id)
+        pixQrCode = pix?.encodedImage ?? null
+        pixCopiaECola = pix?.payload ?? null
+      }
+
       return reply.send({
         success: true,
         subscriptionId: subscription.id,
         status: subscription.status,
         nextDueDate: subscription.nextDueDate,
         message: 'Assinatura e aporte criados. Aguardando confirmação de pagamento.',
-        paymentUrl: `https://www.asaas.com/c/${subscription.id}`,
+        // Campos que o frontend do checkout renderiza (PIX/boleto/fatura).
+        invoiceUrl,
+        bankSlipUrl,
+        pixQrCode,
+        pixCopiaECola,
+        // paymentUrl = fatura pagável real (não mais /c/{id}). Fallback: fatura do aporte.
+        paymentUrl: invoiceUrl ?? aporte?.invoiceUrl ?? null,
         aporte: aporte ? {
           id: aporte.id,
           value: aporte.value,
-          invoiceUrl: aporte.invoiceUrl ?? `https://www.asaas.com/i/${aporte.id}`,
+          invoiceUrl: aporte.invoiceUrl ?? null,
           bankSlipUrl: aporte.bankSlipUrl ?? null,
         } : null,
       })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -689,6 +689,40 @@ async function runMigrations(prisma: any) {
     )`,
     `CREATE INDEX IF NOT EXISTS tenant_addons_tenant_status_idx ON tenant_addons("tenantId", status)`,
     `CREATE INDEX IF NOT EXISTS tenant_addons_asaas_charge_idx ON tenant_addons("asaasChargeId")`,
+
+    // Agendamento de visitas (público). A tabela existe em produção mas foi
+    // criada por um `db push` antigo, sem as colunas adicionadas depois (mode,
+    // status, updatedAt...), então o INSERT falhava (500 "Erro ao agendar").
+    // CREATE é no-op se já existe; os ADD COLUMN IF NOT EXISTS corrigem o drift.
+    `CREATE TABLE IF NOT EXISTS property_visits (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "companyId" TEXT NOT NULL,
+      "propertyId" TEXT NOT NULL,
+      "brokerId" TEXT,
+      "visitorName" TEXT NOT NULL,
+      "visitorEmail" TEXT,
+      "visitorPhone" TEXT NOT NULL,
+      "scheduledAt" TIMESTAMPTZ NOT NULL,
+      mode TEXT NOT NULL DEFAULT 'in_person',
+      status TEXT NOT NULL DEFAULT 'pending',
+      notes TEXT,
+      rating INTEGER,
+      feedback TEXT,
+      "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS "brokerId" TEXT`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS "visitorEmail" TEXT`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'in_person'`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending'`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS notes TEXT`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS rating INTEGER`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS feedback TEXT`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()`,
+    `ALTER TABLE property_visits ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()`,
+    `CREATE INDEX IF NOT EXISTS property_visits_company_scheduled_idx ON property_visits("companyId", "scheduledAt")`,
+    `CREATE INDEX IF NOT EXISTS property_visits_property_idx ON property_visits("propertyId")`,
+    `CREATE INDEX IF NOT EXISTS property_visits_status_idx ON property_visits(status)`,
   ]
   for (const sql of saasMigrations) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }

--- a/apps/api/src/services/ai.service.ts
+++ b/apps/api/src/services/ai.service.ts
@@ -13,6 +13,27 @@ const getClient = () => {
 /** Normalize image mediaType to values accepted by the Claude API */
 const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'] as const
 type AllowedMediaType = typeof ALLOWED_MEDIA_TYPES[number]
+function isPdfMediaType(mt: string): boolean {
+  const lower = (mt ?? '').toLowerCase().trim()
+  return lower === 'application/pdf' || lower.includes('pdf')
+}
+
+/**
+ * Monta o bloco de conteúdo Anthropic correto para um anexo:
+ * - PDF → bloco `document` (o bloco `image` NÃO aceita PDF → "Could not
+ *   process image", que era o erro do Agente IA de Documentos).
+ * - Imagem → bloco `image` com media_type normalizado (jpeg/png/gif/webp).
+ * Retorna null quando o tipo não é suportado.
+ */
+function buildAttachmentBlock(img: { base64: string; mediaType: string }): any | null {
+  if (isPdfMediaType(img.mediaType)) {
+    return { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: img.base64 } }
+  }
+  const mt = normalizeMediaType(img.mediaType)
+  if (!mt) return null
+  return { type: 'image', source: { type: 'base64', media_type: mt, data: img.base64 } }
+}
+
 function normalizeMediaType(mt: string): AllowedMediaType | null {
   const lower = (mt ?? '').toLowerCase().trim()
   if (lower === 'image/jpg') return 'image/jpeg'
@@ -490,16 +511,13 @@ Retorne o HTML completo começando com <!DOCTYPE html>`
 
   const userContent: any[] = []
 
-  // Add images if provided
+  // Add images/PDFs if provided
   if (input.images?.length) {
     for (const img of input.images) {
-      const mediaType = normalizeMediaType(img.mediaType)
-      if (!mediaType) continue // skip unsupported types
-      userContent.push({
-        type: 'image',
-        source: { type: 'base64', media_type: mediaType, data: img.base64 },
-      })
-      userContent.push({ type: 'text', text: `Imagem acima: ${img.description}` })
+      const block = buildAttachmentBlock(img)
+      if (!block) continue // tipo não suportado
+      userContent.push(block)
+      userContent.push({ type: 'text', text: `Anexo acima: ${img.description}` })
     }
   }
 
@@ -629,12 +647,9 @@ ADMINISTRATIVO (protocolo-documentos, regulamento-condominio, folha-rosto):
   if (input.images?.length) {
     let addedImages = 0
     for (const img of input.images) {
-      const mediaType = normalizeMediaType(img.mediaType)
-      if (!mediaType) continue // skip unsupported types
-      userContent.push({
-        type: 'image',
-        source: { type: 'base64', media_type: mediaType, data: img.base64 },
-      })
+      const block = buildAttachmentBlock(img)
+      if (!block) continue // tipo não suportado
+      userContent.push(block)
       addedImages++
     }
     if (addedImages > 0) {

--- a/apps/api/src/services/asaas.service.ts
+++ b/apps/api/src/services/asaas.service.ts
@@ -386,14 +386,23 @@ export async function getSubscriptionPayments(subscriptionId: string): Promise<{
  * cobrança gerada por ela. Sem isso, montávamos uma URL /c/{id} inválida e o
  * Asaas mostrava "Link de pagamento não encontrado".
  */
-export async function getSubscriptionInvoiceUrl(subscriptionId: string): Promise<string | null> {
-  try {
-    const res = await getSubscriptionPayments(subscriptionId)
-    const first = res?.data?.[0]
-    return first?.invoiceUrl ?? null
-  } catch {
-    return null
+export async function getSubscriptionInvoiceUrl(
+  subscriptionId: string,
+  retries = 5,
+  delayMs = 800,
+): Promise<string | null> {
+  // Logo após criar a assinatura, o Asaas pode levar um instante para gerar a
+  // 1ª cobrança — o GET /payments volta vazio e o link vinha nulo ("link não
+  // encontrado"). Poll curto até a cobrança existir.
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await getSubscriptionPayments(subscriptionId)
+      const first = res?.data?.[0]
+      if (first?.invoiceUrl) return first.invoiceUrl
+    } catch { /* tenta de novo */ }
+    if (i < retries - 1) await new Promise((r) => setTimeout(r, delayMs))
   }
+  return null
 }
 
 export async function cancelSubscription(subscriptionId: string): Promise<{ deleted: boolean }> {

--- a/apps/web/src/app/(public)/checkout/sucesso/page.tsx
+++ b/apps/web/src/app/(public)/checkout/sucesso/page.tsx
@@ -23,7 +23,11 @@ export default async function CheckoutSuccessPage({ searchParams }: PageProps) {
   const params = await searchParams
   const subdomain = (params.ref || '').replace(/[^a-z0-9-]/g, '')
   const siteUrl = subdomain ? `https://${subdomain}.agoraencontrei.com.br` : null
-  const paymentUrl = params.payment ? `https://www.asaas.com/c/${params.payment}` : null
+  // `payment` deve ser a URL de fatura REAL do Asaas (invoiceUrl), passada já
+  // pronta. Não montar https://asaas.com/c/{id} — /c/ é payment link, não
+  // cobrança/assinatura, e o Asaas mostra "link não encontrado".
+  const rawPayment = params.payment ? decodeURIComponent(params.payment) : ''
+  const paymentUrl = /^https:\/\/(www\.)?asaas\.com\//.test(rawPayment) ? rawPayment : null
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#143A1F] to-[#0f1c3a] py-12 px-4">


### PR DESCRIPTION
3 erros reportados em produção, diagnosticados e corrigidos:

1. **Asaas não abre o link de pagamento** (checkout de parceiro/especialista) — `specialists/payments.ts` montava `asaas.com/c/{subscriptionId}` (formato de payment link, não de assinatura → "link não encontrado"). Agora busca a 1ª cobrança real da assinatura com retry (race do Asaas) e devolve `invoiceUrl`/`bankSlipUrl`/`pixQrCode`. Mesmo `/c/` latente corrigido na página de sucesso do checkout SaaS; `getSubscriptionInvoiceUrl` ganhou retry.

2. **"Erro ao agendar" visita (500)** — a tabela `property_visits` existe em prod mas foi criada por um `db push` antigo sem colunas adicionadas depois → o INSERT falhava. `runMigrations` agora garante a tabela + colunas (idempotente). *Confirmado ao vivo: POST retornava 500 SCHEDULE_FAILED.*

3. **"Could not process image" no Agente IA de Documentos** — um PDF anexado era enviado ao Claude como bloco `image` (`normalizeMediaType` assumia jpeg p/ tipo desconhecido). PDF agora vira bloco `document`; imagem segue `image`. Vale p/ identify e generate.

Validado: build sem erros novos, guarda de boot passa (96 módulos), web typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_