### PR TITLE
fix: bugs financeiros/fiscais (cobrança avulsa, NFS-e, sinal PJ, clicksign, modelo IA)

### DIFF
--- a/apps/api/src/routes/deals/index.ts
+++ b/apps/api/src/routes/deals/index.ts
@@ -376,7 +376,7 @@ export default async function dealsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: 'NO_CONTACT', message: 'A negociação precisa de um contato (comprador).' })
     }
 
-    const cpfCnpj = (body.cpfCnpj || (deal.contact as any).cpf || '').replace(/\D/g, '')
+    const cpfCnpj = (body.cpfCnpj || (deal.contact as any).cpf || (deal.contact as any).cnpj || '').replace(/\D/g, '')
     if (cpfCnpj.length !== 11 && cpfCnpj.length !== 14) {
       return reply.status(400).send({ error: 'INVALID_CPF', message: 'Informe um CPF/CNPJ válido do comprador.' })
     }

--- a/apps/api/src/routes/finance/index.ts
+++ b/apps/api/src/routes/finance/index.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify'
 import nodemailer from 'nodemailer'
-import { createCharge, findOrCreateCustomer } from '../../services/asaas.service.js'
+import { createCharge, findOrCreateCustomer, getPixQrCode } from '../../services/asaas.service.js'
 import { env } from '../../utils/env.js'
 import { createAuditLog } from '../../services/audit.service.js'
 
@@ -1456,23 +1456,46 @@ export default async function financeRoutes(app: FastifyInstance) {
       })
     }
 
-    // Create or find Asaas customer for the tenant
-    const asaasCustomer = await findOrCreateCustomer({
-      name:    contract.tenant.name,
-      cpfCnpj: contract.tenant.document,
-      email:   contract.tenant.email  ?? undefined,
-      phone:   contract.tenant.phone  ?? undefined,
-    })
+    // Create Asaas customer + charge (+ PIX QR code) — wrapped so any Asaas
+    // failure surfaces as a controlled 502 instead of an unhandled 500.
+    const billingType = body.billingType ?? 'PIX'
+    let asaasCharge: Awaited<ReturnType<typeof createCharge>>
+    let pixCode:   string | null = null
+    let pixQrCode: string | null = null
+    try {
+      const asaasCustomer = await findOrCreateCustomer({
+        name:    contract.tenant.name,
+        cpfCnpj: contract.tenant.document,
+        email:   contract.tenant.email  ?? undefined,
+        phone:   contract.tenant.phone  ?? undefined,
+      })
 
-    // Create Asaas charge
-    const asaasCharge = await createCharge({
-      customer:          asaasCustomer.id,
-      billingType:       body.billingType ?? 'PIX',
-      value:             body.amount,
-      dueDate:           body.dueDate,
-      description:       body.description,
-      externalReference: contract.legacyId ?? contract.id,
-    })
+      asaasCharge = await createCharge({
+        customer:          asaasCustomer.id,
+        billingType,
+        value:             body.amount,
+        dueDate:           body.dueDate,
+        description:       body.description,
+        externalReference: contract.legacyId ?? contract.id,
+      })
+
+      // createCharge({billingType:'PIX'}) does NOT return pixCode — fetch the QR code.
+      if (billingType === 'PIX') {
+        const pix = await getPixQrCode(asaasCharge.id).catch(() => null)
+        pixCode   = pix?.payload ?? asaasCharge.pixCode ?? null
+        pixQrCode = pix?.encodedImage ? `data:image/png;base64,${pix.encodedImage}` : null
+      } else {
+        pixCode = asaasCharge.pixCode ?? null
+      }
+    } catch (err: any) {
+      app.log.error({ err }, `[finance/charges] Asaas error: ${err?.message}`)
+      return reply.status(502).send({
+        error:   'ASAAS_ERROR',
+        message: err?.message ?? 'Falha ao gerar cobrança no Asaas.',
+      })
+    }
+
+    const boletoUrl = asaasCharge.bankSlipUrl ?? asaasCharge.invoiceUrl ?? null
 
     // Persist invoice record in DB with asaasId for tracking
     const invoice = await app.prisma.invoice.create({
@@ -1484,8 +1507,8 @@ export default async function financeRoutes(app: FastifyInstance) {
         mensagem:        body.description,
         asaasId:         asaasCharge.id,
         asaasStatus:     asaasCharge.status ?? 'PENDING',
-        asaasBankSlipUrl: asaasCharge.bankSlipUrl ?? null,
-        asaasPixCode:    asaasCharge.pixCode ?? null,
+        asaasBankSlipUrl: boletoUrl,
+        asaasPixCode:    pixCode,
       },
     })
 
@@ -1495,9 +1518,7 @@ export default async function financeRoutes(app: FastifyInstance) {
         const tenant = contract.tenant!
         const fmt = (v: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v)
         const fmtDate = (d: string) => { const [y, m, day] = d.split('-'); return `${day}/${m}/${y}` }
-        const billingLabel = (body.billingType ?? 'PIX') === 'BOLETO' ? 'Boleto Bancário' : 'PIX'
-        const pixCode = (asaasCharge as any).pixCode ?? null
-        const boletoUrl = (asaasCharge as any).bankSlipUrl ?? null
+        const billingLabel = billingType === 'BOLETO' ? 'Boleto Bancário' : 'PIX'
 
         const waMsgLines = [
           `💳 *Cobrança Gerada — Imobiliária Lemos*`,
@@ -1549,7 +1570,15 @@ export default async function financeRoutes(app: FastifyInstance) {
       }
     })
 
-    return reply.status(201).send({ invoice, asaasCharge })
+    // Return shape matches what the LemosBank cobranças front reads at the TOP level:
+    // result.boletoUrl / result.pixCode / result.pixQrCode (plus invoice + raw charge).
+    return reply.status(201).send({
+      boletoUrl,
+      pixCode,
+      pixQrCode,
+      invoice,
+      asaasCharge,
+    })
   })
 
   // PATCH /api/v1/finance/rentals/:id/estorno — Estornar pagamento (PAID → PENDING)

--- a/apps/api/src/routes/fiscal/index.ts
+++ b/apps/api/src/routes/fiscal/index.ts
@@ -140,17 +140,35 @@ export default async function fiscalRoutes(app: FastifyInstance) {
 
     const competencia = `${note.rentalYear}-${String(note.rentalMonth).padStart(2, '0')}-01`
 
-    const asaasInvoice = await createAsaasInvoice({
-      serviceDescription: note.serviceDescription ?? 'Prestação de serviços de administração e intermediação imobiliária',
-      observations: `Contrato de locação — ${note.propertyAddress ?? 'Imóvel'}\nProprietário: ${note.landlordName}\nCPF: ${note.landlordCpf}\nReferência: ${String(note.rentalMonth).padStart(2, '0')}/${note.rentalYear}`,
-      value: nfValue,
-      effectiveDate: competencia,
-      externalReference: note.id,
-      taxes: {
-        retainIss: false,
-        iss: 5,       // ISS 5% padrão para serviços imobiliários
-      },
-    })
+    // Asaas /invoices exige um customer — resolver/criar o proprietário como customer.
+    let asaasInvoice: Awaited<ReturnType<typeof createAsaasInvoice>>
+    try {
+      const customer = await findOrCreateCustomer({
+        name:    note.landlordName,
+        cpfCnpj: note.landlordCpf,
+        email:   note.landlordEmail ?? undefined,
+        phone:   note.landlordPhone ?? undefined,
+      })
+
+      asaasInvoice = await createAsaasInvoice({
+        customer: customer.id,
+        serviceDescription: note.serviceDescription ?? 'Prestação de serviços de administração e intermediação imobiliária',
+        observations: `Contrato de locação — ${note.propertyAddress ?? 'Imóvel'}\nProprietário: ${note.landlordName}\nCPF: ${note.landlordCpf}\nReferência: ${String(note.rentalMonth).padStart(2, '0')}/${note.rentalYear}`,
+        value: nfValue,
+        effectiveDate: competencia,
+        externalReference: note.id,
+        taxes: {
+          retainIss: false,
+          iss: 5,       // ISS 5% padrão para serviços imobiliários
+        },
+      })
+    } catch (err: any) {
+      app.log.error({ err }, `[fiscal/emitir-asaas] Asaas error: ${err?.message}`)
+      return reply.status(502).send({
+        error:   'ASAAS_ERROR',
+        message: err?.message ?? 'Falha ao emitir NFS-e no Asaas.',
+      })
+    }
 
     // Atualizar nota no banco com dados do Asaas
     const updated = await app.prisma.fiscalNote.update({
@@ -192,7 +210,24 @@ export default async function fiscalRoutes(app: FastifyInstance) {
     schema: { tags: ['fiscal'], summary: 'Emitir NFS-e em lote via Asaas' },
   }, async (req, reply) => {
     const cid = req.user.cid
-    const body = req.body as { month: number; year: number; noteIds?: string[] }
+
+    // Validação: exige noteIds não-vazio OU (month E year) — evita emitir TODAS as DRAFT.
+    const parsed = z.object({
+      month:   z.number().int().min(1).max(12).optional(),
+      year:    z.number().int().min(2000).max(2100).optional(),
+      noteIds: z.array(z.string()).optional(),
+    }).refine(
+      b => (b.noteIds && b.noteIds.length > 0) || (b.month != null && b.year != null),
+      { message: 'Informe noteIds (não-vazio) ou month e year.' },
+    ).safeParse(req.body)
+
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error:   'INVALID_BODY',
+        message: parsed.error.issues[0]?.message ?? 'Parâmetros inválidos.',
+      })
+    }
+    const body = parsed.data
 
     const where: any = {
       companyId: cid,
@@ -217,7 +252,15 @@ export default async function fiscalRoutes(app: FastifyInstance) {
 
         const competencia = `${note.rentalYear}-${String(note.rentalMonth).padStart(2, '0')}-01`
 
+        const customer = await findOrCreateCustomer({
+          name:    note.landlordName,
+          cpfCnpj: note.landlordCpf,
+          email:   note.landlordEmail ?? undefined,
+          phone:   note.landlordPhone ?? undefined,
+        })
+
         const asaasInvoice = await createAsaasInvoice({
+          customer: customer.id,
           serviceDescription: note.serviceDescription ?? 'Prestação de serviços de administração e intermediação imobiliária',
           observations: `Proprietário: ${note.landlordName} | CPF: ${note.landlordCpf} | Ref: ${String(note.rentalMonth).padStart(2, '0')}/${note.rentalYear}`,
           value: nfValue,

--- a/apps/api/src/routes/seo-programatico/index.ts
+++ b/apps/api/src/routes/seo-programatico/index.ts
@@ -327,7 +327,7 @@ export default async function seoProgramaticoRoutes(app: FastifyInstance) {
         const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
         generateContent = async (keyword, cidade, uf, ctx) => {
           const msg = await client.messages.create({
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-5',
             max_tokens: 2048,
             messages: [{ role: 'user', content: buildSeoPrompt(keyword, cidade, uf, ctx) }],
           })

--- a/apps/api/src/services/asaas.service.ts
+++ b/apps/api/src/services/asaas.service.ts
@@ -261,6 +261,7 @@ export interface AsaasWebhookEvent {
 // ── NFS-e (Nota Fiscal de Serviço) ──────────────────────────────────────────
 
 export interface AsaasInvoicePayload {
+  customer?: string             // ID do customer Asaas (exigido pelo /invoices)
   payment?: string              // ID do pagamento vinculado (opcional)
   serviceDescription: string    // descrição do serviço
   observations?: string

--- a/apps/api/src/services/clicksign.service.ts
+++ b/apps/api/src/services/clicksign.service.ts
@@ -57,8 +57,14 @@ export interface SignatureStatus {
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-const CLICKSIGN_TOKEN = (env as any).CLICKSIGN_ACCESS_TOKEN || '60edac7d-32b3-4bb7-9190-0fd39f6e129c'
+// Sem fallback hardcoded: usar apenas a env. Se ausente, as operações de
+// assinatura falham de forma controlada (o boot NÃO é interrompido).
+const CLICKSIGN_TOKEN = (env as any).CLICKSIGN_ACCESS_TOKEN || ''
 const CLICKSIGN_BASE_URL = (env as any).CLICKSIGN_BASE_URL || 'https://app.clicksign.com/api/v1'
+
+function isClicksignConfigured(): boolean {
+  return CLICKSIGN_TOKEN.length > 0
+}
 
 const AUTH_MAP: Record<string, string> = {
   email: 'email',
@@ -225,6 +231,11 @@ export async function createEnvelope(
   prisma: PrismaClient,
   input: CreateEnvelopeInput,
 ): Promise<EnvelopeResult> {
+  if (!isClicksignConfigured()) {
+    console.warn('[clicksign] CLICKSIGN_ACCESS_TOKEN não configurado — operação de assinatura abortada.')
+    return { success: false, error: 'Clicksign não configurado (CLICKSIGN_ACCESS_TOKEN ausente).' }
+  }
+
   // 1. Create document in Clicksign
   const doc = await createDocument(
     input.fileName,


### PR DESCRIPTION
Achados da varredura estática da plataforma, todos confirmados e corrigidos:

1. **CRÍTICO — Cobrança avulsa LemosBank** (`finance`): PIX vinha nulo (`createCharge` não retorna `pixCode` — agora chama `getPixQrCode`) e a tela de sucesso ficava vazia (shape). Resposta devolve `boletoUrl`/`pixCode`/`pixQrCode` no topo, batendo com o front. Caminho Asaas em try/catch → **502** com msg (era 500 não tratado).
2. **CRÍTICO — NFS-e** (`fiscal`): `createAsaasInvoice` era chamada sem `customer` → Asaas 400 → 500. Agora resolve o proprietário (`findOrCreateCustomer`) e envia `customer`; single-emit em try/catch → 502.
3. **MÉDIO — NFS-e em lote sem validação**: Zod exige `noteIds` OU `month`+`year` (evita emitir todas as notas DRAFT num body vazio — risco financeiro).
4. **ALTO — Sinal de negócio bloqueava comprador PJ**: `cpfCnpj` cai para `contact.cpf || contact.cnpj`.
5. **ALTO — Token Clicksign hardcoded** removido; usa só env + aviso controlado.
6. **MÉDIO — Modelo Anthropic depreciado** no SEO programático → `claude-sonnet-5`.

Validado: guarda de boot 96 módulos; erros TS em `deals:173`/`fiscal:67` são **pré-existentes** (confirmado com/sem o diff), zero erros novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_