### PR TITLE
fix(web): mantém "AgoraEncontrei" como nome do site principal (logo segue dinâmico)

### DIFF
--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -174,14 +174,9 @@ export default async function PublicLayout({ children }: { children: React.React
                 />
                 <div className="flex flex-col leading-none">
                   <span className="font-bold text-base" style={{ fontFamily: 'Arial, Helvetica, sans-serif' }}>
-                    {brand.companyName ? (
-                      <span style={{ color: '#d1d5db', fontWeight: 700 }}>{brand.companyName}</span>
-                    ) : (
-                      <>
-                        <span style={{ color: '#1a5c2a', fontWeight: 700 }}>Agora</span>
-                        <span style={{ color: '#d1d5db', fontWeight: 700 }}>Encontrei</span>
-                      </>
-                    )}
+                    {/* Nome fixo "AgoraEncontrei" (marca do marketplace); logo é dinâmico. */}
+                    <span style={{ color: '#1a5c2a', fontWeight: 700 }}>Agora</span>
+                    <span style={{ color: '#d1d5db', fontWeight: 700 }}>Encontrei</span>
                   </span>
                   <span className="text-[10px] font-medium" style={{ color: '#9ca3af', letterSpacing: '0.04em' }}>Marketplace</span>
                 </div>

--- a/apps/web/src/components/public/Navbar.tsx
+++ b/apps/web/src/components/public/Navbar.tsx
@@ -141,14 +141,11 @@ export function Navbar({ logoUrl, companyName, hasCustomLogo }: NavbarProps = {}
             />
             <div className="flex flex-col leading-none">
               <span className="text-base tracking-tight" style={{ fontFamily: 'Arial, Helvetica, sans-serif', letterSpacing: '-0.01em' }}>
-                {brandName ? (
-                  <span style={{ color: '#d1d5db', fontWeight: 700 }}>{brandName}</span>
-                ) : (
-                  <>
-                    <span style={{ color: '#1a5c2a', fontWeight: 700 }}>Agora</span>
-                    <span style={{ color: '#d1d5db', fontWeight: 700 }}>Encontrei</span>
-                  </>
-                )}
+                {/* Nome fixo "AgoraEncontrei" (identidade do marketplace). O LOGO
+                    é editável pelo admin; o NOME só mudaria via campo dedicado,
+                    p/ não virar o nome legal da empresa (ex.: "Imobiliária Lemos"). */}
+                <span style={{ color: '#1a5c2a', fontWeight: 700 }}>Agora</span>
+                <span style={{ color: '#d1d5db', fontWeight: 700 }}>Encontrei</span>
               </span>
               <span className="text-[9px] font-medium" style={{ color: '#9ca3af', letterSpacing: '0.04em' }}>
                 Marketplace


### PR DESCRIPTION
Correção de acompanhamento do PR #251. A editabilidade fazia o Navbar/footer usarem `company.name` como texto da marca, que está **sempre preenchido** (= "Imobiliária Lemos") — então o site principal passaria a exibir o nome da empresa em vez de **"AgoraEncontrei"** (mudança visível não solicitada).

Agora: o **nome** do marketplace volta a ser fixo "AgoraEncontrei"; o **logo** e as **cores** continuam editáveis pelo admin. Nome editável fica para um campo dedicado futuro (evita usar o nome legal da empresa).

Validado: typecheck limpo em Navbar/layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_