### PR TITLE
feat(auth): recuperação de senha (e-mail/CPF/telefone) + notificações de onboarding

### DIFF
--- a/apps/api/src/routes/auth/first-access.ts
+++ b/apps/api/src/routes/auth/first-access.ts
@@ -22,6 +22,125 @@ export async function createPasswordSetupToken(prisma: any, email: string, ttlDa
 }
 
 export default async function firstAccessRoutes(app: FastifyInstance) {
+  // POST /esqueci-senha { identifier } — solicita link de redefinição de senha.
+  // Aceita e-mail, CPF/CNPJ (via Specialist/Client) ou telefone. Por segurança,
+  // NUNCA revela se existe uma conta: sempre responde 200 com mensagem genérica.
+  app.post('/esqueci-senha', {
+    schema: { tags: ['auth'], summary: 'Solicita link de redefinição de senha (e-mail/WhatsApp)' },
+  }, async (req, reply) => {
+    const GENERIC = {
+      success: true,
+      message: 'Se houver uma conta com esses dados, enviamos o link de redefinição por e-mail e WhatsApp.',
+    }
+
+    try {
+      const identifier = String((req.body as any)?.identifier ?? '').trim()
+      if (!identifier) return reply.send(GENERIC)
+
+      const prisma = app.prisma as any
+      let user: any = null
+
+      if (identifier.includes('@')) {
+        // E-mail (case-insensitive)
+        const email = identifier.toLowerCase()
+        user = await prisma.user.findFirst({
+          where: { email: { equals: email, mode: 'insensitive' } },
+        }).catch(() => null)
+      } else {
+        const digits = identifier.replace(/\D/g, '')
+
+        if (digits.length === 11 || digits.length === 14) {
+          // CPF (11) ou CNPJ (14) — buscar o e-mail associado em Specialist/Client.
+          let email: string | null = null
+
+          const specialist = await prisma.specialist.findFirst({
+            where: { cpfCnpj: digits },
+          }).catch(() => null)
+          if (specialist?.email) email = specialist.email
+
+          if (!email) {
+            // Client armazena o documento no campo `document`.
+            const client = await prisma.client.findFirst({
+              where: { document: digits, email: { not: null } },
+            }).catch(() => null)
+            if (client?.email) email = client.email
+          }
+
+          if (email) {
+            user = await prisma.user.findFirst({
+              where: { email: { equals: email.toLowerCase(), mode: 'insensitive' } },
+            }).catch(() => null)
+          }
+        }
+
+        // Telefone: 10 ou 11 dígitos (sem DDI). Compara apenas dígitos do phone.
+        if (!user && (digits.length === 10 || digits.length === 11)) {
+          const candidates = await prisma.user.findMany({
+            where: { phone: { not: null } },
+            select: { id: true, email: true, phone: true },
+          }).catch(() => [])
+          user = candidates.find((u: any) => (u.phone || '').replace(/\D/g, '').endsWith(digits)) || null
+        }
+      }
+
+      if (!user?.email) return reply.send(GENERIC)
+
+      // Gera token e monta o link para a página web de definição de senha.
+      const token = await createPasswordSetupToken(prisma, user.email).catch(() => null)
+      if (!token) return reply.send(GENERIC)
+
+      const base = process.env.WEB_URL || 'https://agoraencontrei.com.br'
+      const link = `${base}/definir-senha?token=${token}`
+
+      // E-mail (best-effort)
+      try {
+        const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+        if (isEmailConfigured()) {
+          const html = `
+            <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+              <h1 style="color:#1B2B5B;margin:0 0 8px">Redefinição de senha</h1>
+              <p style="margin:0 0 16px;color:#475569">Recebemos um pedido para redefinir a senha da sua conta no AgoraEncontrei.</p>
+              <div style="text-align:center;margin:24px 0">
+                <a href="${link}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:700;padding:12px 24px;border-radius:10px;text-decoration:none">Definir nova senha →</a>
+              </div>
+              <p style="margin:16px 0;color:#475569">Ou copie e cole este link no navegador:</p>
+              <p style="margin:0 0 16px;word-break:break-all"><a href="${link}" style="color:#C9A84C">${link}</a></p>
+              <p style="margin:16px 0;color:#475569">O link expira em 7 dias. Se não foi você que solicitou, ignore este e-mail — sua senha continua a mesma.</p>
+            </div>`
+          await sendEmail({
+            to: user.email,
+            subject: 'Redefinição de senha — AgoraEncontrei',
+            html,
+          })
+        }
+      } catch (e: any) {
+        app.log.error({ err: e }, '[esqueci-senha] email failed')
+      }
+
+      // WhatsApp (best-effort)
+      if (user.phone) {
+        try {
+          const { sendWhatsappText } = await import('../../services/whatsapp-notify.service.js')
+          const msg =
+            `🔒 *AgoraEncontrei — Redefinição de senha*\n\n` +
+            `Recebemos um pedido para redefinir a senha da sua conta.\n\n` +
+            `*Defina uma nova senha:*\n${link}\n\n` +
+            `(o link expira em 7 dias)\n\n` +
+            `Se não foi você, ignore esta mensagem.`
+          await sendWhatsappText(user.phone, msg)
+        } catch (e: any) {
+          app.log.error({ err: e }, '[esqueci-senha] whatsapp failed')
+        }
+      }
+
+      return reply.send(GENERIC)
+    } catch (e: any) {
+      // Nunca vaza erro — resposta genérica sempre.
+      app.log.error({ err: e }, '[esqueci-senha] unexpected error')
+      return reply.send(GENERIC)
+    }
+  })
+
   // GET /definir-senha/validar?token= — valida o token (para a UX do frontend)
   app.get('/definir-senha/validar', {
     schema: { tags: ['auth'], summary: 'Valida um token de definição de senha' },

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -310,6 +310,53 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       // Link pagável real = invoiceUrl da 1ª cobrança da assinatura.
       const invoiceUrl = await getSubscriptionInvoiceUrl(subscription.id)
 
+      // Confirmação imediata do cadastro (best-effort, não-fatal). O link para
+      // definir a senha só sai depois do pagamento confirmado (via webhook),
+      // aqui apenas avisamos que recebemos o cadastro e incluímos o link de
+      // pagamento se houver.
+      try {
+        const paymentLine = invoiceUrl
+          ? `\n\n*Link para pagamento:*\n${invoiceUrl}`
+          : ''
+        const confirmMsg =
+          `Recebemos seu cadastro do plano ${plan.name}. ` +
+          `Assim que o pagamento for confirmado você recebe o link para definir sua senha e acessar.`
+
+        // E-mail
+        try {
+          const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+          if (isEmailConfigured()) {
+            const html = `
+              <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+                <h1 style="color:#1B2B5B;margin:0 0 8px">Cadastro recebido!</h1>
+                <p style="margin:0 0 16px;color:#475569">${confirmMsg}</p>
+                ${invoiceUrl ? `<div style="text-align:center;margin:24px 0"><a href="${invoiceUrl}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:700;padding:12px 24px;border-radius:10px;text-decoration:none">Concluir pagamento →</a></div><p style="margin:0 0 16px;word-break:break-all;color:#475569">${invoiceUrl}</p>` : ''}
+                <p style="margin:24px 0 0;font-size:13px;color:#64748b">Qualquer dúvida, responda este e-mail.</p>
+              </div>`
+            await sendEmail({
+              to: body.customer.email,
+              subject: `Recebemos seu cadastro — Plano ${plan.name}`,
+              html,
+            })
+          }
+        } catch (e: any) {
+          app.log.error({ err: e }, '[saas-billing] confirmation email failed')
+        }
+
+        // WhatsApp
+        const notifyPhone = body.customer.mobilePhone || body.customer.phone
+        if (notifyPhone) {
+          try {
+            const { sendWhatsappText } = await import('../../services/whatsapp-notify.service.js')
+            await sendWhatsappText(notifyPhone, `✅ *AgoraEncontrei*\n\n${confirmMsg}${paymentLine}`)
+          } catch (e: any) {
+            app.log.error({ err: e }, '[saas-billing] confirmation whatsapp failed')
+          }
+        }
+      } catch (e: any) {
+        app.log.error({ err: e }, '[saas-billing] checkout confirmation notify failed')
+      }
+
       return reply.status(201).send({
         success: true,
         data: {

--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -258,35 +258,20 @@ async function handleTenantEvent(
 
         if (customerPhone) {
           try {
-            const cleanPhone = customerPhone.replace(/\D/g, '')
-            const formattedPhone = cleanPhone.startsWith('55') ? cleanPhone : `55${cleanPhone}`
-            const WHATSAPP_TOKEN = process.env.WHATSAPP_TOKEN || process.env.WHATSAPP_ACCESS_TOKEN
-            const WHATSAPP_PHONE_ID = process.env.WHATSAPP_PHONE_ID || process.env.WHATSAPP_PHONE_NUMBER_ID
-            if (WHATSAPP_TOKEN && WHATSAPP_PHONE_ID) {
-              const siteUrl = `https://${subdomain}.agoraencontrei.com.br`
-              const msg =
-                `🎉 *AgoraEncontrei — Pagamento confirmado!*\n\n` +
-                `Seu site está no ar:\n${siteUrl}\n\n` +
-                `*Acesso ao painel:*\nhttps://agoraencontrei.com.br/login\n\n` +
-                `*E-mail:* ${customerEmail}\n\n` +
-                `*Defina sua senha de acesso:*\n${setupLink}\n\n` +
-                `(o link expira em 7 dias)`
-              await fetch(`https://graph.facebook.com/v19.0/${WHATSAPP_PHONE_ID}/messages`, {
-                method: 'POST',
-                headers: {
-                  Authorization: `Bearer ${WHATSAPP_TOKEN}`,
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  messaging_product: 'whatsapp',
-                  to: formattedPhone,
-                  type: 'text',
-                  text: { body: msg, preview_url: false },
-                }),
-              })
-              app.log.info(`[saas-webhook] Welcome WhatsApp enviado para ${formattedPhone}`)
+            const { sendWhatsappText } = await import('../../services/whatsapp-notify.service.js')
+            const siteUrl = `https://${subdomain}.agoraencontrei.com.br`
+            const msg =
+              `🎉 *AgoraEncontrei — Pagamento confirmado!*\n\n` +
+              `Seu site está no ar:\n${siteUrl}\n\n` +
+              `*Acesso ao painel:*\nhttps://agoraencontrei.com.br/login\n\n` +
+              `*E-mail:* ${customerEmail}\n\n` +
+              `*Defina sua senha de acesso:*\n${setupLink}\n\n` +
+              `(o link expira em 7 dias)`
+            const sent = await sendWhatsappText(customerPhone, msg)
+            if (sent) {
+              app.log.info(`[saas-webhook] Welcome WhatsApp enviado para ${customerPhone}`)
             } else {
-              app.log.warn('[saas-webhook] WhatsApp não configurado — credenciais não enviadas por WhatsApp')
+              app.log.warn('[saas-webhook] WhatsApp não enviado (não configurado ou erro)')
             }
           } catch (e: any) {
             app.log.error({ err: e }, '[saas-webhook] welcome whatsapp failed')

--- a/apps/api/src/services/whatsapp-notify.service.ts
+++ b/apps/api/src/services/whatsapp-notify.service.ts
@@ -1,0 +1,58 @@
+/**
+ * WhatsApp Notify — helper compartilhado para envio de texto simples via
+ * Meta Cloud API (graph.facebook.com).
+ *
+ * Extraído da lógica inline do saas-webhook para ser reutilizado por outros
+ * fluxos (recuperação de senha, confirmação de cadastro, etc). Nunca lança:
+ * retorna false (e loga) quando não configurado ou em caso de erro, para que
+ * quem chama trate o WhatsApp como best-effort.
+ */
+
+/**
+ * Envia uma mensagem de texto para um número (BR). Normaliza o telefone com o
+ * DDI 55 quando ausente. Usa WHATSAPP_TOKEN||WHATSAPP_ACCESS_TOKEN e
+ * WHATSAPP_PHONE_ID||WHATSAPP_PHONE_NUMBER_ID. Retorna true em sucesso, false
+ * quando não configurado / telefone vazio / erro.
+ */
+export async function sendWhatsappText(phone: string, message: string): Promise<boolean> {
+  try {
+    const cleanPhone = (phone || '').replace(/\D/g, '')
+    if (!cleanPhone) {
+      console.warn('[whatsapp-notify] telefone vazio — mensagem não enviada')
+      return false
+    }
+    const formattedPhone = cleanPhone.startsWith('55') ? cleanPhone : `55${cleanPhone}`
+
+    const WHATSAPP_TOKEN = process.env.WHATSAPP_TOKEN || process.env.WHATSAPP_ACCESS_TOKEN
+    const WHATSAPP_PHONE_ID = process.env.WHATSAPP_PHONE_ID || process.env.WHATSAPP_PHONE_NUMBER_ID
+    if (!WHATSAPP_TOKEN || !WHATSAPP_PHONE_ID) {
+      console.warn('[whatsapp-notify] WhatsApp não configurado — mensagem não enviada')
+      return false
+    }
+
+    const resp = await fetch(`https://graph.facebook.com/v19.0/${WHATSAPP_PHONE_ID}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WHATSAPP_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to: formattedPhone,
+        type: 'text',
+        text: { body: message, preview_url: false },
+      }),
+    })
+
+    if (!resp.ok) {
+      const errText = await resp.text().catch(() => '')
+      console.error(`[whatsapp-notify] envio falhou (${resp.status}): ${errText}`)
+      return false
+    }
+
+    return true
+  } catch (e: any) {
+    console.error(`[whatsapp-notify] erro ao enviar: ${e?.message || e}`)
+    return false
+  }
+}

--- a/apps/web/src/app/(auth)/definir-senha/page.tsx
+++ b/apps/web/src/app/(auth)/definir-senha/page.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+function DefinirSenhaInner() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const token = searchParams.get('token') ?? ''
+
+  const [checking, setChecking] = useState(true)
+  const [valid, setValid] = useState(false)
+  const [email, setEmail] = useState<string | null>(null)
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  // Valida o token ao montar.
+  useEffect(() => {
+    let alive = true
+    async function validate() {
+      if (!token) {
+        if (alive) { setValid(false); setChecking(false) }
+        return
+      }
+      try {
+        const res = await fetch(`${API_URL}/api/v1/auth/definir-senha/validar?token=${encodeURIComponent(token)}`)
+        const data = await res.json().catch(() => ({ valid: false }))
+        if (alive) {
+          setValid(!!data.valid)
+          setEmail(data.email ?? null)
+        }
+      } catch {
+        if (alive) setValid(false)
+      } finally {
+        if (alive) setChecking(false)
+      }
+    }
+    validate()
+    return () => { alive = false }
+  }, [token])
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (password.length < 8) {
+      setError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
+    if (password !== confirm) {
+      setError('As senhas não coincidem.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const res = await fetch(`${API_URL}/api/v1/auth/definir-senha`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data.success) {
+        setError(data.message || 'Não foi possível definir a senha. O link pode ter expirado.')
+        setSubmitting(false)
+        return
+      }
+      setDone(true)
+      setTimeout(() => router.push('/login'), 2500)
+    } catch {
+      setError('Erro de conexão. Tente novamente em instantes.')
+      setSubmitting(false)
+    }
+  }
+
+  if (checking) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!valid) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Link inválido</CardTitle>
+          <CardDescription>Este link de redefinição é inválido ou expirou.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            Solicite um novo link de redefinição de senha.
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Link href="/esqueci-senha" className="text-sm text-primary hover:underline font-medium w-full text-center">
+            Solicitar novo link
+          </Link>
+        </CardFooter>
+      </Card>
+    )
+  }
+
+  if (done) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Senha definida!</CardTitle>
+          <CardDescription>Sua senha foi atualizada com sucesso.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md bg-primary/10 p-3 text-sm text-foreground">
+            Redirecionando para o login...
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Link href="/login" className="text-sm text-primary hover:underline font-medium w-full text-center">
+            Ir para o login agora
+          </Link>
+        </CardFooter>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Definir nova senha</CardTitle>
+        <CardDescription>
+          {email ? `Conta: ${email}` : 'Crie uma nova senha para acessar sua conta.'}
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="password">Nova senha</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Mínimo 8 caracteres"
+                autoComplete="new-password"
+                className="pr-10"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                style={{ fontSize: 16 }}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="confirm">Confirmar senha</Label>
+            <Input
+              id="confirm"
+              name="confirm"
+              type={showPassword ? 'text' : 'password'}
+              placeholder="Repita a senha"
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              style={{ fontSize: 16 }}
+              required
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3">
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Definir senha
+          </Button>
+          <p className="text-sm text-muted-foreground text-center">
+            <Link href="/login" className="text-primary hover:underline font-medium">
+              Voltar para o login
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}
+
+export default function DefinirSenhaPage() {
+  return (
+    <Suspense
+      fallback={
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      }
+    >
+      <DefinirSenhaInner />
+    </Suspense>
+  )
+}

--- a/apps/web/src/app/(auth)/esqueci-senha/page.tsx
+++ b/apps/web/src/app/(auth)/esqueci-senha/page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Loader2 } from 'lucide-react'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+export default function EsqueciSenhaPage() {
+  const [identifier, setIdentifier] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (loading) return
+    setLoading(true)
+    try {
+      await fetch(`${API_URL}/api/v1/auth/esqueci-senha`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: identifier.trim() }),
+      })
+    } catch {
+      // Nunca revelamos nada — mesmo em erro de rede mostramos sucesso genérico.
+    } finally {
+      setLoading(false)
+      setSent(true)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recuperar senha</CardTitle>
+        <CardDescription>
+          Informe seu e-mail, CPF/CNPJ ou telefone. Enviaremos um link para você definir uma nova senha.
+        </CardDescription>
+      </CardHeader>
+
+      {sent ? (
+        <>
+          <CardContent>
+            <div className="rounded-md bg-primary/10 p-4 text-sm text-foreground">
+              Se houver uma conta com esses dados, enviamos o link de redefinição por e-mail e WhatsApp.
+              Verifique sua caixa de entrada (e o spam).
+            </div>
+          </CardContent>
+          <CardFooter>
+            <Link href="/login" className="text-sm text-primary hover:underline font-medium w-full text-center">
+              Voltar para o login
+            </Link>
+          </CardFooter>
+        </>
+      ) : (
+        <form onSubmit={onSubmit}>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="identifier">E-mail, CPF/CNPJ ou telefone</Label>
+              <Input
+                id="identifier"
+                name="identifier"
+                type="text"
+                placeholder="seu@email.com"
+                autoComplete="username"
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
+                style={{ fontSize: 16 }}
+                required
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button type="submit" className="w-full" disabled={loading || !identifier.trim()}>
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              Enviar link de redefinição
+            </Button>
+            <p className="text-sm text-muted-foreground text-center">
+              Lembrou a senha?{' '}
+              <Link href="/login" className="text-primary hover:underline font-medium">
+                Fazer login
+              </Link>
+            </p>
+          </CardFooter>
+        </form>
+      )}
+    </Card>
+  )
+}

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -203,6 +203,11 @@ export default function LoginPage() {
               Entrar
             </Button>
             <p className="text-sm text-muted-foreground text-center">
+              <Link href="/esqueci-senha" className="text-primary hover:underline font-medium">
+                Esqueci minha senha
+              </Link>
+            </p>
+            <p className="text-sm text-muted-foreground text-center">
               Não tem conta?{' '}
               <Link href="/register" className="text-primary hover:underline font-medium">
                 Criar conta


### PR DESCRIPTION
Parceiro que paga não tinha como acessar a conta: o cadastro não define senha (por design — o link de definir senha vem depois), mas **não havia "esqueci a senha" nem endpoint de reset**. Se o link não chegasse (SMTP/WhatsApp), a pessoa ficava sem saída.

## Implementado
- **`POST /api/v1/auth/esqueci-senha`** — aceita **e-mail, CPF/CNPJ** (via Specialist/Client) ou **telefone**; gera token (reusa `createPasswordSetupToken`) e envia o link por **e-mail + WhatsApp**. Sempre responde 200 genérico (sem enumeração de conta).
- **Web**: link "Esqueci minha senha" no login + páginas `/esqueci-senha` (solicitar) e `/definir-senha` (valida token, define senha ≥8, inputs 16px p/ iOS).
- **`whatsapp-notify.service.ts`**: helper `sendWhatsappText` reutilizável; `saas-webhook` refatorado para usá-lo (comportamento idêntico).
- **`saas-checkout`**: confirmação **imediata** do cadastro por e-mail + WhatsApp (best-effort), além do link de senha que já sai no pagamento confirmado.

## Validação
- build API sem erros novos, guarda de boot 96 módulos, web typecheck limpo no route group `(auth)`.

⚠️ A entrega depende de `SMTP_*` e `WHATSAPP_TOKEN`/`WHATSAPP_PHONE_ID` configurados no Railway (vou consolidar isso na lista de pendências).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_