### PR TITLE
feat(admin): "Reenviar acesso / trocar e-mail do parceiro" no painel …

### DIFF
--- a/apps/api/src/routes/master/index.ts
+++ b/apps/api/src/routes/master/index.ts
@@ -240,6 +240,134 @@ export default async function masterRoutes(app: FastifyInstance) {
     return reply.send({ success: true, data: tenant })
   })
 
+  // POST /tenant/:id/reset-access — Trocar e-mail do parceiro e/ou gerar novo
+  // link de definição de senha (1º acesso). O setupLink volta NA RESPOSTA para
+  // o admin copiar e enviar manualmente — funciona mesmo sem SMTP/WhatsApp.
+  app.post('/tenant/:id/reset-access', {
+    schema: { tags: ['master'], summary: 'Trocar e-mail do parceiro e reenviar link de acesso' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const body = z.object({
+      newEmail: z.string().email('E-mail inválido').optional(),
+    }).parse(req.body ?? {})
+
+    // 1. Tenant
+    const tenant = await (app.prisma as any).tenant.findUnique({ where: { id } }).catch(() => null)
+    if (!tenant) {
+      return reply.status(404).send({ error: 'TENANT_NOT_FOUND', message: 'Tenant não encontrado.' })
+    }
+
+    // 2. User dono — por ownerId, senão por settings.customerEmail
+    const settings = (tenant.settings && typeof tenant.settings === 'object') ? tenant.settings : {}
+    const customerEmail: string | undefined = settings.customerEmail
+    let user: any = null
+    if (tenant.ownerId) {
+      user = await app.prisma.user.findUnique({ where: { id: tenant.ownerId } }).catch(() => null)
+    }
+    if (!user && customerEmail) {
+      user = await app.prisma.user.findFirst({
+        where: { email: { equals: String(customerEmail).toLowerCase(), mode: 'insensitive' } },
+      }).catch(() => null)
+    }
+    if (!user) {
+      return reply.status(404).send({
+        error: 'OWNER_NOT_FOUND',
+        message: 'Não foi possível localizar o usuário dono deste tenant (sem ownerId e sem customerEmail correspondente).',
+      })
+    }
+
+    // 3. Trocar e-mail (se veio e é diferente)
+    const desiredEmail = body.newEmail?.toLowerCase().trim()
+    if (desiredEmail && desiredEmail !== String(user.email).toLowerCase()) {
+      const inUse = await app.prisma.user.findUnique({ where: { email: desiredEmail } }).catch(() => null)
+      if (inUse && inUse.id !== user.id) {
+        return reply.status(409).send({
+          error: 'EMAIL_IN_USE',
+          message: 'Este e-mail já está em uso por outro usuário.',
+        })
+      }
+      user = await app.prisma.user.update({
+        where: { id: user.id },
+        data: { email: desiredEmail },
+      })
+      // Merge no JSON settings sem apagar o resto
+      await (app.prisma as any).tenant.update({
+        where: { id },
+        data: { settings: { ...settings, customerEmail: desiredEmail } },
+      }).catch(() => {})
+    }
+
+    // 4. Token de definição de senha
+    const { createPasswordSetupToken } = await import('../auth/first-access.js')
+    const token = await createPasswordSetupToken(app.prisma, user.email)
+
+    // 5. Link
+    const base = process.env.WEB_URL || 'https://agoraencontrei.com.br'
+    const setupLink = `${base}/definir-senha?token=${token}`
+
+    // 6. Best-effort — e-mail e WhatsApp
+    let emailSent = false
+    let whatsappSent = false
+    try {
+      const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+      if (isEmailConfigured()) {
+        const html = `
+          <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+            <h1 style="color:#1B2B5B;margin:0 0 8px">Seu acesso ao AgoraEncontrei</h1>
+            <p style="margin:0 0 16px;color:#475569">Use o botão abaixo para definir a senha e acessar sua conta.</p>
+            <div style="text-align:center;margin:24px 0">
+              <a href="${setupLink}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:700;padding:12px 24px;border-radius:10px;text-decoration:none">Definir minha senha →</a>
+            </div>
+            <p style="margin:16px 0;color:#475569">Ou copie e cole este link no navegador:</p>
+            <p style="margin:0 0 16px;word-break:break-all"><a href="${setupLink}" style="color:#C9A84C">${setupLink}</a></p>
+            <p style="margin:16px 0;color:#475569">O link expira em 7 dias.</p>
+          </div>`
+        await sendEmail({
+          to: user.email,
+          subject: 'Seu acesso ao AgoraEncontrei',
+          html,
+        })
+        emailSent = true
+      }
+    } catch (e: any) {
+      app.log.error({ err: e }, '[reset-access] email failed')
+    }
+
+    if (user.phone) {
+      try {
+        const { sendWhatsappText } = await import('../../services/whatsapp-notify.service.js')
+        const msg =
+          `🔑 *AgoraEncontrei — Seu acesso*\n\n` +
+          `Use o link abaixo para definir sua senha e acessar sua conta:\n${setupLink}\n\n` +
+          `(o link expira em 7 dias)`
+        whatsappSent = await sendWhatsappText(user.phone, msg)
+      } catch (e: any) {
+        app.log.error({ err: e }, '[reset-access] whatsapp failed')
+      }
+    }
+
+    // 7. Auditoria (best-effort)
+    await app.prisma.auditLog.create({
+      data: {
+        companyId: 'platform',
+        action: 'master.tenant.reset_access' as any,
+        resource: 'tenant',
+        resourceId: id,
+        userId: (req.user as any)?.sub ?? 'unknown',
+        payload: { email: user.email, emailChanged: !!desiredEmail, emailSent, whatsappSent } as any,
+      },
+    }).catch(() => {})
+
+    // 8. Resposta — setupLink é o ponto central
+    return reply.send({
+      success: true,
+      email: user.email,
+      setupLink,
+      emailSent,
+      whatsappSent,
+    })
+  })
+
   // GET /health — Platform health check
   app.get('/health', {
     schema: { tags: ['master'], summary: 'Platform health check' },

--- a/apps/web/src/app/(dashboard)/dashboard/admin/tenants/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/admin/tenants/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   Building2, Loader2, Search, Power, PauseCircle, XCircle,
-  CheckCircle2, ExternalLink, RefreshCw,
+  CheckCircle2, ExternalLink, RefreshCw, KeyRound, Copy, Check, X,
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -21,6 +21,14 @@ interface Tenant {
   propertyCount?: number;
   totalCommission?: number;
   createdAt: string;
+  settings?: { customerEmail?: string } | null;
+}
+
+interface ResetResult {
+  email: string;
+  setupLink: string;
+  emailSent: boolean;
+  whatsappSent: boolean;
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -40,6 +48,14 @@ export default function AdminTenantsPage() {
   const [search, setSearch] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
   const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null);
+
+  // Modal "Reenviar acesso"
+  const [resetTenant, setResetTenant] = useState<Tenant | null>(null);
+  const [resetEmail, setResetEmail] = useState('');
+  const [resetLoading, setResetLoading] = useState(false);
+  const [resetResult, setResetResult] = useState<ResetResult | null>(null);
+  const [resetError, setResetError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const notify = useCallback((msg: string, ok: boolean) => {
     setToast({ msg, ok });
@@ -122,6 +138,62 @@ export default function AdminTenantsPage() {
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ plan }),
       }));
+  };
+
+  const openReset = (t: Tenant) => {
+    setResetTenant(t);
+    setResetEmail('');
+    setResetResult(null);
+    setResetError(null);
+    setCopied(false);
+  };
+
+  const closeReset = () => {
+    setResetTenant(null);
+    setResetLoading(false);
+  };
+
+  const submitReset = async () => {
+    if (!resetTenant) return;
+    setResetLoading(true);
+    setResetError(null);
+    setResetResult(null);
+    try {
+      const token = await getValidToken();
+      if (!token) throw new Error('Sessão expirada. Faça login novamente.');
+      const newEmail = resetEmail.trim();
+      const res = await fetch(`${API_URL}/api/v1/master/tenant/${resetTenant.id}/reset-access`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(newEmail ? { newEmail } : {}),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(body.message || body.error || 'Falha ao gerar link de acesso');
+      }
+      setResetResult({
+        email: body.email,
+        setupLink: body.setupLink,
+        emailSent: !!body.emailSent,
+        whatsappSent: !!body.whatsappSent,
+      });
+      await load();
+    } catch (e) {
+      setResetError((e as Error).message);
+    } finally {
+      setResetLoading(false);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!resetResult) return;
+    try {
+      await navigator.clipboard.writeText(resetResult.setupLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      notify('Não foi possível copiar automaticamente. Selecione o link manualmente.', false);
+    }
   };
 
   const filtered = tenants.filter((t) => {
@@ -230,6 +302,14 @@ export default function AdminTenantsPage() {
                       <td className="px-4 py-3">
                         <div className="flex items-center justify-end gap-1.5">
                           {busy && <Loader2 size={14} className="animate-spin text-amber-400" />}
+                          <button
+                            onClick={() => openReset(t)}
+                            disabled={busy}
+                            title="Reenviar acesso (trocar e-mail / gerar link de senha)"
+                            className="flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs text-amber-300 hover:bg-amber-500/20 disabled:opacity-50"
+                          >
+                            <KeyRound size={13} /> Reenviar acesso
+                          </button>
                           {t.planStatus !== 'ACTIVE' && !cancelled && (
                             <button
                               onClick={() => activate(t)}
@@ -284,6 +364,128 @@ export default function AdminTenantsPage() {
           cancelar desativa de forma permanente preservando os dados.
         </p>
       </div>
+
+      {/* Modal — Reenviar acesso */}
+      {resetTenant && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={closeReset}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-gray-800 bg-gray-900 p-5 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <KeyRound size={20} className="text-amber-400 flex-shrink-0" />
+                <div>
+                  <h2 className="text-base font-bold text-white">Reenviar acesso</h2>
+                  <p className="text-xs text-gray-400">{resetTenant.name}</p>
+                </div>
+              </div>
+              <button
+                onClick={closeReset}
+                className="rounded-md p-1 text-gray-500 hover:bg-gray-800 hover:text-white"
+                title="Fechar"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {!resetResult ? (
+              <>
+                <div className="mb-4 rounded-lg border border-gray-800 bg-gray-950 px-3 py-2">
+                  <p className="text-xs text-gray-500">E-mail atual do parceiro</p>
+                  <p className="text-sm text-gray-200 break-all">
+                    {resetTenant.settings?.customerEmail || '(não definido)'}
+                  </p>
+                </div>
+
+                <label className="mb-1 block text-xs font-medium text-gray-400">
+                  Novo e-mail (deixe vazio para manter)
+                </label>
+                <input
+                  type="email"
+                  value={resetEmail}
+                  onChange={(e) => setResetEmail(e.target.value)}
+                  placeholder="novo@email.com"
+                  autoComplete="off"
+                  className="mb-3 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-white placeholder-gray-600 focus:border-amber-500 focus:outline-none"
+                  style={{ fontSize: '16px' }}
+                />
+
+                {resetError && (
+                  <p className="mb-3 rounded-lg border border-red-500/40 bg-red-900/30 px-3 py-2 text-xs text-red-200">
+                    {resetError}
+                  </p>
+                )}
+
+                <button
+                  onClick={submitReset}
+                  disabled={resetLoading}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2.5 text-sm font-semibold text-gray-950 hover:bg-amber-400 disabled:opacity-60"
+                >
+                  {resetLoading
+                    ? <><Loader2 size={16} className="animate-spin" /> Gerando...</>
+                    : <><KeyRound size={16} /> Gerar link de acesso</>}
+                </button>
+                <p className="mt-2 text-[11px] leading-relaxed text-gray-600">
+                  O link permite ao parceiro definir a senha e acessar a conta.
+                  Ele aparece aqui para você copiar e enviar — funciona mesmo sem e-mail/WhatsApp configurados.
+                </p>
+              </>
+            ) : (
+              <>
+                <div className="mb-3 rounded-lg border border-emerald-500/30 bg-emerald-900/20 px-3 py-2">
+                  <p className="text-xs text-emerald-200">
+                    Link gerado para <span className="font-semibold break-all">{resetResult.email}</span>
+                  </p>
+                  <p className="mt-1 text-[11px] text-emerald-300/80">
+                    {resetResult.emailSent && resetResult.whatsappSent
+                      ? 'Enviado por e-mail e WhatsApp.'
+                      : resetResult.emailSent
+                        ? 'Enviado por e-mail.'
+                        : resetResult.whatsappSent
+                          ? 'Enviado por WhatsApp.'
+                          : 'Não enviado automaticamente — copie o link e envie manualmente.'}
+                  </p>
+                </div>
+
+                <label className="mb-1 block text-xs font-medium text-gray-400">
+                  Link de definição de senha
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    readOnly
+                    value={resetResult.setupLink}
+                    onFocus={(e) => e.currentTarget.select()}
+                    className="min-w-0 flex-1 rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-gray-200 focus:border-amber-500 focus:outline-none"
+                    style={{ fontSize: '16px' }}
+                  />
+                  <button
+                    onClick={copyLink}
+                    title="Copiar link"
+                    className={`flex items-center gap-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                      copied
+                        ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-300'
+                        : 'border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700'
+                    }`}
+                  >
+                    {copied ? <><Check size={15} /> Copiado</> : <><Copy size={15} /> Copiar</>}
+                  </button>
+                </div>
+
+                <button
+                  onClick={closeReset}
+                  className="mt-4 w-full rounded-lg border border-gray-700 px-4 py-2 text-sm text-gray-300 hover:bg-gray-800"
+                >
+                  Fechar
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
…master

Resolve o cenário de parceiro que se cadastrou com e-mail errado/sem acesso. POST /api/v1/master/tenant/:id/reset-access (SUPER_ADMIN): troca o e-mail do dono do tenant (opcional, com checagem de colisão 409), gera novo token de definição de senha e DEVOLVE o setupLink NA RESPOSTA — o admin copia e envia, funcionando mesmo sem SMTP/WhatsApp. Também tenta enviar por e-mail + WhatsApp. Front: botão "Reenviar acesso" por tenant + modal com link copiável.


Claude-Session: https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r