### PR TITLE
fix(seo): sitemap-index instantâneo + timeouts + conteúdo p/ páginas de cidade

### DIFF
--- a/apps/api/src/routes/public/auctions.ts
+++ b/apps/api/src/routes/public/auctions.ts
@@ -1,0 +1,188 @@
+import type { FastifyInstance } from 'fastify'
+import { calculateDealScore } from '../../services/market-intelligence.service.js'
+
+// ── In-memory cache helpers (reuse from parent if available) ──────────────────
+const _memCache = new Map<string, { value: unknown; expiresAt: number }>()
+
+function memCacheGet(key: string): unknown | null {
+  const entry = _memCache.get(key)
+  if (!entry) return null
+  if (Date.now() > entry.expiresAt) { _memCache.delete(key); return null }
+  return entry.value
+}
+
+function memCacheSet(key: string, value: unknown, ttlSeconds: number): void {
+  _memCache.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 })
+}
+
+async function cacheGet(redis: FastifyInstance['redis'], key: string): Promise<unknown | null> {
+  if (redis) {
+    try {
+      const raw = await redis.get(key)
+      if (raw) return JSON.parse(raw)
+    } catch { /* fall through */ }
+  }
+  return memCacheGet(key)
+}
+
+async function cacheSet(redis: FastifyInstance['redis'], key: string, value: unknown, ttl = 600): Promise<void> {
+  if (redis) {
+    try { await redis.setex(key, ttl, JSON.stringify(value)) } catch { /* ignore */ }
+  }
+  memCacheSet(key, value, ttl)
+}
+
+// ── Cidades alvo: Franca e região ─────────────────────────────────────────────
+const TARGET_CITIES = [
+  'FRANCA', 'BATATAIS', 'CRISTAIS PAULISTA', 'PATROCINIO PAULISTA',
+  'ITIRAPUA', 'RESTINGA', 'JERIQUARA', 'PEDREGULHO', 'ALTINOPOLIS',
+  'BRODOWSKI', 'NUPORANGA', 'SALES OLIVEIRA', 'CLARAVAL', 'RIFAINA',
+  'IBIRACI', 'CAPETINGA', 'ITAMOGI', 'PASSOS',
+]
+
+interface AuctionItem {
+  id: string
+  city: string
+  neighborhood: string
+  address: string
+  price: number
+  appraisalValue: number
+  discount: number
+  financeable: boolean
+  description: string
+  saleType: string
+  link: string
+  propertyType: string
+  bedrooms: number
+  totalArea: number
+  privateArea: number
+  landArea: number
+  parkingSpots: number
+}
+
+function parsePropertyType(description: string): string {
+  const d = description.toLowerCase()
+  if (d.includes('apartamento')) return 'Apartamento'
+  if (d.includes('casa')) return 'Casa'
+  if (d.includes('terreno') || d.includes('lote')) return 'Terreno'
+  if (d.includes('galpao') || d.includes('galp')) return 'Galpão'
+  if (d.includes('predio') || d.includes('pr')) return 'Prédio'
+  if (d.includes('sitio') || d.includes('s')) return 'Sítio'
+  if (d.includes('fazenda')) return 'Fazenda'
+  if (d.includes('chacara') || d.includes('ch')) return 'Chácara'
+  return 'Imóvel'
+}
+
+function parseNumber(s: string): number {
+  return parseFloat(s.replace(/\./g, '').replace(',', '.').trim()) || 0
+}
+
+function parseAreaFromDesc(description: string, keyword: string): number {
+  // Match pattern like "72.62 de área total"
+  const re = new RegExp('([\\d,.]+)\\s*de\\s*' + keyword, 'i')
+  const m = description.match(re)
+  return m ? parseFloat(m[1].replace(',', '.')) : 0
+}
+
+export async function auctionsRoute(app: FastifyInstance) {
+  app.get('/auctions', async (_req, reply) => {
+    try {
+      const cacheKey = 'pub:caixa:auctions:SP:v4'
+      const cached = await cacheGet(app.redis, cacheKey)
+      if (cached) return reply.send(cached)
+
+      // Download CSV from Caixa
+      const csvUrl = 'https://venda-imoveis.caixa.gov.br/listaweb/Lista_imoveis_SP.csv'
+      const response = await fetch(csvUrl, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          'Referer': 'https://venda-imoveis.caixa.gov.br/',
+          'Accept': 'text/csv,*/*',
+        },
+        signal: AbortSignal.timeout(25000),
+      })
+
+      if (!response.ok) {
+        app.log.warn({ status: response.status }, '[auctions] Caixa returned non-OK status')
+        return reply.status(502).send({ error: 'CAIXA_UNAVAILABLE', status: response.status })
+      }
+
+      // Decode latin1 -> utf8
+      const buffer = await response.arrayBuffer()
+      const decoder = new TextDecoder('latin1')
+      const csvText = decoder.decode(buffer)
+
+      // Parse CSV (skip 2 header lines)
+      const lines = csvText.split('\n').slice(2)
+      const auctions: AuctionItem[] = []
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        const cols = line.split(';')
+        if (cols.length < 11) continue
+
+        const id = (cols[0] ?? '').trim()
+        const city = (cols[2] ?? '').trim()
+        const neighborhood = (cols[3] ?? '').trim()
+        const address = (cols[4] ?? '').trim()
+        const price = parseNumber(cols[5] ?? '0')
+        const appraisalValue = parseNumber(cols[6] ?? '0')
+        const discount = parseFloat(((cols[7] ?? '0').replace(',', '.').trim())) || 0
+        const financeable = (cols[8] ?? '').trim().toLowerCase() === 'sim'
+        const description = (cols[9] ?? '').trim()
+        const saleType = (cols[10] ?? '').trim()
+        const link = (cols[11] ?? '').trim()
+
+        const propertyType = parsePropertyType(description)
+        const bedroomsMatch = description.match(/(\d+)\s*qto/i)
+        const bedrooms = bedroomsMatch ? parseInt(bedroomsMatch[1]) : 0
+        const totalArea = parseAreaFromDesc(description, 'área\\s*total')
+        const privateArea = parseAreaFromDesc(description, 'área\\s*privativa')
+        const landArea = parseAreaFromDesc(description, 'área\\s*do\\s*terreno')
+        const parkingMatch = description.match(/(\d+)\s*vaga/i)
+        const parkingSpots = parkingMatch ? parseInt(parkingMatch[1]) : 0
+
+        const dealScore = calculateDealScore({
+          precoVenda: price,
+          precoAvaliacao: appraisalValue,
+          area: privateArea || totalArea || undefined,
+          bairro: neighborhood,
+          cidade: city,
+          uf: 'SP',
+          modalidade: saleType,
+        })
+
+        auctions.push({
+          id, city, neighborhood, address,
+          price, appraisalValue, discount, financeable,
+          description, saleType, link, propertyType,
+          bedrooms, totalArea, privateArea, landArea, parkingSpots,
+          dealScore,
+        } as AuctionItem & { dealScore: typeof dealScore })
+      }
+
+      // Sort: Franca first, then by discount descending
+      auctions.sort((a, b) => {
+        const cA = a.city.toUpperCase()
+        const cB = b.city.toUpperCase()
+        const pA = cA.includes('FRANCA') ? 0 : cA.includes('BATATAIS') || cA.includes('PATROCINIO') || cA.includes('CRISTAIS') || cA.includes('RESTINGA') ? 1 : 3
+        const pB = cB.includes('FRANCA') ? 0 : cB.includes('BATATAIS') || cB.includes('PATROCINIO') || cB.includes('CRISTAIS') || cB.includes('RESTINGA') ? 1 : 3
+        if (pA !== pB) return pA - pB
+        return b.discount - a.discount
+      })
+
+      const result = {
+        total: auctions.length,
+        updatedAt: new Date().toISOString(),
+        items: auctions,
+      }
+
+      // Cache for 6 hours
+      await cacheSet(app.redis, cacheKey, result, 21600)
+      return reply.send(result)
+    } catch (err) {
+      app.log.error({ err }, '[auctions] Error fetching Caixa auctions')
+      return reply.status(500).send({ error: 'INTERNAL_ERROR' })
+    }
+  })
+}

--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -1,0 +1,273 @@
+import type { FastifyInstance } from 'fastify'
+
+export default async function visitRoutes(app: FastifyInstance) {
+  // POST /api/v1/public/visits — schedule a visit (public, no auth)
+  app.post('/', async (req, reply) => {
+    const body = req.body as {
+      propertyId: string
+      propertySlug?: string
+      propertyTitle?: string
+      name: string
+      phone: string
+      email?: string
+      preferredDate: string  // ISO date string
+      preferredTime: string  // HH:mm
+      notes?: string
+      website?: string  // honeypot anti-bot
+    }
+
+    // Honeypot: campo invisível preenchido = bot. Sucesso falso, nada criado.
+    if (typeof body.website === 'string' && body.website.trim().length > 0) {
+      return reply.send({ success: true })
+    }
+
+    if (!body.propertyId || !body.name || !body.phone || !body.preferredDate || !body.preferredTime) {
+      return reply.status(400).send({ error: 'MISSING_FIELDS' })
+    }
+
+    // Get the property to find the company
+    const property = await app.prisma.property.findFirst({
+      where: { id: body.propertyId },
+      select: { companyId: true, title: true, street: true, city: true },
+    }).catch(() => null)
+    if (!property) return reply.status(404).send({ error: 'PROPERTY_NOT_FOUND' })
+
+    const companyId = property.companyId
+    const visitDateTime = new Date(`${body.preferredDate}T${body.preferredTime}:00`)
+    if (isNaN(visitDateTime.getTime())) {
+      return reply.status(400).send({ error: 'INVALID_DATE', message: 'Data ou horário inválido.' })
+    }
+    const title = body.propertyTitle ?? property.title ?? 'Imóvel'
+
+    // 1. Find or create a lead (Contact) — best-effort (não pode quebrar o agendamento)
+    let contact: { id: string } | null = null
+    try {
+      contact = await app.prisma.contact.findFirst({
+        where: { phone: body.phone, companyId },
+        select: { id: true },
+      })
+      if (!contact) {
+        contact = await app.prisma.contact.create({
+          data: {
+            name: body.name,
+            phone: body.phone,
+            email: body.email ?? null,
+            companyId,
+            type: 'INDIVIDUAL',
+          },
+          select: { id: true },
+        })
+      }
+    } catch (err) {
+      app.log.warn({ err }, 'visit: contact upsert failed (non-fatal)')
+    }
+
+    // 2. PRINCIPAL: registro estruturado da visita (agenda do dashboard).
+    //    É o critério de sucesso — se isto falhar, retorna erro real.
+    const propertyVisit = await app.prisma.propertyVisit.create({
+      data: {
+        companyId,
+        propertyId: body.propertyId,
+        visitorName: body.name,
+        visitorEmail: body.email ?? null,
+        visitorPhone: body.phone,
+        scheduledAt: visitDateTime,
+        mode: 'in_person',
+        notes: body.notes ?? null,
+      },
+    }).catch((err: unknown) => {
+      app.log.error({ err }, 'visit: propertyVisit.create failed')
+      return null
+    })
+
+    if (!propertyVisit) {
+      return reply.status(500).send({ error: 'SCHEDULE_FAILED', message: 'Não foi possível agendar. Tente novamente.' })
+    }
+
+    // 3. Activity na timeline livre — best-effort.
+    let activity: { id: string } | null = null
+    try {
+      activity = await app.prisma.activity.create({
+        data: {
+          companyId,
+          contactId: contact?.id ?? null,
+          type: 'visit',
+          title: `Visita: ${title}`,
+          description: `Cliente: ${body.name} (${body.phone})\nImóvel: ${title}\nData: ${visitDateTime.toLocaleDateString('pt-BR')} às ${body.preferredTime}\n${body.notes ? `Obs: ${body.notes}` : ''}`,
+          scheduledAt: visitDateTime,
+        },
+        select: { id: true },
+      })
+    } catch (err) {
+      app.log.warn({ err }, 'visit: activity.create failed (non-fatal)')
+    }
+
+    // In-app + e-mail notification for company admins so the visit is
+    // surfaced the moment it is scheduled.
+    try {
+      const { notify } = await import('../../services/notification.service.js')
+      const dateLabel = visitDateTime.toLocaleString('pt-BR', {
+        day: '2-digit', month: '2-digit', year: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      })
+      await notify({
+        prisma: app.prisma,
+        companyId,
+        type: 'visit_requested',
+        title: 'Nova visita agendada',
+        body: `${body.name} agendou uma visita para ${title} em ${dateLabel}.\nTelefone: ${body.phone}${body.notes ? `\nObs: ${body.notes}` : ''}`,
+        payload: {
+          visitId: propertyVisit?.id ?? null,
+          propertyId: body.propertyId,
+          visitorName: body.name,
+          visitorPhone: body.phone,
+          scheduledAt: visitDateTime.toISOString(),
+        },
+      })
+    } catch (err) {
+      app.log.warn({ err }, 'visit notify failed')
+    }
+
+    // 4. Create a Deal (lead pipeline) if not exists — best-effort.
+    try {
+      if (contact) {
+        const existingDeal = await app.prisma.deal.findFirst({
+          where: {
+            contactId: contact.id,
+            companyId,
+            status: { in: ['OPEN', 'IN_PROGRESS'] },
+            properties: { some: { propertyId: body.propertyId } },
+          },
+          select: { id: true },
+        })
+        if (!existingDeal) {
+          const broker = await app.prisma.user.findFirst({
+            where: { companyId, status: 'ACTIVE' },
+            select: { id: true },
+          })
+          if (broker) {
+            await app.prisma.deal.create({
+              data: {
+                companyId,
+                contactId: contact.id,
+                brokerId: broker.id,
+                title: `Visita agendada — ${title}`,
+                status: 'OPEN',
+                value: null,
+                properties: { create: { propertyId: body.propertyId } },
+              },
+            })
+          }
+        }
+      }
+    } catch (err) {
+      app.log.warn({ err }, 'visit: deal creation failed (non-fatal)')
+    }
+
+    // 4. Send WhatsApp to company agent (if configured)
+    const { env } = await import('../../utils/env.js')
+    if (env.WHATSAPP_TOKEN && env.WHATSAPP_PHONE_ID) {
+      try {
+        // Find company's WhatsApp phone number (from settings or first admin user)
+        const company = await app.prisma.company.findUnique({
+          where: { id: companyId },
+          select: { phone: true, name: true },
+        })
+
+        const dateStr = visitDateTime.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: 'long' })
+        const message = `🏠 *Nova Visita Agendada!*\n\n👤 *Cliente:* ${body.name}\n📱 *Telefone:* ${body.phone}${body.email ? `\n📧 *E-mail:* ${body.email}` : ''}\n\n🏡 *Imóvel:* ${title}${property.city ? ` — ${property.city}` : ''}\n\n📅 *Data:* ${dateStr}\n⏰ *Horário:* ${body.preferredTime}${body.notes ? `\n📝 *Obs:* ${body.notes}` : ''}\n\n_Via Portal Imobiliária Lemos_`
+
+        // Use company phone as destination (the agent's WhatsApp)
+        const agentPhone = company?.phone?.replace(/\D/g, '')
+        if (agentPhone && agentPhone.length >= 10) {
+          const destination = agentPhone.startsWith('55') ? agentPhone : `55${agentPhone}`
+          await fetch(`https://graph.facebook.com/v18.0/${env.WHATSAPP_PHONE_ID}/messages`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${env.WHATSAPP_TOKEN}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              messaging_product: 'whatsapp',
+              to: destination,
+              type: 'text',
+              text: { body: message },
+            }),
+          })
+        }
+      } catch (err) {
+        app.log.warn({ err }, 'Failed to send WhatsApp visit notification')
+      }
+    }
+
+    return reply.send({ success: true, visitId: propertyVisit.id, activityId: activity?.id ?? null, contactId: contact?.id ?? null })
+  })
+
+  // GET /api/v1/public/visits/:id/feedback — fetch visit info for the public
+  // feedback page (only returns the bare minimum needed to render the form).
+  app.get('/:id/feedback', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const visit = await app.prisma.propertyVisit.findUnique({
+      where: { id },
+      select: {
+        id: true, visitorName: true, scheduledAt: true,
+        status: true, rating: true, propertyId: true,
+      },
+    }).catch(() => null)
+    if (!visit) return reply.status(404).send({ error: 'NOT_FOUND' })
+
+    const prop = await app.prisma.property.findUnique({
+      where: { id: visit.propertyId },
+      select: { title: true, slug: true, neighborhood: true, city: true },
+    }).catch(() => null)
+
+    return reply.send({
+      id: visit.id,
+      visitorName: visit.visitorName,
+      scheduledAt: visit.scheduledAt,
+      status: visit.status,
+      alreadyRated: visit.rating != null,
+      property: prop,
+    })
+  })
+
+  // POST /api/v1/public/visits/:id/feedback — visitor submits rating + comment.
+  // Only accepted when the visit is marked done and has no rating yet, so the
+  // link can be safely shared (no auth) without risk of overwrite or spam.
+  app.post('/:id/feedback', async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const body = req.body as { rating?: number; feedback?: string }
+    const rating = Math.max(1, Math.min(5, Number(body.rating) || 0))
+    const feedback = (body.feedback ?? '').toString().slice(0, 2000)
+    if (!rating) return reply.status(400).send({ error: 'INVALID_RATING' })
+
+    const visit = await app.prisma.propertyVisit.findUnique({
+      where: { id },
+      select: { id: true, status: true, rating: true, companyId: true, visitorName: true },
+    }).catch(() => null)
+    if (!visit) return reply.status(404).send({ error: 'NOT_FOUND' })
+    if (visit.status !== 'done') return reply.status(409).send({ error: 'VISIT_NOT_COMPLETED' })
+    if (visit.rating != null) return reply.status(409).send({ error: 'ALREADY_RATED' })
+
+    await app.prisma.propertyVisit.update({
+      where: { id },
+      data: { rating, feedback: feedback || null },
+    })
+
+    // Notifica o corretor que o feedback chegou — sinal forte para reabrir o
+    // diálogo com o cliente (proposta, novas opções, etc.).
+    try {
+      const { notify } = await import('../../services/notification.service.js')
+      await notify({
+        prisma: app.prisma,
+        companyId: visit.companyId,
+        type: 'system',
+        title: 'Feedback de visita recebido',
+        body: `${visit.visitorName} avaliou a visita ${rating}/5.${feedback ? `\n"${feedback.slice(0, 200)}"` : ''}`,
+        payload: { visitId: id, rating },
+      })
+    } catch { /* non-fatal */ }
+
+    return reply.send({ success: true })
+  })
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -102,6 +102,12 @@ const nextConfig = {
         source: '/api/v1/:path*',
         destination: `${apiUrl}/api/v1/:path*`,
       },
+      // ── Sub-sitemaps servidos FORA de /api/ ──────────────────────────────
+      // Os sitemaps paginados vivem em /api/sitemap/*, mas /api/ é Disallow no
+      // robots.txt. O Googlebot então falhava ("Não foi possível buscar o
+      // sitemap"). Expomos os mesmos handlers em /sitemaps/* (caminho liberado)
+      // e o sitemap-index aponta para cá — sem depender do Allow /api/sitemap/.
+      { source: '/sitemaps/:path*', destination: '/api/sitemap/:path*' },
       // /health is handled directly by app/health/route.ts — no proxy needed
       // ── SEO Programático: /{categoria}/{cidade} → /seo/{categoria}/{cidade} ──
       // Property types

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { MapPin, Home, Search, ChevronRight } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { CitySeoContent } from '@/components/public/CitySeoContent'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
@@ -338,6 +339,14 @@ export default async function ClusterPage(props: { params: Promise<{ estado: str
             ))}
           </div>
         </section>
+
+        <CitySeoContent
+          cityName={city.name}
+          stateUf={city.state}
+          context={meta.title.toLowerCase()}
+          hasResults={properties.length > 0}
+          relatedLinks={related.map(([k, v]) => ({ href: `/${params.estado}/${params.cidade}/${k}`, label: v.title }))}
+        />
       </div>
 
       {/* Floating CTA */}

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -105,7 +105,9 @@ async function fetchProperties(cityName: string, cluster: string) {
     const purpose = purposeMap[cluster] || 'SALE'
     const type = typeMap[cluster] || ''
     const url = `${API_URL}/api/v1/public/properties?city=${encodeURIComponent(cityName)}&purpose=${purpose}${type ? `&type=${type}` : ''}&limit=9`
-    const r = await fetch(url, { next: { revalidate: 3600 } })
+    // Timeout de 5s: se a API estiver lenta/fria, cai no fallback [] em vez de
+    // travar o render por 60s (causava timeout no build e erro sob rastreamento).
+    const r = await fetch(url, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (r.ok) { const d = await r.json(); return d.data || [] }
   } catch {}
   return []

--- a/apps/web/src/app/(public)/condominios/franca/[condo]/page.tsx
+++ b/apps/web/src/app/(public)/condominios/franca/[condo]/page.tsx
@@ -68,7 +68,7 @@ async function fetchSpecialists(buildingSlug: string) {
   try {
     const res = await fetch(
       `${API_URL}/api/v1/specialists/by-building/${buildingSlug}?limit=6`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) }
     )
     if (!res.ok) return []
     const data = await res.json()

--- a/apps/web/src/app/(public)/imoveis-a-venda/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-a-venda/[cidade]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { MapPin, Home, Search, MessageCircle, Building, TrendingUp } from 'lucide-react'
 import { UNIQUE_CITIES, PROPERTY_TYPES } from '@/data/seo-cities'
 import { canonicalFromCityUf } from '@/lib/seo-canonical'
+import { CitySeoContent } from '@/components/public/CitySeoContent'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const WEB_URL = 'https://www.agoraencontrei.com.br'
@@ -112,6 +113,18 @@ export default async function VendaCidadePage(props: { params: Promise<{ cidade:
           <Link href="/avaliacao" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📊 Avaliar Imóvel</Link>
           <Link href="/anunciar-imovel" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📢 Anunciar</Link>
         </div>
+
+        <CitySeoContent
+          cityName={city.name}
+          stateUf={city.state}
+          context="imóveis à venda"
+          hasResults={properties.length > 0}
+          relatedLinks={[
+            { href: `/imoveis-para-alugar/${params.cidade}`, label: `Alugar em ${city.name}` },
+            { href: `/leilao-imoveis-em/${params.cidade}`, label: `Leilões em ${city.name}` },
+            ...nearby.slice(0, 6).map(c => ({ href: `/imoveis-a-venda/${c.slug}`, label: `${c.name}/${c.state}` })),
+          ]}
+        />
       </div>
     </>
   )

--- a/apps/web/src/app/(public)/imoveis-a-venda/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-a-venda/[cidade]/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata(props: { params: Promise<{ cidade: string
 
 async function fetchProps(cityName: string) {
   try {
-    const r = await fetch(`${API_URL}/api/v1/public/properties?city=${encodeURIComponent(cityName)}&purpose=SALE&limit=12`, { next: { revalidate: 3600 } })
+    const r = await fetch(`${API_URL}/api/v1/public/properties?city=${encodeURIComponent(cityName)}&purpose=SALE&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (r.ok) { const d = await r.json(); return d.data || [] }
   } catch {} return []
 }

--- a/apps/web/src/app/(public)/imoveis-belo-horizonte-mg/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-belo-horizonte-mg/page.tsx
@@ -26,7 +26,7 @@ const BAIRROS = ['Savassi', 'Lourdes', 'Funcionários', 'Buritis', 'Sion', 'Serr
 
 async function fetchProperties() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Belo Horizonte&limit=12`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Belo Horizonte&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []
@@ -35,7 +35,7 @@ async function fetchProperties() {
 
 async function fetchAuctions() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=Belo Horizonte&limit=6`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=Belo Horizonte&limit=6`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/imoveis-brasilia-df/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-brasilia-df/page.tsx
@@ -26,7 +26,7 @@ const BAIRROS = ['Asa', 'Sul', 'Asa', 'Norte', 'Lago', 'Sul', 'Lago', 'Norte', '
 
 async function fetchProperties() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Brasília&limit=12`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Brasília&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []
@@ -35,7 +35,7 @@ async function fetchProperties() {
 
 async function fetchAuctions() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=Brasília&limit=6`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=Brasília&limit=6`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/imoveis-curitiba-pr/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-curitiba-pr/page.tsx
@@ -26,7 +26,7 @@ const BAIRROS = ['Batel', 'Água', 'Verde', 'Ecoville', 'Cabral', 'Juvevê', 'Cr
 
 async function fetchProperties() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Curitiba&limit=12`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Curitiba&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []
@@ -35,7 +35,7 @@ async function fetchProperties() {
 
 async function fetchAuctions() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=Curitiba&limit=6`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=Curitiba&limit=6`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/imoveis-goiania-go/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-goiania-go/page.tsx
@@ -26,7 +26,7 @@ const BAIRROS = ['Setor', 'Bueno', 'Setor', 'Marista', 'Jardim', 'Goiás', 'Seto
 
 async function fetchProperties() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Goiânia&limit=12`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?city=Goiânia&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []
@@ -35,7 +35,7 @@ async function fetchProperties() {
 
 async function fetchAuctions() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=Goiânia&limit=6`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=Goiânia&limit=6`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/imoveis-para-alugar/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-para-alugar/[cidade]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { MapPin, Home, Search, MessageCircle, Building, TrendingUp } from 'lucide-react'
 import { UNIQUE_CITIES, PROPERTY_TYPES } from '@/data/seo-cities'
 import { canonicalFromCityUf } from '@/lib/seo-canonical'
+import { CitySeoContent } from '@/components/public/CitySeoContent'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const WEB_URL = 'https://www.agoraencontrei.com.br'
@@ -111,6 +112,18 @@ export default async function AluguelCidadePage(props: { params: Promise<{ cidad
           <Link href="/avaliacao" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📊 Avaliar Imóvel</Link>
           <Link href="/anunciar-imovel" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📢 Anunciar</Link>
         </div>
+
+        <CitySeoContent
+          cityName={city.name}
+          stateUf={city.state}
+          context="imóveis para alugar"
+          hasResults={properties.length > 0}
+          relatedLinks={[
+            { href: `/imoveis-a-venda/${params.cidade}`, label: `Comprar em ${city.name}` },
+            { href: `/leilao-imoveis-em/${params.cidade}`, label: `Leilões em ${city.name}` },
+            ...nearby.slice(0, 6).map(c => ({ href: `/imoveis-para-alugar/${c.slug}`, label: `${c.name}/${c.state}` })),
+          ]}
+        />
       </div>
     </>
   )

--- a/apps/web/src/app/(public)/imoveis-para-alugar/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-para-alugar/[cidade]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(props: { params: Promise<{ cidade: string
 
 async function fetchProps(cityName: string) {
   try {
-    const r = await fetch(`${API_URL}/api/v1/public/properties?city=${encodeURIComponent(cityName)}&purpose=RENT&limit=12`, { next: { revalidate: 3600 } })
+    const r = await fetch(`${API_URL}/api/v1/public/properties?city=${encodeURIComponent(cityName)}&purpose=RENT&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (r.ok) { const d = await r.json(); return d.data || [] }
   } catch {} return []
 }

--- a/apps/web/src/app/(public)/imoveis-sao-paulo-sp/page.tsx
+++ b/apps/web/src/app/(public)/imoveis-sao-paulo-sp/page.tsx
@@ -26,7 +26,7 @@ const BAIRROS = ['Pinheiros', 'Vila', 'Mariana', 'Moema', 'Itaim', 'Bibi', 'Broo
 
 async function fetchProperties() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?city=São Paulo&limit=12`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?city=São Paulo&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []
@@ -35,7 +35,7 @@ async function fetchProperties() {
 
 async function fetchAuctions() {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=São Paulo&limit=6`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=São Paulo&limit=6`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
@@ -83,7 +83,7 @@ async function fetchNearbyProperties(city: string, neighborhood?: string) {
   try {
     const params = new URLSearchParams({ city, limit: '12', sortBy: 'createdAt', sortOrder: 'desc' })
     if (neighborhood) params.set('neighborhood', neighborhood)
-    const res = await fetch(`${API_URL}/api/v1/public/properties?${params}`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/public/properties?${params}`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return data.data || []

--- a/apps/web/src/app/(public)/leilao-imoveis-em/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis-em/[cidade]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(props: { params: Promise<{ cidade: string
 
 async function fetchProps(cityName: string) {
   try {
-    const r = await fetch(`${API_URL}/api/v1/auctions?city=${encodeURIComponent(cityName)}&purpose=SALE&limit=12`, { next: { revalidate: 3600 } })
+    const r = await fetch(`${API_URL}/api/v1/auctions?city=${encodeURIComponent(cityName)}&purpose=SALE&limit=12`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (r.ok) { const d = await r.json(); return d.data || [] }
   } catch {} return []
 }

--- a/apps/web/src/app/(public)/leilao-imoveis-em/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis-em/[cidade]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { MapPin, Home, Search, MessageCircle, Building, TrendingUp } from 'lucide-react'
 import { UNIQUE_CITIES, PROPERTY_TYPES } from '@/data/seo-cities'
 import { canonicalFromCityUf } from '@/lib/seo-canonical'
+import { CitySeoContent } from '@/components/public/CitySeoContent'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const WEB_URL = 'https://www.agoraencontrei.com.br'
@@ -111,6 +112,18 @@ export default async function LeilaoCidadePage(props: { params: Promise<{ cidade
           <Link href="/avaliacao" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📊 Avaliar Imóvel</Link>
           <Link href="/anunciar-imovel" className="text-center p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition text-sm">📢 Anunciar</Link>
         </div>
+
+        <CitySeoContent
+          cityName={city.name}
+          stateUf={city.state}
+          context="imóveis em leilão"
+          hasResults={properties.length > 0}
+          relatedLinks={[
+            { href: `/imoveis-a-venda/${params.cidade}`, label: `Comprar em ${city.name}` },
+            { href: `/imoveis-para-alugar/${params.cidade}`, label: `Alugar em ${city.name}` },
+            ...nearby.slice(0, 6).map(c => ({ href: `/leilao-imoveis-em/${c.slug}`, label: `${c.name}/${c.state}` })),
+          ]}
+        />
       </div>
     </>
   )

--- a/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
@@ -76,7 +76,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 async function fetchAuctions(bairro: string, cidade: string) {
   // Try API
   try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?city=${encodeURIComponent(cidade)}&search=${encodeURIComponent(bairro)}&limit=20`, { next: { revalidate: 3600 } })
+    const res = await fetch(`${API_URL}/api/v1/auctions?city=${encodeURIComponent(cidade)}&search=${encodeURIComponent(bairro)}&limit=20`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (res.ok) { const d = await res.json(); if (d.data?.length > 0) return d.data }
   } catch {}
   // Try Supabase
@@ -84,7 +84,7 @@ async function fetchAuctions(bairro: string, cidade: string) {
     try {
       const res = await fetch(
         `${SUPABASE_URL}/rest/v1/auctions?select=*&or=(neighborhood.ilike.*${encodeURIComponent(bairro)}*,city.ilike.*${encodeURIComponent(cidade)}*)&status=not.in.(CANCELLED,CLOSED)&limit=20`,
-        { headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${SUPABASE_ANON_KEY}` }, next: { revalidate: 3600 } }
+        { headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${SUPABASE_ANON_KEY}` }, next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) }
       )
       if (res.ok) return res.json()
     } catch {}

--- a/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
@@ -65,7 +65,7 @@ async function fetchData(
   try {
     const res = await fetch(
       `${API_URL}/api/v1/public/property-intelligence?city=${cidade}&state=${estado}`,
-      { next: { revalidate: 3600 } },
+      { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) },
     )
     if (!res.ok) throw new Error(`API ${res.status}`)
     return (await res.json()) as PropertyIntel

--- a/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
@@ -77,7 +77,7 @@ async function fetchProperties(cityName: string, cat: SeoCategoria) {
     const qs = new URLSearchParams({ city: cityName, limit: '9' })
     if (cat.apiFilter.purpose) qs.set('purpose', cat.apiFilter.purpose)
     if (cat.apiFilter.type) qs.set('type', cat.apiFilter.type)
-    const r = await fetch(`${API_URL}/api/v1/public/properties?${qs}`, { next: { revalidate: 3600 } })
+    const r = await fetch(`${API_URL}/api/v1/public/properties?${qs}`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })
     if (r.ok) { const d = await r.json(); return d.data || [] }
   } catch {}
   return []

--- a/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/seo/[categoria]/[cidade]/page.tsx
@@ -12,6 +12,7 @@ import { notFound } from 'next/navigation'
 import { MapPin, Search, ChevronRight, Home, ArrowRight } from 'lucide-react'
 import { SEO_CATEGORIAS_MAP, type SeoCategoria } from '@/data/seo-categorias'
 import { UNIQUE_CITIES } from '@/data/seo-cities'
+import { CitySeoContent } from '@/components/public/CitySeoContent'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://www.agoraencontrei.com.br'
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
@@ -368,6 +369,14 @@ export default async function SeoCidadePage(
             </a>
           </div>
         </section>
+
+        <CitySeoContent
+          cityName={city.name}
+          stateUf={city.state}
+          context={cat.titulo.toLowerCase()}
+          hasResults={properties.length > 0}
+          relatedLinks={related.map(r => ({ href: `/${r.slug}/${params.cidade}`, label: r.titulo }))}
+        />
       </div>
     </>
   )

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -52,7 +52,7 @@ export default function robots(): MetadataRoute.Robots {
       `${WEB_URL}/sitemap-index.xml`,
       // Sitemap dedicado de Franca (máxima prioridade)
       `${WEB_URL}/sitemap-franca.xml`,
-      `${WEB_URL}/api/sitemap/blog`,
+      `${WEB_URL}/sitemaps/blog`,
     ],
     host: WEB_URL,
   }

--- a/apps/web/src/app/sitemap-index.xml/route.ts
+++ b/apps/web/src/app/sitemap-index.xml/route.ts
@@ -42,29 +42,29 @@ export async function GET() {
   // 3. Sitemaps de cidades (paginados)
   const cidadePages = Math.ceil(CIDADES_TOTAL / URLS_PER_SITEMAP)
   for (let i = 0; i < cidadePages; i++) {
-    sitemaps.push(`<sitemap><loc>${WEB_URL}/api/sitemap/cidades?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
+    sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemaps/cidades?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
   }
 
   // 4. Sitemaps de comparações (paginados)
   const compPages = Math.ceil(COMPARACOES_TOTAL / URLS_PER_SITEMAP)
   for (let i = 0; i < compPages; i++) {
-    sitemaps.push(`<sitemap><loc>${WEB_URL}/api/sitemap/comparacoes?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
+    sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemaps/comparacoes?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
   }
 
   // 5. Sitemaps de leilões por cidade (paginados) — /leilao/[estado]/[cidade]
   const leilaoPages = Math.ceil(LEILAO_PAGES_TOTAL / URLS_PER_SITEMAP)
   for (let i = 0; i < leilaoPages; i++) {
-    sitemaps.push(`<sitemap><loc>${WEB_URL}/api/sitemap/leiloes?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
+    sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemaps/leiloes?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
   }
 
   // 6. Sitemaps de bairros (paginados) — /[estado]/[cidade]/bairro/[bairro]
   const bairroPages = Math.ceil(BAIRROS_TOTAL / URLS_PER_SITEMAP)
   for (let i = 0; i < bairroPages; i++) {
-    sitemaps.push(`<sitemap><loc>${WEB_URL}/api/sitemap/bairros?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
+    sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemaps/bairros?page=${i}</loc><lastmod>${now}</lastmod></sitemap>`)
   }
 
   // 7. Blog
-  sitemaps.push(`<sitemap><loc>${WEB_URL}/api/sitemap/blog</loc><lastmod>${now}</lastmod></sitemap>`)
+  sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemaps/blog</loc><lastmod>${now}</lastmod></sitemap>`)
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/apps/web/src/app/sitemap-index.xml/route.ts
+++ b/apps/web/src/app/sitemap-index.xml/route.ts
@@ -8,7 +8,7 @@
  * GET /sitemap-index.xml
  */
 import { NextResponse } from 'next/server'
-import { buildSitemapEntries, SITEMAP_CHUNK_SIZE } from '@/lib/sitemap-entries'
+import { sitemapChunkCount } from '@/lib/sitemap-entries'
 
 const WEB_URL = 'https://www.agoraencontrei.com.br'
 
@@ -27,14 +27,9 @@ export async function GET() {
   sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemap-franca.xml</loc><lastmod>${now}</lastmod></sitemap>`)
 
   // 2. Sitemap core, fatiado pelo Next (generateSitemaps → /sitemap/{id}.xml).
-  //    Contamos os chunks a partir do mesmo builder usado em app/sitemap.ts.
-  let coreChunks = 1
-  try {
-    const entries = await buildSitemapEntries()
-    coreChunks = Math.max(1, Math.ceil(entries.length / SITEMAP_CHUNK_SIZE))
-  } catch {
-    coreChunks = 2 // fallback conservador (~66k URLs ⇒ 2 chunks de 40k)
-  }
+  //    Contagem BARATA (sem fetch) — idêntica à usada por generateSitemaps,
+  //    então o índice responde instantâneo e nunca estoura o tempo do Googlebot.
+  const coreChunks = sitemapChunkCount()
   for (let i = 0; i < coreChunks; i++) {
     sitemaps.push(`<sitemap><loc>${WEB_URL}/sitemap/${i}.xml</loc><lastmod>${now}</lastmod></sitemap>`)
   }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next'
-import { buildSitemapEntries, SITEMAP_CHUNK_SIZE } from '@/lib/sitemap-entries'
+import { buildSitemapEntries, sitemapChunkCount, SITEMAP_CHUNK_SIZE } from '@/lib/sitemap-entries'
 
 /**
  * Sitemap principal — fatiado para respeitar o limite de 50.000 URLs do Google.
@@ -12,8 +12,8 @@ import { buildSitemapEntries, SITEMAP_CHUNK_SIZE } from '@/lib/sitemap-entries'
  */
 
 export async function generateSitemaps(): Promise<{ id: number }[]> {
-  const entries = await buildSitemapEntries()
-  const count = Math.max(1, Math.ceil(entries.length / SITEMAP_CHUNK_SIZE))
+  // Contagem barata (sem fetch) — precisa bater com o sitemap-index.xml.
+  const count = sitemapChunkCount()
   return Array.from({ length: count }, (_, id) => ({ id }))
 }
 

--- a/apps/web/src/components/public/CitySeoContent.tsx
+++ b/apps/web/src/components/public/CitySeoContent.tsx
@@ -1,0 +1,131 @@
+import Link from 'next/link'
+import { Gavel, FileSearch, Megaphone, Users, Handshake, ArrowRight, Building2 } from 'lucide-react'
+
+/**
+ * Bloco de conteúdo para páginas de cidade — evita páginas "vazias/rasas".
+ *
+ * Quando uma página programática de cidade não tem imóvel em estoque, este
+ * bloco vira o conteúdo principal: oferta dos serviços da AgoraEncontrei
+ * (avaliação, leilão, anúncio, corretor, planos) + buscas relacionadas reais
+ * (internal linking). Também aparece abaixo das listagens quando há imóveis,
+ * reforçando conteúdo e links internos.
+ *
+ * O texto varia por cidade (determinístico) para reduzir duplicação — o Google
+ * penaliza milhares de páginas com texto idêntico ("doorway pages").
+ */
+
+interface RelatedLink {
+  href: string
+  label: string
+}
+
+interface Props {
+  cityName: string
+  stateUf?: string
+  /** Ex.: "imóveis à venda", "imóveis para alugar", "imóveis em leilão". */
+  context?: string
+  /** Links de busca relacionada (cidades próximas, categorias irmãs). */
+  relatedLinks?: RelatedLink[]
+  /** Quando false, este bloco é o conteúdo principal (página sem estoque). */
+  hasResults?: boolean
+}
+
+const SERVICES = [
+  { href: '/avaliacao', icon: FileSearch, title: 'Avaliação de imóvel grátis', desc: 'Descubra o valor de mercado com laudo baseado em dados reais.' },
+  { href: '/leiloes', icon: Gavel, title: 'Leilões de imóveis', desc: 'Oportunidades com desconto — Caixa, bancos e leilões judiciais.' },
+  { href: '/anunciar-imovel', icon: Megaphone, title: 'Anuncie seu imóvel', desc: 'Divulgue nos principais portais com anúncio otimizado por IA.' },
+  { href: '/corretores', icon: Users, title: 'Fale com um corretor', desc: 'Especialistas locais para comprar, vender ou alugar com segurança.' },
+  { href: '/parceiros/cadastro', icon: Handshake, title: 'Sou corretor / imobiliária', desc: 'CRM, automação e captação de leads no plano para profissionais.' },
+]
+
+/** Variações determinísticas de texto por cidade (evita conteúdo idêntico). */
+function intro(cityName: string, stateUf: string | undefined, context: string): string {
+  const loc = stateUf ? `${cityName}/${stateUf}` : cityName
+  const variants = [
+    `O mercado de ${context} em ${loc} está em constante movimento. A AgoraEncontrei reúne imóveis, leilões e serviços imobiliários para você fechar o melhor negócio na cidade com segurança e transparência.`,
+    `Procurando ${context} em ${loc}? Além das oportunidades listadas, a AgoraEncontrei oferece avaliação, leilões e apoio de corretores locais para cada etapa da sua decisão em ${cityName}.`,
+    `Em ${loc}, encontrar ${context} fica mais simples com a AgoraEncontrei: comparamos preços, mapeamos leilões e conectamos você a profissionais da região para uma compra ou locação sem dor de cabeça.`,
+  ]
+  // Índice determinístico a partir do nome (mesma cidade → mesmo texto sempre).
+  const idx = cityName.split('').reduce((a, c) => a + c.charCodeAt(0), 0) % variants.length
+  return variants[idx]
+}
+
+export function CitySeoContent({ cityName, stateUf, context = 'imóveis', relatedLinks = [], hasResults = false }: Props) {
+  return (
+    <section className="mt-10 space-y-8">
+      {!hasResults && (
+        <div className="bg-white rounded-2xl border p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <Building2 className="w-5 h-5" style={{ color: '#C9A84C' }} />
+            <h2 className="text-xl font-bold" style={{ color: '#143A1F', fontFamily: 'Georgia, serif' }}>
+              {context.charAt(0).toUpperCase() + context.slice(1)} em {cityName}{stateUf ? `/${stateUf}` : ''}
+            </h2>
+          </div>
+          <p className="text-gray-600 leading-relaxed">{intro(cityName, stateUf, context)}</p>
+        </div>
+      )}
+
+      {/* Serviços da AgoraEncontrei */}
+      <div>
+        <h2 className="text-lg font-bold mb-4" style={{ color: '#143A1F', fontFamily: 'Georgia, serif' }}>
+          Serviços da AgoraEncontrei em {cityName}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {SERVICES.map(s => {
+            const Icon = s.icon
+            return (
+              <Link key={s.href} href={s.href}
+                className="group bg-white rounded-2xl border p-5 hover:border-[#C9A84C] hover:shadow-md transition-all">
+                <div className="flex items-center gap-2 mb-2">
+                  <Icon className="w-5 h-5" style={{ color: '#143A1F' }} />
+                  <h3 className="font-bold text-sm text-gray-800">{s.title}</h3>
+                </div>
+                <p className="text-xs text-gray-500 leading-relaxed">{s.desc}</p>
+                <span className="mt-3 inline-flex items-center gap-1 text-xs font-bold" style={{ color: '#143A1F' }}>
+                  Saiba mais <ArrowRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+                </span>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Buscas relacionadas (internal linking) */}
+      {relatedLinks.length > 0 && (
+        <div>
+          <h2 className="text-lg font-bold mb-4" style={{ color: '#143A1F', fontFamily: 'Georgia, serif' }}>
+            Buscas relacionadas
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {relatedLinks.map(l => (
+              <Link key={l.href} href={l.href}
+                className="flex items-center justify-between p-3 bg-white rounded-xl border hover:border-[#C9A84C] transition-all text-sm">
+                <span className="font-medium text-gray-700 truncate">{l.label}</span>
+                <ArrowRight className="w-4 h-4 text-gray-400 shrink-0" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* CTA final */}
+      <div className="bg-gradient-to-br from-[#143A1F] to-[#0f1c3a] rounded-2xl p-6 text-center text-white">
+        <p className="text-lg font-bold mb-1" style={{ fontFamily: 'Georgia, serif' }}>
+          Não encontrou o imóvel ideal em {cityName}?
+        </p>
+        <p className="text-white/70 text-sm mb-4">
+          Fale com a AgoraEncontrei e receba oportunidades selecionadas na sua região.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link href="/imoveis" className="px-5 py-2.5 rounded-xl font-bold text-sm" style={{ background: '#C9A84C', color: '#143A1F' }}>
+            Ver todos os imóveis
+          </Link>
+          <Link href="/contato" className="px-5 py-2.5 rounded-xl font-bold text-sm bg-white/10 border border-white/20">
+            Falar com especialista
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/lib/sitemap-entries.ts
+++ b/apps/web/src/lib/sitemap-entries.ts
@@ -3,12 +3,15 @@ import type { MetadataRoute } from 'next'
 /**
  * Fonte única de verdade das URLs do sitemap principal.
  *
- * Extraído de app/sitemap.ts para ser reutilizado por:
+ * Usado por:
  *   - app/sitemap.ts            → chunking via generateSitemaps() (<50k por arquivo)
  *   - app/sitemap-index.xml     → contagem de chunks para montar o <sitemapindex>
  *
- * O Google rejeita sitemaps com mais de 50.000 URLs. Como este builder gera
- * ~66k URLs, o arquivo é fatiado em pedaços de SITEMAP_CHUNK_SIZE.
+ * IMPORTANTE (perf): o índice e o generateSitemaps só precisam da CONTAGEM de
+ * chunks — que é calculada por sitemapChunkCount() a partir das URLs ESTÁTICAS
+ * (sem nenhum fetch). Só o conteúdo real de cada /sitemap/{id}.xml chama
+ * buildSitemapEntries() (que inclui os fetches dinâmicos, com timeout). Assim o
+ * /sitemap-index.xml responde instantâneo e nunca estoura o tempo do Googlebot.
  */
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL ?? 'https://www.agoraencontrei.com.br'
@@ -16,6 +19,9 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
 /** Máximo de URLs por arquivo de sitemap (limite do Google é 50.000). */
 export const SITEMAP_CHUNK_SIZE = 40000
+
+/** Timeout dos fetches dinâmicos — em cache frio a API não pode travar o build. */
+const FETCH_TIMEOUT_MS = 8000
 
 // ── Landing pages ───────────────────────────────────────────────────────────
 const LANDING_PAGES = [
@@ -201,13 +207,12 @@ const SEO_CITIES = [
 ]
 
 /**
- * Constrói TODAS as URLs do sitemap principal (estáticas + dinâmicas da API).
- * Chamado por app/sitemap.ts (fatiado) e app/sitemap-index.xml (contagem).
+ * Todas as URLs ESTÁTICAS (determinísticas, sem nenhum fetch de rede).
+ * É o grosso do sitemap (~60k URLs) e é barato de construir.
  */
-export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
+export function buildStaticEntries(): MetadataRoute.Sitemap {
   const now = new Date()
 
-  // ── Core pages ──────────────────────────────────────────────────────────
   const core: MetadataRoute.Sitemap = [
     { url: WEB_URL, lastModified: now, changeFrequency: 'daily', priority: 1.0 },
     { url: `${WEB_URL}/imoveis`, lastModified: now, changeFrequency: 'hourly', priority: 0.95 },
@@ -234,68 +239,51 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
     { url: `${WEB_URL}/contato`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
   ]
 
-  // ── Landing pages (alta prioridade SEO) ──────────────────────────────────
   const landings = LANDING_PAGES.map(p => ({
     url: `${WEB_URL}${p}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.95,
   }))
 
-  // ── Serviços ──────────────────────────────────────────────────────────────
   const servicos = SERVICOS.map(p => ({
     url: `${WEB_URL}${p}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75,
   }))
 
-  // ── Cidades regionais ────────────────────────────────────────────────────
   const cidades = CIDADES_REGIONAIS.map(c => ({
     url: `${WEB_URL}/imoveis-${c}-sp`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85,
   }))
-  // Hub regional
   cidades.push({ url: `${WEB_URL}/imoveis-regiao-franca-sp`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.9 })
 
   const vendaPages = SEO_CITIES.map(c => ({ url: `${WEB_URL}/imoveis-a-venda/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 }))
   const aluguelPages = SEO_CITIES.map(c => ({ url: `${WEB_URL}/imoveis-para-alugar/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 }))
   const leilaoCidadePages = SEO_CITIES.map(c => ({ url: `${WEB_URL}/leilao-imoveis-em/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 }))
 
-  // ── Capitais (alta prioridade) ────────────────────────────────────────────
   const capitais = [
     'sao-paulo-sp', 'belo-horizonte-mg', 'curitiba-pr', 'goiania-go', 'brasilia-df',
   ].map(c => ({
     url: `${WEB_URL}/imoveis-${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.95,
   }))
 
-  // ── Bairros de Franca ────────────────────────────────────────────────────
   const bairros = BAIRROS_FRANCA.map(b => ({
     url: `${WEB_URL}/bairros/franca/${b}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
   }))
 
-  // ── Condomínios ──────────────────────────────────────────────────────────
   const condominios = CONDOMINIOS.map(c => ({
     url: `${WEB_URL}/condominios/franca/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.85,
   }))
 
-  // ── Leilão em TODOS os bairros de Franca ─────────────────────────────────
   const leilaoBairrosFranca = BAIRROS_FRANCA.map(b => ({
     url: `${WEB_URL}/leilao-imoveis/${b}-franca-sp`,
-    lastModified: now,
-    changeFrequency: 'weekly' as const,
-    priority: 0.8,
+    lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
   }))
-  // Venda por bairro — usa a rota indexável /imoveis/em/franca/{bairro}
   const vendaBairrosFranca = BAIRROS_FRANCA.map(b => ({
     url: `${WEB_URL}/imoveis/em/franca/${b}`,
-    lastModified: now,
-    changeFrequency: 'weekly' as const,
-    priority: 0.75,
+    lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75,
   }))
   const aluguelBairrosFranca: MetadataRoute.Sitemap = []
-  // Leilão em todos os condomínios
   const leilaoCondominios = CONDOMINIOS.map(c => ({
     url: `${WEB_URL}/leilao-imoveis/${c.replace('condominio-', '')}-franca-sp`,
-    lastModified: now,
-    changeFrequency: 'weekly' as const,
-    priority: 0.8,
+    lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
   }))
 
-  // ── Leilão por Bairro (SEO programático) ────────────────────────────────
   const leilaoBairroSlugs = [
     'centro-franca-sp', 'jardim-petraglia-franca-sp', 'city-petropolis-franca-sp',
     'vila-santa-cruz-franca-sp', 'jardim-paulista-franca-sp', 'jardim-california-franca-sp',
@@ -310,12 +298,9 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
   ]
   const leilaoBairros = leilaoBairroSlugs.map(slug => ({
     url: `${WEB_URL}/leilao-imoveis/${slug}`,
-    lastModified: now,
-    changeFrequency: 'daily' as const,
-    priority: 0.9,
+    lastModified: now, changeFrequency: 'daily' as const, priority: 0.9,
   }))
 
-  // ── POIs (Pontos de Interesse) ──────────────────────────────────────────
   const poiSlugs = [
     'uni-franca', 'unesp-franca', 'shopping-franca', 'shopping-boulevard',
     'santa-casa-franca', 'hospital-regional', 'sesi-franca', 'senai-franca',
@@ -326,96 +311,102 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
   ]
   const pois = poiSlugs.map(slug => ({
     url: `${WEB_URL}/imoveis/perto-de/${slug}`,
-    lastModified: now,
-    changeFrequency: 'weekly' as const,
-    priority: 0.8,
+    lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
   }))
 
-  // ── Landing pages de leilão por bairro (Manus) ────────────────────────────
   const leilaoBairrosManus = LEILAO_BAIRROS.map(slug => ({
     url: `${WEB_URL}/leiloes/${slug}`,
-    lastModified: now,
-    changeFrequency: 'daily' as const,
-    priority: 0.92,
+    lastModified: now, changeFrequency: 'daily' as const, priority: 0.92,
   }))
 
-  // ── Leilões (dinâmicos da API) ────────────────────────────────────────────
-  let leiloes: MetadataRoute.Sitemap = []
-  try {
-    const res = await fetch(`${API_URL}/api/v1/auctions?limit=500&sortBy=createdAt&sortOrder=desc`, { next: { revalidate: 3600 } })
-    if (res.ok) {
-      const data = await res.json()
-      leiloes = (data.data ?? []).map((a: any) => ({
-        url: `${WEB_URL}/leiloes/${a.slug}`,
-        lastModified: new Date(a.updatedAt ?? now),
-        changeFrequency: 'daily' as const,
-        priority: 0.85,
-      }))
-    }
-  } catch {}
+  // ── 152 cidades IBGE: rotas /{estado}/{cidade} ─────────────────────────
+  const ibge: MetadataRoute.Sitemap = (() => {
+    try {
+      const { IBGE_CITIES_152 } = require('@/data/seo-ibge-cities-expanded')
+      const CLUSTER_SLUGS = [
+        'imoveis-a-venda', 'imoveis-para-alugar', 'casas-a-venda', 'apartamentos-a-venda',
+        'terrenos-a-venda', 'condominios-fechados', 'lancamentos-imobiliarios', 'imoveis-comerciais',
+        'leilao-de-imoveis', 'imoveis-para-investir', 'imoveis-caixa',
+        'chacaras-a-venda', 'sitios-a-venda', 'loteamentos', 'imoveis-rurais',
+      ]
+      const GUIA_SLUGS = [
+        'melhores-bairros-para-morar', 'custo-de-vida', 'como-comprar-imovel',
+        'como-alugar-imovel', 'financiamento-imobiliario', 'melhores-construtoras',
+        'bairros-mais-valorizados', 'onde-morar-em', 'precos-de-imoveis', 'mercado-imobiliario',
+      ]
+      const SERVICO_SLUGS = [
+        'arquiteto', 'engenheiro-civil', 'pedreiro', 'empreiteira', 'construtora',
+        'avaliacao-de-imovel', 'vistoria-de-imovel', 'topografia',
+        'regularizacao-de-imovel', 'fotografia-de-imovel', 'drone', 'decoracao-de-interiores',
+        'avaliacao-online-de-imovel', 'quanto-vale-meu-imovel', 'preco-do-metro-quadrado',
+        'fotos-de-imovel-com-ia', 'tour-virtual-360', 'home-staging-virtual',
+        'video-com-drone', 'planta-humanizada',
+        'anuncio-de-imovel-com-ia', 'divulgar-imovel-nos-portais', 'anunciar-imovel-gratis',
+        'captacao-de-imoveis',
+        'crm-imobiliario', 'automacao-de-leads', 'atendimento-com-ia', 'whatsapp-imobiliario',
+        'funil-de-vendas-imobiliario', 'lead-scoring',
+        'software-para-imobiliaria', 'gestao-de-aluguel', 'gestao-de-locacao',
+        'repasse-ao-proprietario', 'cobranca-de-aluguel', 'contrato-digital',
+        'administracao-de-imoveis',
+        'plano-para-corretor', 'assinatura-corretor', 'plano-para-imobiliaria',
+        'site-para-corretor', 'programa-de-afiliados', 'seja-um-parceiro',
+      ]
+      const INVEST_SLUGS = [
+        'leilao-de-imoveis', 'leilao-judicial-de-imoveis', 'imoveis-caixa',
+        'imoveis-retomados', 'investimento-imobiliario', 'imoveis-para-investir',
+        'fundos-imobiliarios', 'arrematacao-de-imoveis',
+      ]
+      const MOD_SLUGS = [
+        'para-investidor', 'para-proprietario', 'alto-padrao', 'popular',
+        'minha-casa-minha-vida', 'para-empresa', 'residencial', 'comercial',
+        'alto-retorno', 'baixo-risco', 'para-familia', 'perto-de-escola',
+        'com-home-office', 'para-airbnb',
+      ]
+      const TOP_CLUSTERS_FOR_MODS = [
+        'imoveis-a-venda', 'imoveis-para-alugar', 'casas-a-venda',
+        'apartamentos-a-venda', 'leilao-de-imoveis',
+      ]
+      const cities = IBGE_CITIES_152 as any[]
 
-  // ── Imóveis individuais (dinâmicos da API) ────────────────────────────────
-  let imoveis: MetadataRoute.Sitemap = []
-  try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?limit=2000`, { next: { revalidate: 3600 } })
-    if (res.ok) {
-      const data = await res.json()
-      imoveis = (data.data ?? []).map((p: any) => ({
-        url: `${WEB_URL}/imoveis/${p.slug}`,
-        lastModified: new Date(p.updatedAt ?? now),
-        changeFrequency: 'weekly' as const,
-        priority: 0.75,
+      const cityHubs = cities.map((c: any) => ({
+        url: `${WEB_URL}/${c.stateSlug}/${c.slug}`,
+        lastModified: now, changeFrequency: 'weekly' as const, priority: 0.85,
       }))
-    }
-  } catch {}
-
-  // ── Blog (posts + categories + clusters) ────────────────────────────────────
-  let blog: MetadataRoute.Sitemap = []
-  try {
-    const [postsRes, catsRes, clustersRes] = await Promise.all([
-      fetch(`${API_URL}/api/v1/blog?limit=500`, { next: { revalidate: 3600 } }),
-      fetch(`${API_URL}/api/v1/blog/categories`, { next: { revalidate: 3600 } }),
-      fetch(`${API_URL}/api/v1/blog/clusters`, { next: { revalidate: 3600 } }),
-    ])
-    if (postsRes.ok) {
-      const data = await postsRes.json()
-      blog = (data.data ?? []).map((p: any) => ({
-        url: `${WEB_URL}/blog/${p.slug}`,
-        lastModified: new Date(p.publishedAt ?? now),
-        changeFrequency: 'monthly' as const,
-        priority: p.featured ? 0.85 : 0.65,
-      }))
-    }
-    if (catsRes.ok) {
-      const data = await catsRes.json()
-      for (const cat of (data.data ?? [])) {
-        blog.push({ url: `${WEB_URL}/blog/categoria/${cat.slug}`, lastModified: now, changeFrequency: 'weekly', priority: 0.75 })
-      }
-    }
-    if (clustersRes.ok) {
-      const data = await clustersRes.json()
-      for (const cl of (data.data ?? [])) {
-        blog.push({ url: `${WEB_URL}/blog/cluster/${cl.slug}`, lastModified: now, changeFrequency: 'weekly', priority: 0.75 })
-      }
-    }
-  } catch {}
-
-  // ── SEO Programático (páginas dinâmicas do banco) ─────────────────────────
-  let seoProgramatico: MetadataRoute.Sitemap = []
-  try {
-    const res = await fetch(`${API_URL}/api/v1/seo/pages?limit=200&status=publicado`, { next: { revalidate: 3600 } })
-    if (res.ok) {
-      const data = await res.json()
-      seoProgramatico = (data.data ?? [])
-        .filter((p: any) => p.status === 'publicado')
-        .map((p: any) => ({
-          url: `${WEB_URL}/s/${p.slug}`,
-          lastModified: new Date(p.published_at ?? now),
-          changeFrequency: 'weekly' as const,
-          priority: 0.7,
+      const clusterPages = cities.flatMap((c: any) =>
+        CLUSTER_SLUGS.map(cluster => ({
+          url: `${WEB_URL}/${c.stateSlug}/${c.slug}/${cluster}`,
+          lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
         }))
-    }
-  } catch {}
+      )
+      const guiaPages = cities.flatMap((c: any) =>
+        GUIA_SLUGS.map(g => ({
+          url: `${WEB_URL}/${c.stateSlug}/${c.slug}/guia/${g}`,
+          lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75,
+        }))
+      )
+      const servicoPages = cities.flatMap((c: any) =>
+        SERVICO_SLUGS.map(s => ({
+          url: `${WEB_URL}/${c.stateSlug}/${c.slug}/servicos/${s}`,
+          lastModified: now, changeFrequency: 'monthly' as const, priority: 0.7,
+        }))
+      )
+      const investPages = cities.flatMap((c: any) =>
+        INVEST_SLUGS.map(i => ({
+          url: `${WEB_URL}/${c.stateSlug}/${c.slug}/investimentos/${i}`,
+          lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
+        }))
+      )
+      const modPages = cities.flatMap((c: any) =>
+        TOP_CLUSTERS_FOR_MODS.flatMap(cluster =>
+          MOD_SLUGS.map(mod => ({
+            url: `${WEB_URL}/${c.stateSlug}/${c.slug}/${cluster}/${mod}`,
+            lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65,
+          }))
+        )
+      )
+      return [...cityHubs, ...clusterPages, ...guiaPages, ...servicoPages, ...investPages, ...modPages]
+    } catch { return [] }
+  })()
 
   return [
     ...core,
@@ -435,7 +426,6 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
     ...leilaoCondominios,
     // ── TERMOS RELACIONADOS A IMÓVEIS × CIDADES (explosão de URLs) ──────
     ...SEO_CITIES.flatMap(c => [
-      // Tipos de imóvel
       { url: `${WEB_URL}/casas-a-venda/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/apartamentos-a-venda/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/terrenos-a-venda/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.8 },
@@ -445,13 +435,11 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       { url: `${WEB_URL}/cobertura-duplex/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/kitnet/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/condominio-fechado/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
-      // Rural
       { url: `${WEB_URL}/chacaras-a-venda/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/sitios-a-venda/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/fazendas-a-venda/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/leilao-rural/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/imoveis-rurais/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
-      // Leilões específicos
       { url: `${WEB_URL}/leilao-casas/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/leilao-apartamentos/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/leilao-terrenos/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.8 },
@@ -462,7 +450,6 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       { url: `${WEB_URL}/leilao-bradesco/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/leilao-itau/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
       { url: `${WEB_URL}/leilao-santander/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
-      // Serviços e Profissionais
       { url: `${WEB_URL}/avaliacao-imoveis/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75 },
       { url: `${WEB_URL}/financiamento-imovel/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75 },
       { url: `${WEB_URL}/materiais-de-construcao/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
@@ -478,56 +465,44 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       { url: `${WEB_URL}/despachante-imobiliario/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/fotografo-imoveis/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/home-staging/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
-      // Custo de vida e comparação
       { url: `${WEB_URL}/custo-de-vida/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/valor-metro-quadrado/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8 },
-      // Por quartos
       { url: `${WEB_URL}/imoveis-1-quarto/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/imoveis-2-quartos/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/imoveis-3-quartos/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/imoveis-4-quartos/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
-      // Por preço
       { url: `${WEB_URL}/imoveis-ate-200mil/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/imoveis-200-500mil/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/imoveis-500mil-1milhao/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/imoveis-acima-1milhao/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
-      // Aluguel por faixa
       { url: `${WEB_URL}/aluguel-ate-1000/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/aluguel-1000-2000/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/aluguel-2000-3000/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/aluguel-acima-3000/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.65 },
-      // Lançamentos e novos
       { url: `${WEB_URL}/lancamentos/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
       { url: `${WEB_URL}/imoveis-novos/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/imoveis-usados/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
-      // Perto de
       { url: `${WEB_URL}/imoveis-perto-metro/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
       { url: `${WEB_URL}/imoveis-perto-escola/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
       { url: `${WEB_URL}/imoveis-perto-hospital/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
       { url: `${WEB_URL}/imoveis-perto-shopping/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
-      // Específicos
       { url: `${WEB_URL}/imoveis-com-piscina/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
       { url: `${WEB_URL}/imoveis-com-churrasqueira/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/imoveis-aceita-pets/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/imoveis-mobiliados/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65 },
       { url: `${WEB_URL}/imoveis-com-varanda/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
-      // Tipo + Finalidade cruzados
       { url: `${WEB_URL}/casas-para-alugar/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/apartamentos-para-alugar/${c}`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85 },
       { url: `${WEB_URL}/kitnets-para-alugar/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
       { url: `${WEB_URL}/salas-para-alugar/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.65 },
       { url: `${WEB_URL}/galpoes-para-alugar/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.65 },
       { url: `${WEB_URL}/casas-em-condominio/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.75 },
-      // Temporada
       { url: `${WEB_URL}/aluguel-temporada/${c}`, lastModified: now, changeFrequency: 'weekly' as const, priority: 0.7 },
-      // Permuta
       { url: `${WEB_URL}/imoveis-permuta/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
-      // Documentação
       { url: `${WEB_URL}/regularizacao-imovel/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/escritura-imovel/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/usucapiao/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
       { url: `${WEB_URL}/inventario-imovel/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
-      // Construção
       { url: `${WEB_URL}/construtoras/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/empreiteiros/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.6 },
       { url: `${WEB_URL}/pedreiros/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
@@ -537,112 +512,84 @@ export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       { url: `${WEB_URL}/marceneiros/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
       { url: `${WEB_URL}/vidraceiros/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
       { url: `${WEB_URL}/serralheiros/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
-      // Seguros
       { url: `${WEB_URL}/seguro-residencial/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
       { url: `${WEB_URL}/seguro-incendio/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
-      // Mudança
       { url: `${WEB_URL}/empresas-mudanca/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.55 },
       { url: `${WEB_URL}/guarda-moveis/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
-      // Limpeza e manutenção
       { url: `${WEB_URL}/limpeza-pos-obra/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
       { url: `${WEB_URL}/dedetizacao/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
       { url: `${WEB_URL}/jardinagem-paisagismo/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
       { url: `${WEB_URL}/impermeabilizacao/${c}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.5 },
     ]),
-    ...leilaoBairros,
     ...leilaoBairrosManus,
     ...pois,
-    ...leiloes,
-    ...imoveis,
-    ...blog,
-    ...seoProgramatico,
-    // ── 152 cidades IBGE: rotas /{estado}/{cidade} ─────────────────────
-    ...(() => {
-      try {
-        const { IBGE_CITIES_152 } = require('@/data/seo-ibge-cities-expanded')
-        const CLUSTER_SLUGS = [
-          'imoveis-a-venda', 'imoveis-para-alugar', 'casas-a-venda', 'apartamentos-a-venda',
-          'terrenos-a-venda', 'condominios-fechados', 'lancamentos-imobiliarios', 'imoveis-comerciais',
-          'leilao-de-imoveis', 'imoveis-para-investir', 'imoveis-caixa',
-          'chacaras-a-venda', 'sitios-a-venda', 'loteamentos', 'imoveis-rurais',
-        ]
-        const GUIA_SLUGS = [
-          'melhores-bairros-para-morar', 'custo-de-vida', 'como-comprar-imovel',
-          'como-alugar-imovel', 'financiamento-imobiliario', 'melhores-construtoras',
-          'bairros-mais-valorizados', 'onde-morar-em', 'precos-de-imoveis', 'mercado-imobiliario',
-        ]
-        const SERVICO_SLUGS = [
-          'arquiteto', 'engenheiro-civil', 'pedreiro', 'empreiteira', 'construtora',
-          'avaliacao-de-imovel', 'vistoria-de-imovel', 'topografia',
-          'regularizacao-de-imovel', 'fotografia-de-imovel', 'drone', 'decoracao-de-interiores',
-          'avaliacao-online-de-imovel', 'quanto-vale-meu-imovel', 'preco-do-metro-quadrado',
-          'fotos-de-imovel-com-ia', 'tour-virtual-360', 'home-staging-virtual',
-          'video-com-drone', 'planta-humanizada',
-          'anuncio-de-imovel-com-ia', 'divulgar-imovel-nos-portais', 'anunciar-imovel-gratis',
-          'captacao-de-imoveis',
-          'crm-imobiliario', 'automacao-de-leads', 'atendimento-com-ia', 'whatsapp-imobiliario',
-          'funil-de-vendas-imobiliario', 'lead-scoring',
-          'software-para-imobiliaria', 'gestao-de-aluguel', 'gestao-de-locacao',
-          'repasse-ao-proprietario', 'cobranca-de-aluguel', 'contrato-digital',
-          'administracao-de-imoveis',
-          'plano-para-corretor', 'assinatura-corretor', 'plano-para-imobiliaria',
-          'site-para-corretor', 'programa-de-afiliados', 'seja-um-parceiro',
-        ]
-        const INVEST_SLUGS = [
-          'leilao-de-imoveis', 'leilao-judicial-de-imoveis', 'imoveis-caixa',
-          'imoveis-retomados', 'investimento-imobiliario', 'imoveis-para-investir',
-          'fundos-imobiliarios', 'arrematacao-de-imoveis',
-        ]
-        const MOD_SLUGS = [
-          'para-investidor', 'para-proprietario', 'alto-padrao', 'popular',
-          'minha-casa-minha-vida', 'para-empresa', 'residencial', 'comercial',
-          'alto-retorno', 'baixo-risco', 'para-familia', 'perto-de-escola',
-          'com-home-office', 'para-airbnb',
-        ]
-        const TOP_CLUSTERS_FOR_MODS = [
-          'imoveis-a-venda', 'imoveis-para-alugar', 'casas-a-venda',
-          'apartamentos-a-venda', 'leilao-de-imoveis',
-        ]
-        const cities = IBGE_CITIES_152 as any[]
-
-        const cityHubs = cities.map((c: any) => ({
-          url: `${WEB_URL}/${c.stateSlug}/${c.slug}`,
-          lastModified: now, changeFrequency: 'weekly' as const, priority: 0.85,
-        }))
-        const clusterPages = cities.flatMap((c: any) =>
-          CLUSTER_SLUGS.map(cluster => ({
-            url: `${WEB_URL}/${c.stateSlug}/${c.slug}/${cluster}`,
-            lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
-          }))
-        )
-        const guiaPages = cities.flatMap((c: any) =>
-          GUIA_SLUGS.map(g => ({
-            url: `${WEB_URL}/${c.stateSlug}/${c.slug}/guia/${g}`,
-            lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75,
-          }))
-        )
-        const servicoPages = cities.flatMap((c: any) =>
-          SERVICO_SLUGS.map(s => ({
-            url: `${WEB_URL}/${c.stateSlug}/${c.slug}/servicos/${s}`,
-            lastModified: now, changeFrequency: 'monthly' as const, priority: 0.7,
-          }))
-        )
-        const investPages = cities.flatMap((c: any) =>
-          INVEST_SLUGS.map(i => ({
-            url: `${WEB_URL}/${c.stateSlug}/${c.slug}/investimentos/${i}`,
-            lastModified: now, changeFrequency: 'weekly' as const, priority: 0.8,
-          }))
-        )
-        const modPages = cities.flatMap((c: any) =>
-          TOP_CLUSTERS_FOR_MODS.flatMap(cluster =>
-            MOD_SLUGS.map(mod => ({
-              url: `${WEB_URL}/${c.stateSlug}/${c.slug}/${cluster}/${mod}`,
-              lastModified: now, changeFrequency: 'monthly' as const, priority: 0.65,
-            }))
-          )
-        )
-        return [...cityHubs, ...clusterPages, ...guiaPages, ...servicoPages, ...investPages, ...modPages]
-      } catch { return [] }
-    })(),
+    ...ibge,
   ]
+}
+
+/** Fetch com timeout — nunca deixa a API travar a geração do sitemap. */
+async function safeFetch(url: string): Promise<any | null> {
+  try {
+    const res = await fetch(url, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+    if (!res.ok) return null
+    return await res.json()
+  } catch { return null }
+}
+
+/** URLs DINÂMICAS (imóveis, leilões, blog, SEO programático) — via API, com timeout. */
+export async function fetchDynamicEntries(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date()
+  const out: MetadataRoute.Sitemap = []
+
+  const auctions = await safeFetch(`${API_URL}/api/v1/auctions?limit=500&sortBy=createdAt&sortOrder=desc`)
+  for (const a of (auctions?.data ?? [])) {
+    out.push({ url: `${WEB_URL}/leiloes/${a.slug}`, lastModified: new Date(a.updatedAt ?? now), changeFrequency: 'daily', priority: 0.85 })
+  }
+
+  const props = await safeFetch(`${API_URL}/api/v1/public/properties?limit=2000`)
+  for (const p of (props?.data ?? [])) {
+    out.push({ url: `${WEB_URL}/imoveis/${p.slug}`, lastModified: new Date(p.updatedAt ?? now), changeFrequency: 'weekly', priority: 0.75 })
+  }
+
+  const [posts, cats, clusters] = await Promise.all([
+    safeFetch(`${API_URL}/api/v1/blog?limit=500`),
+    safeFetch(`${API_URL}/api/v1/blog/categories`),
+    safeFetch(`${API_URL}/api/v1/blog/clusters`),
+  ])
+  for (const p of (posts?.data ?? [])) {
+    out.push({ url: `${WEB_URL}/blog/${p.slug}`, lastModified: new Date(p.publishedAt ?? now), changeFrequency: 'monthly', priority: p.featured ? 0.85 : 0.65 })
+  }
+  for (const cat of (cats?.data ?? [])) {
+    out.push({ url: `${WEB_URL}/blog/categoria/${cat.slug}`, lastModified: now, changeFrequency: 'weekly', priority: 0.75 })
+  }
+  for (const cl of (clusters?.data ?? [])) {
+    out.push({ url: `${WEB_URL}/blog/cluster/${cl.slug}`, lastModified: now, changeFrequency: 'weekly', priority: 0.75 })
+  }
+
+  const seo = await safeFetch(`${API_URL}/api/v1/seo/pages?limit=200&status=publicado`)
+  for (const p of (seo?.data ?? [])) {
+    if (p.status !== 'publicado') continue
+    out.push({ url: `${WEB_URL}/s/${p.slug}`, lastModified: new Date(p.published_at ?? now), changeFrequency: 'weekly', priority: 0.7 })
+  }
+
+  return out
+}
+
+/**
+ * Todas as URLs (estáticas + dinâmicas). Usado só pelo conteúdo real de
+ * /sitemap/{id}.xml — NÃO pelo índice (que usa sitemapChunkCount()).
+ */
+export async function buildSitemapEntries(): Promise<MetadataRoute.Sitemap> {
+  return [...buildStaticEntries(), ...(await fetchDynamicEntries())]
+}
+
+/**
+ * Número de chunks do sitemap, calculado de forma BARATA (só as URLs estáticas,
+ * sem fetch) + uma folga para as dinâmicas. O índice e o generateSitemaps usam
+ * esta função para se manterem em sincronia sem nunca travar.
+ */
+export function sitemapChunkCount(): number {
+  const DYNAMIC_RESERVE = 10000 // imóveis (2000) + leilões (500) + blog + SEO, com folga
+  const total = buildStaticEntries().length + DYNAMIC_RESERVE
+  return Math.max(1, Math.ceil(total / SITEMAP_CHUNK_SIZE))
 }


### PR DESCRIPTION
Follow-up do PR #248 (já mergeado). Reúne correções que ficaram fora daquele merge, incluindo **uma regressão que o #248 deixou em produção**.

## 🔴 Correção de regressão (prioritária)
O #248 mergeou o split do sitemap em que o **`/sitemap-index.xml` passou a construir ~66k URLs + chamadas à API só para contar os chunks** → em cache frio estoura o tempo (>45s). Como o Google lê o índice primeiro, isso **derruba a leitura de todos os sub-sitemaps**. Este PR corrige:
- `sitemapChunkCount()` calcula a contagem de forma barata (só URLs estáticas, sem fetch) → índice responde instantâneo.
- `buildSitemapEntries` separado em estático + dinâmico, com **timeout de 8s** nos fetches à API.

## Resiliência (causa provável dos ~26k "4xx" no GSC)
As páginas programáticas faziam `fetch` à API **sem timeout**; com a API lenta/fria o render travava até 60s → timeout no build (SSG) e erro sob rastreamento em massa.
- `AbortSignal.timeout(5000)` na `[estado]/[cidade]/[cluster]` (14.533 páginas) e em 13 outras famílias programáticas.

## Sub-sitemaps fora de `/api/`
- Rewrite `/sitemaps/* → /api/sitemap/*` + índice/robots apontando para `/sitemaps/` (elimina a dependência do `Allow /api/sitemap/` no robots).

## Conteúdo para páginas de cidade (evitar páginas vazias/rasas)
- Novo componente `CitySeoContent`: oferta dos serviços AgoraEncontrei + buscas relacionadas (internal linking) + texto **city-aware** com variação determinística (evita "doorway pages").
- Conectado em 5 famílias (venda, aluguel, leilão, cluster, seo/[categoria]). Renderiza sempre; vira o conteúdo principal quando a cidade não tem estoque.

## Validação
- `next build`: compila (`Compiled successfully`). Typecheck web: 9 erros = baseline, **zero** nos arquivos tocados.
- A geração estática completa depende da API acessível (falha isolada no sandbox por indisponibilidade da API, não pelo código); o build do Vercel/CI com a API no ar confirma.

> Nota: o backend (API no Railway) esteve retornando 502 durante este trabalho — incidente de infraestrutura separado, tratado à parte. Estas mudanças deixam o frontend resiliente a API lenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dobj1d9q3PJCiSNi1ZHSih)_