### PR TITLE
fix(build): destrava o deploy + segurança, login white-label e notificação ao proprietário

### DIFF
--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -17,8 +17,18 @@ const RegisterBody = z.object({
 })
 
 const LoginBody = z.object({
-  email: z.string().email(),
+  // Aceita e-mail, telefone ou CPF via `identifier`; mantém `email` por
+  // compatibilidade com clientes antigos. Pelo menos um é obrigatório.
+  identifier: z.string().min(3).max(128).optional(),
+  email: z.string().email().optional(),
   password: z.string().min(6).max(128),
+}).refine((d) => !!(d.identifier || d.email), {
+  message: 'Informe e-mail, telefone ou CPF',
+  path: ['identifier'],
+})
+
+const ResolveCompanyBody = z.object({
+  identifier: z.string().min(3).max(128),
 })
 
 const RefreshBody = z.object({
@@ -72,6 +82,21 @@ export default async function authRoutes(app: FastifyInstance) {
     const { email } = req.body as { email?: string }
     if (!email) return reply.status(400).send({ error: 'MISSING_EMAIL', message: 'E-mail obrigatório' })
     const result = await svc.resendVerification(email)
+    return reply.send(result)
+  })
+
+  // POST /api/v1/auth/resolve-company — etapa 1 do login white-label.
+  // Recebe e-mail/telefone/CPF e devolve só a MARCA da empresa (nome + logo +
+  // cor) para montar a tela de senha com a identidade do parceiro. Não
+  // confirma senha nem devolve dados sensíveis. Rate-limit apertado para
+  // desestimular varredura.
+  app.post('/resolve-company', {
+    config: { rateLimit: { max: 20, timeWindow: '15 minutes' } },
+    schema: { tags: ['auth'], summary: 'Resolve company branding for white-label login' },
+  }, async (req, reply) => {
+    const parsed = ResolveCompanyBody.safeParse(req.body)
+    if (!parsed.success) return reply.status(400).send({ error: 'VALIDATION_ERROR', message: parsed.error.message })
+    const result = await svc.resolveCompanyBranding(parsed.data.identifier)
     return reply.send(result)
   })
 

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -258,11 +258,12 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
               nicheSlug: body.nicheSlug || 'imobiliaria',
               customerEmail: body.customer.email,
               customerPhone: body.customer.phone || null,
-              // Marcamos a senha como temporária para o webhook saber que
-              // ele deve incluí-la no e-mail/WhatsApp de boas-vindas. Após
-              // o primeiro login bem-sucedido a flag deve sair.
+              // A senha nasce aleatória e só o hash argon2 fica no User; o
+              // parceiro define a própria senha pelo link de 1º acesso que o
+              // webhook envia (createPasswordSetupToken). NUNCA guardamos a
+              // senha em texto puro no banco. A flag abaixo só sinaliza que o
+              // onboarding ainda não teve o primeiro login.
               tempPasswordIssued: true,
-              tempPasswordPlain: tempPassword,
             },
           },
         })

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -170,6 +170,13 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
       })
     }
 
+    // CPF é único por usuário. Se este CPF já pertence a outra conta (ex.: dono
+    // de mais de uma imobiliária), NÃO gravamos no novo usuário — evita abortar
+    // a transação por violação de unicidade. O login por CPF resolve a 1ª conta.
+    const cpfTaken = cpfClean.length === 11
+      ? await app.prisma.user.findUnique({ where: { cpf: cpfClean } }).then((u: any) => !!u).catch(() => false)
+      : false
+
     // 3. Price from DB — never trust frontend
     const cycle = body.billingCycle || 'MONTHLY'
     const price = cycle === 'YEARLY' && plan.priceYearly
@@ -232,6 +239,10 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
             name: body.customer.name,
             email: body.customer.email.toLowerCase().trim(),
             phone: body.customer.phone || null,
+            // Guarda o CPF (11 dígitos) para permitir login white-label por
+            // documento. CNPJ (14 dígitos) não é credencial de pessoa e CPF já
+            // usado por outra conta fica de fora (ver cpfTaken acima).
+            cpf: cpfClean.length === 11 && !cpfTaken ? cpfClean : null,
             passwordHash,
             role: 'ADMIN' as any,
             status: 'ACTIVE' as any,

--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -170,7 +170,6 @@ async function handleTenantEvent(
       }
 
       const settings = (tenant.settings as any) || {}
-      const tempPasswordPlain: string | undefined = settings.tempPasswordPlain
       const customerEmail: string | undefined = settings.customerEmail
       const customerPhone: string | undefined = settings.customerPhone
 

--- a/apps/api/src/routes/properties/index.ts
+++ b/apps/api/src/routes/properties/index.ts
@@ -649,6 +649,9 @@ export default async function propertiesRoutes(app: FastifyInstance) {
   }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const body = CreatePropertyBody.partial().parse(req.body)
+    // `notifyOwner` é um flag de fora do schema do imóvel (o Zod o descarta),
+    // então lemos do corpo cru: quando marcado, avisamos os proprietários.
+    const notifyOwner = (req.body as any)?.notifyOwner === true
 
     const existing = await app.prisma.property.findFirst({
       where: { id, companyId: req.user.cid },
@@ -703,6 +706,29 @@ export default async function propertiesRoutes(app: FastifyInstance) {
       after:  updated  as any,
     })
 
+    // Notificação automática ao proprietário (apenas quando selecionado na
+    // edição). Best-effort: não bloqueia nem falha a atualização.
+    let ownerNotify: { notified: number; channels: number; owners: number } | null = null
+    if (notifyOwner) {
+      const changedFields = Object.keys(body).filter(
+        (k) => JSON.stringify((body as any)[k]) !== JSON.stringify((existing as any)[k]),
+      )
+      try {
+        const company = await app.prisma.company.findUnique({
+          where: { id: req.user.cid },
+          select: { name: true, tradeName: true },
+        })
+        const { notifyPropertyOwnersOfUpdate } = await import('../../services/property-owner-notify.service.js')
+        ownerNotify = await notifyPropertyOwnersOfUpdate(app.prisma, {
+          propertyId: id,
+          changedFields,
+          companyName: company?.tradeName || company?.name || undefined,
+        })
+      } catch (err: any) {
+        app.log.warn({ err }, '[owner-notify] failed to notify property owners')
+      }
+    }
+
     // Match the listing against client alerts when it transitions to ACTIVE
     // (draft properties only fire match when first activated).
     if (body.status === 'ACTIVE' && existing.status !== 'ACTIVE') {
@@ -736,7 +762,7 @@ export default async function propertiesRoutes(app: FastifyInstance) {
       }
     }
 
-    return reply.send({ ...updated, _autoPost: autoPostStatus })
+    return reply.send({ ...updated, _autoPost: autoPostStatus, _ownerNotify: ownerNotify })
   })
 
   // DELETE /api/v1/properties/:id (soft — set INACTIVE)

--- a/apps/api/src/routes/specialists/auth.ts
+++ b/apps/api/src/routes/specialists/auth.ts
@@ -1,0 +1,56 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import { randomBytes } from 'node:crypto'
+import { safeStringEqual } from '../../utils/crypto-safe.js'
+
+/**
+ * Autorização do painel do especialista.
+ *
+ * O especialista NÃO usa a senha/JWT da plataforma. Ele acessa os próprios
+ * dados via magic-link: um `accessToken` (rotacionável) entregue por e-mail
+ * e WhatsApp. Esta função libera o acesso quando UMA das condições vale:
+ *
+ *  1. a requisição traz `?token=` que bate (comparação constante) com o
+ *     `accessToken` salvo do especialista; OU
+ *  2. o chamador é um usuário autenticado da plataforma com papel
+ *     ADMIN / SUPER_ADMIN / MANAGER (suporte/moderação).
+ *
+ * Em caso de negação, envia a resposta (401/403) e retorna `false`; o
+ * handler deve apenas `return` sem enviar nada.
+ */
+export async function specialistTokenOrAdmin(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  storedToken: string | null | undefined,
+): Promise<boolean> {
+  const token = (req.query as any)?.token as string | undefined
+  if (token && safeStringEqual(String(token), storedToken ?? null)) {
+    return true
+  }
+
+  // Sem token válido — tenta autenticar como admin da plataforma.
+  try {
+    await (req as any).jwtVerify()
+  } catch {
+    reply.status(401).send({
+      error: 'UNAUTHORIZED',
+      message: 'Link de acesso inválido/expirado. Solicite um novo link ou faça login.',
+    })
+    return false
+  }
+
+  const role = (req as any).user?.role
+  if (['SUPER_ADMIN', 'ADMIN', 'MANAGER'].includes(role)) {
+    return true
+  }
+
+  reply.status(403).send({ error: 'FORBIDDEN' })
+  return false
+}
+
+/**
+ * Gera um novo token de acesso opaco (32 bytes → 64 hex chars). Rotaciona a
+ * cada pedido de link, invalidando links antigos.
+ */
+export function generateSpecialistAccessToken(): string {
+  return randomBytes(32).toString('hex')
+}

--- a/apps/api/src/routes/specialists/index.ts
+++ b/apps/api/src/routes/specialists/index.ts
@@ -9,6 +9,7 @@
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { slugify } from '../../utils/slugify.js'
+import { specialistTokenOrAdmin, generateSpecialistAccessToken } from './auth.js'
 
 const categoryLabels: Record<string, string> = {
   ARQUITETO: 'Arquiteto(a)',
@@ -370,12 +371,120 @@ export default async function specialistsRoute(app: FastifyInstance) {
     }
   })
 
-  // ─── GET /by-email/:email — busca por email (para o painel do parceiro) ──
+  // ─── POST /request-access — envia magic-link do painel por e-mail/WhatsApp ─
+  // Login sem senha do especialista. Recebe o e-mail, rotaciona o accessToken
+  // e entrega o link por e-mail + WhatsApp. Responde SEMPRE 200 (mesmo quando
+  // o e-mail não existe) para não permitir enumeração de cadastro.
+  app.post('/request-access', async (request, reply) => {
+    const parsed = z.object({ email: z.string().email() }).safeParse(request.body)
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'E-mail inválido' })
+    }
+    const email = parsed.data.email.toLowerCase().trim()
+    const genericOk = {
+      success: true,
+      message: 'Se houver um cadastro com este e-mail, enviamos um link de acesso.',
+    }
+
+    try {
+      const specialist = await prisma.specialist.findUnique({
+        where: { email },
+        select: { id: true, name: true, email: true, phone: true, whatsapp: true },
+      })
+      // Resposta idêntica quando não existe — evita enumeração.
+      if (!specialist) return reply.send(genericOk)
+
+      const token = generateSpecialistAccessToken()
+      await prisma.specialist.update({
+        where: { id: specialist.id },
+        data: { accessToken: token, accessTokenSentAt: new Date() },
+      })
+
+      const panelUrl = `https://www.agoraencontrei.com.br/meu-painel?token=${token}`
+
+      // E-mail (best-effort)
+      try {
+        const { sendEmail, isEmailConfigured } = await import('../../services/email.service.js')
+        if (isEmailConfigured()) {
+          await sendEmail({
+            to: specialist.email,
+            subject: 'Seu link de acesso ao painel — AgoraEncontrei',
+            html: `
+              <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+                <h1 style="color:#1B2B5B;margin:0 0 8px">Acesso ao seu painel</h1>
+                <p style="margin:0 0 16px;color:#475569">Olá${specialist.name ? `, ${specialist.name}` : ''}! Clique no botão para acessar o painel do seu perfil no AgoraEncontrei.</p>
+                <div style="text-align:center;margin:24px 0">
+                  <a href="${panelUrl}" style="display:inline-block;background:#C9A84C;color:#1B2B5B;font-weight:700;padding:12px 24px;border-radius:10px;text-decoration:none">Acessar meu painel →</a>
+                </div>
+                <p style="margin:16px 0;color:#475569;font-size:13px">Se você não pediu este link, ignore este e-mail. Não compartilhe este link — ele dá acesso ao seu perfil.</p>
+                <p style="margin:24px 0 0;font-size:12px;color:#94a3b8">AgoraEncontrei — Marketplace Imobiliário de Franca e Região</p>
+              </div>`,
+            text: `Acesse seu painel no AgoraEncontrei: ${panelUrl}`,
+          })
+        }
+      } catch (e) {
+        request.log.error({ err: e }, '[specialists] request-access email failed')
+      }
+
+      // WhatsApp (best-effort)
+      const notifyPhone = specialist.whatsapp || specialist.phone
+      if (notifyPhone) {
+        try {
+          const { sendWhatsappText } = await import('../../services/whatsapp-notify.service.js')
+          await sendWhatsappText(
+            notifyPhone,
+            `🔑 *AgoraEncontrei*\n\nSeu link de acesso ao painel:\n${panelUrl}\n\nNão compartilhe — ele dá acesso ao seu perfil.`,
+          )
+        } catch (e) {
+          request.log.error({ err: e }, '[specialists] request-access whatsapp failed')
+        }
+      }
+
+      return reply.send(genericOk)
+    } catch (err: any) {
+      request.log.error({ err }, '[specialists] request-access failed')
+      // Mesmo em erro devolvemos a mensagem genérica para não vazar estado.
+      return reply.send(genericOk)
+    }
+  })
+
+  // ─── GET /session — resolve o painel a partir do magic-link (?token=) ─────
+  // Resolvedor primário do login sem senha: o especialista chega pelo link
+  // recebido por e-mail/WhatsApp e o token opaco (256 bits, coluna única)
+  // identifica o próprio cadastro. Não expõe campos sensíveis nem o token.
+  app.get('/session', async (request, reply) => {
+    const token = (request.query as any)?.token as string | undefined
+    if (!token || typeof token !== 'string') {
+      return reply.status(401).send({ error: 'MISSING_TOKEN', message: 'Link de acesso ausente.' })
+    }
+    try {
+      const specialist = await prisma.specialist.findUnique({
+        where: { accessToken: token },
+        include: {
+          buildings: {
+            include: { building: { select: { name: true, slug: true } } },
+          },
+        },
+      })
+      if (!specialist) {
+        return reply.status(401).send({ error: 'INVALID_TOKEN', message: 'Link inválido ou expirado. Solicite um novo.' })
+      }
+      const { asaasCustomerId, asaasSubscriptionId, cpfCnpj, accessToken, ...safe } = specialist as any
+      return reply.send(safe)
+    } catch (err: any) {
+      return reply.status(500).send({ error: 'Erro ao carregar painel', details: err.message })
+    }
+  })
+
+  // ─── GET /by-email/:email — dados privados do painel do parceiro ──────────
+  // SEGURANÇA: rota antes era pública — qualquer um lia telefone/plano/status
+  // de qualquer especialista informando o e-mail. Agora exige o magic-link
+  // (?token=) do próprio especialista OU um admin autenticado.
   app.get('/by-email/:email', async (request, reply) => {
     const { email } = request.params as { email: string }
     try {
       const specialist = await prisma.specialist.findUnique({
-        where: { email: decodeURIComponent(email) },
+        where: { email: decodeURIComponent(email).toLowerCase().trim() },
         include: {
           buildings: {
             include: { building: { select: { name: true, slug: true } } },
@@ -383,8 +492,12 @@ export default async function specialistsRoute(app: FastifyInstance) {
         },
       })
       if (!specialist) return reply.status(404).send({ error: 'Especialista não encontrado' })
-      // Não retornar campos sensíveis
-      const { asaasCustomerId, asaasSubscriptionId, cpfCnpj, ...safe } = specialist as any
+
+      const ok = await specialistTokenOrAdmin(request, reply, (specialist as any).accessToken)
+      if (!ok) return // resposta 401/403 já enviada
+
+      // Não retornar campos sensíveis (inclui o próprio accessToken).
+      const { asaasCustomerId, asaasSubscriptionId, cpfCnpj, accessToken, ...safe } = specialist as any
       return reply.send(safe)
     } catch (err: any) {
       return reply.status(500).send({ error: 'Erro ao buscar especialista', details: err.message })

--- a/apps/api/src/routes/specialists/payments.ts
+++ b/apps/api/src/routes/specialists/payments.ts
@@ -10,6 +10,7 @@ import { prisma } from '../../lib/prisma.js'
 import { env } from '../../utils/env.js'
 import { findOrCreateCustomer } from '../../services/asaas.service.js'
 import { safeStringEqual } from '../../utils/crypto-safe.js'
+import { specialistTokenOrAdmin } from './auth.js'
 
 const ASAAS_BASE_URL = env.ASAAS_BASE_URL ?? 'https://www.asaas.com/api/v3'
 const ASAAS_API_KEY  = env.ASAAS_API_KEY  ?? ''
@@ -415,14 +416,9 @@ export async function specialistPaymentRoutes(app: FastifyInstance) {
   })
 
   // ── DELETE /cancel — Cancela assinatura ──────────────────────────────────
-  // SEGURANÇA (interino): a rota era PÚBLICA — qualquer um cancelava a
-  // assinatura de qualquer especialista pelo id. Até existir o login por
-  // magic-link do especialista (token por e-mail/WhatsApp), o cancelamento
-  // exige um admin autenticado. TODO: trocar por token do especialista.
-  app.delete('/cancel/:specialistId', { preHandler: [app.authenticate] }, async (req, reply) => {
-    if (!['SUPER_ADMIN', 'ADMIN', 'MANAGER'].includes((req as any).user?.role)) {
-      return reply.status(403).send({ error: 'FORBIDDEN' })
-    }
+  // SEGURANÇA: o próprio especialista cancela via magic-link (?token=) OU um
+  // admin autenticado. Antes a rota era pública (qualquer um cancelava pelo id).
+  app.delete('/cancel/:specialistId', async (req, reply) => {
     const { specialistId } = req.params as { specialistId: string }
 
     if (!ASAAS_API_KEY) {
@@ -432,10 +428,14 @@ export async function specialistPaymentRoutes(app: FastifyInstance) {
     try {
       const specialist = await prisma.specialist.findUnique({
         where: { id: specialistId },
-        select: { asaasSubscriptionId: true, plan: true },
+        select: { asaasSubscriptionId: true, plan: true, accessToken: true },
       })
 
       if (!specialist) return reply.status(404).send({ error: 'Especialista não encontrado' })
+
+      const ok = await specialistTokenOrAdmin(req, reply, specialist.accessToken)
+      if (!ok) return // 401/403 já enviado
+
       if (!specialist.asaasSubscriptionId) return reply.status(400).send({ error: 'Nenhuma assinatura ativa' })
 
       await cancelSubscription(specialist.asaasSubscriptionId)
@@ -458,15 +458,20 @@ export async function specialistPaymentRoutes(app: FastifyInstance) {
   })
 
   // ── GET /status/:specialistId — Verifica status da assinatura ────────────
+  // SEGURANÇA: dados de plano/assinatura são privados — exige magic-link do
+  // próprio especialista (?token=) OU admin autenticado.
   app.get('/status/:specialistId', async (req, reply) => {
     const { specialistId } = req.params as { specialistId: string }
 
     const specialist = await prisma.specialist.findUnique({
       where: { id: specialistId },
-      select: { plan: true, planStatus: true, planActivatedAt: true, planExpiresAt: true, asaasSubscriptionId: true },
+      select: { plan: true, planStatus: true, planActivatedAt: true, planExpiresAt: true, asaasSubscriptionId: true, accessToken: true },
     })
 
     if (!specialist) return reply.status(404).send({ error: 'Especialista não encontrado' })
+
+    const ok = await specialistTokenOrAdmin(req, reply, specialist.accessToken)
+    if (!ok) return // 401/403 já enviado
 
     return reply.send({
       plan: specialist.plan,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1250,6 +1250,12 @@ async function runMigrations(prisma: any) {
            FOREIGN KEY ("carneId") REFERENCES "iptu_carnes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
        END IF;
      END $$`,
+
+    // ── users.cpf ── login white-label por telefone/CPF/e-mail ────────────────
+    // CPF permite ao parceiro logar pelo documento; único (NULLs coexistem no
+    // Postgres). Índice único idempotente.
+    `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "cpf" TEXT`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "users_cpf_key" ON "users"("cpf")`,
   ]
   for (const sql of recentMigrations) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -319,6 +319,10 @@ async function runMigrations(prisma: any) {
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "planExpiresAt" TIMESTAMP`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "asaasCustomerId" TEXT`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "asaasSubscriptionId" TEXT`,
+    // Magic-link de acesso ao painel do especialista (login sem senha).
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "accessToken" TEXT`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "accessTokenSentAt" TIMESTAMP`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS specialists_access_token_key ON specialists("accessToken")`,
     `CREATE INDEX IF NOT EXISTS specialists_plan_idx ON specialists(plan)`,
     `CREATE INDEX IF NOT EXISTS specialists_category_idx ON specialists(category)`,
     `CREATE INDEX IF NOT EXISTS buildings_city_idx ON buildings(city, state)`,

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -24,7 +24,10 @@ export interface RegisterInput {
 }
 
 export interface LoginInput {
-  email: string
+  // `identifier` = e-mail, telefone OU CPF (login white-label). `email` fica
+  // por compatibilidade com clientes antigos que ainda mandam só o e-mail.
+  identifier?: string
+  email?: string
   password: string
 }
 
@@ -33,6 +36,66 @@ export class AuthService {
     private readonly prisma: PrismaClient,
     private readonly app: FastifyInstance,
   ) {}
+
+  /**
+   * Resolve um usuário a partir de um identificador que pode ser e-mail,
+   * telefone ou CPF. E-mail e CPF são colunas únicas (lookup direto). Telefone
+   * pode estar formatado no banco, então comparamos só os dígitos via SQL.
+   * Um valor de 11 dígitos é ambíguo (CPF ou celular com DDD) — tentamos CPF
+   * primeiro e caímos para telefone.
+   */
+  private async findUserByIdentifier(raw: string): Promise<User | null> {
+    const trimmed = (raw ?? '').trim()
+    if (!trimmed) return null
+
+    if (trimmed.includes('@')) {
+      return this.prisma.user.findUnique({ where: { email: trimmed.toLowerCase() } })
+    }
+
+    const digits = trimmed.replace(/\D/g, '')
+    if (digits.length === 11) {
+      const byCpf = await this.prisma.user.findUnique({ where: { cpf: digits } })
+      if (byCpf) return byCpf
+    }
+
+    if (digits.length >= 8) {
+      const rows = await this.prisma.$queryRawUnsafe<{ id: string }[]>(
+        `SELECT id FROM users WHERE regexp_replace(coalesce(phone,''), '\\D', '', 'g') = $1 LIMIT 1`,
+        digits,
+      )
+      if (rows.length) {
+        return this.prisma.user.findUnique({ where: { id: rows[0].id } })
+      }
+    }
+
+    return null
+  }
+
+  /**
+   * Retorna apenas a marca da empresa do usuário (nome + logo + cor) para
+   * montar a tela de senha white-label. Não confirma senha nem devolve dados
+   * sensíveis; quando não encontra, devolve `company: null` e o front usa a
+   * marca padrão AgoraEncontrei.
+   */
+  async resolveCompanyBranding(identifier: string) {
+    const user = await this.findUserByIdentifier(identifier)
+    if (!user) return { company: null }
+
+    const company = await this.prisma.company.findUnique({
+      where: { id: user.companyId },
+      select: { name: true, tradeName: true, logoUrl: true, settings: true },
+    })
+    if (!company) return { company: null }
+
+    const settings = (company.settings as any) || {}
+    return {
+      company: {
+        name: company.tradeName || company.name,
+        logoUrl: company.logoUrl || settings.logoUrl || null,
+        primaryColor: settings.primaryColor || settings.primary_color || null,
+      },
+    }
+  }
 
   private async verifyPassword(passwordHash: string, plainPassword: string): Promise<boolean> {
     if (!passwordHash) return false
@@ -125,9 +188,11 @@ export class AuthService {
   // ── Login ────────────────────────────────────────────────────────────────
 
   async login(input: LoginInput, ipAddress?: string, userAgent?: string) {
-    const user = await this.prisma.user.findUnique({
-      where: { email: input.email.toLowerCase().trim() },
-    })
+    const identifier = input.identifier || input.email
+    if (!identifier) {
+      throw Object.assign(new Error('Credenciais inválidas'), { statusCode: 401, code: 'INVALID_CREDENTIALS' })
+    }
+    const user = await this.findUserByIdentifier(identifier)
 
     if (!user || !user.passwordHash) {
       throw Object.assign(new Error('Credenciais inválidas'), { statusCode: 401, code: 'INVALID_CREDENTIALS' })

--- a/apps/api/src/services/property-owner-notify.service.ts
+++ b/apps/api/src/services/property-owner-notify.service.ts
@@ -1,0 +1,108 @@
+import type { PrismaClient } from '@prisma/client'
+import { sendWhatsappText } from './whatsapp-notify.service.js'
+import { sendEmail, isEmailConfigured } from './email.service.js'
+
+// Rótulos amigáveis para os campos alterados (espelha o histórico do front).
+const FIELD_LABELS: Record<string, string> = {
+  title: 'Título', description: 'Descrição', price: 'Preço', priceRent: 'Aluguel',
+  status: 'Situação', type: 'Tipo', purpose: 'Finalidade', bedrooms: 'Quartos',
+  bathrooms: 'Banheiros', suites: 'Suítes', parkingSpaces: 'Vagas', area: 'Área',
+  totalArea: 'Área total', street: 'Rua', number: 'Número', neighborhood: 'Bairro',
+  city: 'Cidade', state: 'Estado', zipCode: 'CEP', condoFee: 'Condomínio',
+  iptu: 'IPTU', features: 'Características', coverImage: 'Foto de capa',
+  images: 'Fotos', isFeatured: 'Destaque', reference: 'Referência',
+}
+
+function labelFor(field: string): string {
+  return FIELD_LABELS[field] ?? field
+}
+
+export interface OwnerNotifyResult {
+  notified: number   // quantos proprietários receberam ao menos 1 canal
+  channels: number   // total de mensagens enviadas (WhatsApp + e-mail)
+  owners: number     // proprietários vinculados ao imóvel
+}
+
+/**
+ * Avisa os proprietários de um imóvel que ele foi atualizado. Disparado apenas
+ * quando o usuário marca "notificar proprietário" na edição. Best-effort: uma
+ * falha de canal (WhatsApp/e-mail) nunca quebra o fluxo de atualização.
+ */
+export async function notifyPropertyOwnersOfUpdate(
+  prisma: PrismaClient,
+  params: {
+    propertyId: string
+    changedFields: string[]
+    companyName?: string
+  },
+): Promise<OwnerNotifyResult> {
+  const property = await prisma.property.findUnique({
+    where: { id: params.propertyId },
+    select: { id: true, title: true, reference: true },
+  })
+  if (!property) return { notified: 0, channels: 0, owners: 0 }
+
+  const owners = await prisma.propertyOwner.findMany({
+    where: { propertyId: params.propertyId },
+    include: { contact: { select: { id: true, name: true, phone: true, email: true } } },
+  })
+  if (!owners.length) return { notified: 0, channels: 0, owners: 0 }
+
+  const changed = params.changedFields
+    .filter((f) => !['id', 'companyId', 'createdAt', 'updatedAt', 'userId', 'slug'].includes(f))
+    .map(labelFor)
+  const changeSummary = changed.length ? changed.join(', ') : 'informações do imóvel'
+  const ref = property.reference ? ` (ref. ${property.reference})` : ''
+  const brand = params.companyName?.trim() || 'AgoraEncontrei'
+
+  let notified = 0
+  let channels = 0
+
+  for (const o of owners) {
+    const c = (o as any).contact
+    if (!c) continue
+    const greeting = c.name ? `Olá, ${c.name}!` : 'Olá!'
+    const text =
+      `${greeting}\n\n` +
+      `${brand}: o seu imóvel *${property.title}*${ref} foi atualizado.\n\n` +
+      `Itens alterados: ${changeSummary}.\n\n` +
+      `Qualquer dúvida sobre a atualização, estamos à disposição.`
+
+    let sent = false
+
+    if (c.phone) {
+      try {
+        const ok = await sendWhatsappText(c.phone, text)
+        if (ok) { sent = true; channels++ }
+      } catch { /* canal indisponível — segue */ }
+    }
+
+    if (c.email && isEmailConfigured()) {
+      try {
+        await sendEmail({
+          to: c.email,
+          subject: `Seu imóvel foi atualizado — ${brand}`,
+          html: `
+            <div style="font-family:system-ui,-apple-system,sans-serif;max-width:560px;margin:0 auto;padding:32px;background:#f8f6f1;color:#1B2B5B">
+              <h1 style="color:#1B2B5B;margin:0 0 8px">${greeting}</h1>
+              <p style="margin:0 0 16px;color:#475569">
+                O seu imóvel <strong>${property.title}</strong>${ref} foi atualizado por <strong>${brand}</strong>.
+              </p>
+              <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:16px 20px;margin:16px 0">
+                <p style="margin:0 0 4px;color:#1B2B5B;font-weight:600">Itens alterados</p>
+                <p style="margin:0;color:#475569">${changeSummary}</p>
+              </div>
+              <p style="margin:16px 0 0;color:#475569">Qualquer dúvida sobre a atualização, estamos à disposição.</p>
+            </div>`,
+          text,
+        })
+        sent = true
+        channels++
+      } catch { /* e-mail indisponível — segue */ }
+    }
+
+    if (sent) notified++
+  }
+
+  return { notified, channels, owners: owners.length }
+}

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,27 +1,19 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
 import Link from 'next/link'
 import Script from 'next/script'
 import { useAuth } from '@/hooks/useAuth'
-import { ApiError } from '@/lib/api'
+import { ApiError, authApi } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { Eye, EyeOff, Loader2, ArrowLeft } from 'lucide-react'
 
 const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? '509328961791-4er50evaata1uota1stgpa2skqh7o9d7.apps.googleusercontent.com'
 
-const schema = z.object({
-  email: z.string().email('E-mail inválido'),
-  password: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
-})
-
-type FormData = z.infer<typeof schema>
+type Branding = { name: string; logoUrl: string | null; primaryColor: string | null }
 
 declare global {
   interface Window {
@@ -40,15 +32,19 @@ declare global {
 
 export default function LoginPage() {
   const { login, googleLogin } = useAuth()
+
+  // Login em 2 etapas (white-label): 'identify' → informa e-mail/telefone/CPF;
+  // 'password' → tela de senha com a marca da empresa do parceiro.
+  const [step, setStep] = useState<'identify' | 'password'>('identify')
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+  const [branding, setBranding] = useState<Branding | null>(null)
+
   const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState('')
+  const [resolving, setResolving] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
   const [googleLoading, setGoogleLoading] = useState(false)
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-  } = useForm<FormData>({ resolver: zodResolver(schema) })
 
   const handleGoogleSuccess = useCallback(async (credential: string) => {
     setGoogleLoading(true)
@@ -100,19 +96,48 @@ export default function LoginPage() {
     }
   }
 
-  async function onSubmit(data: FormData) {
+  // Etapa 1 → resolve a marca da empresa e avança para a senha.
+  async function onIdentify(e: React.FormEvent) {
+    e.preventDefault()
+    const id = identifier.trim()
+    if (id.length < 3) {
+      setError('Informe seu e-mail, telefone ou CPF')
+      return
+    }
     setError('')
+    setResolving(true)
     try {
-      await login(data.email, data.password)
+      const { company } = await authApi.resolveCompany(id)
+      setBranding(company) // pode ser null → usa marca padrão AgoraEncontrei
+      setStep('password')
+    } catch {
+      // Mesmo se a resolução falhar, deixamos seguir para a senha (a validação
+      // real acontece no login) — sem marca da empresa.
+      setBranding(null)
+      setStep('password')
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  // Etapa 2 → autentica com identifier + senha.
+  async function onLogin(e: React.FormEvent) {
+    e.preventDefault()
+    if (password.length < 6) {
+      setError('Senha deve ter pelo menos 6 caracteres')
+      return
+    }
+    setError('')
+    setSubmitting(true)
+    try {
+      await login(identifier.trim(), password)
     } catch (err) {
       if (err instanceof ApiError) {
         setError(
-          // Network/timeout (status 0) come first — they look the same to a
-          // user as "wrong password" if we don't differentiate them.
           err.code === 'NETWORK_ERROR' ? 'Servidor indisponível no momento. Tente novamente em alguns instantes.' :
           err.code === 'TIMEOUT' ? 'O servidor demorou demais para responder. Verifique sua internet ou tente novamente.' :
           err.code === 'PENDING_VERIFICATION' ? 'Verifique seu e-mail antes de fazer login. Cheque sua caixa de entrada e spam.' :
-          err.status === 401 ? 'E-mail ou senha incorretos' :
+          err.status === 401 ? 'Credenciais incorretas' :
           err.status === 403 ? 'Conta inativa ou suspensa. Contate o administrador.' :
           err.status === 429 ? 'Muitas tentativas. Aguarde alguns minutos e tente novamente.' :
           err.status >= 500 ? 'Erro interno do servidor. A equipe foi notificada — tente novamente em instantes.' :
@@ -121,8 +146,12 @@ export default function LoginPage() {
       } else {
         setError('Erro inesperado. Recarregue a página e tente novamente.')
       }
+    } finally {
+      setSubmitting(false)
     }
   }
+
+  const accent = branding?.primaryColor || undefined
 
   return (
     <>
@@ -132,90 +161,162 @@ export default function LoginPage() {
         onLoad={initGoogle}
       />
       <Card>
-        <CardHeader>
-          <CardTitle>Entrar</CardTitle>
-          <CardDescription>Acesse sua conta para gerenciar seus imóveis</CardDescription>
-        </CardHeader>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <CardContent className="space-y-4">
-            {error && (
-              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
-            )}
+        {step === 'identify' ? (
+          <>
+            <CardHeader>
+              <CardTitle>Entrar</CardTitle>
+              <CardDescription>Acesse com seu e-mail, telefone ou CPF</CardDescription>
+            </CardHeader>
+            <form onSubmit={onIdentify}>
+              <CardContent className="space-y-4">
+                {error && (
+                  <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+                )}
 
-            {/* Google Sign-In */}
-            <div className="space-y-2">
-              {googleLoading ? (
-                <div className="flex items-center justify-center h-10">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                {/* Google Sign-In */}
+                <div className="space-y-2">
+                  {googleLoading ? (
+                    <div className="flex items-center justify-center h-10">
+                      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : (
+                    <div id="google-signin-btn" className="w-full" />
+                  )}
                 </div>
-              ) : (
-                <div id="google-signin-btn" className="w-full" />
-              )}
-            </div>
 
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <span className="w-full border-t" />
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <span className="w-full border-t" />
+                  </div>
+                  <div className="relative flex justify-center text-xs uppercase">
+                    <span className="bg-card px-2 text-muted-foreground">ou</span>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="identifier">E-mail, telefone ou CPF</Label>
+                  <Input
+                    id="identifier"
+                    type="text"
+                    placeholder="seu@email.com, (16) 99999-9999 ou CPF"
+                    autoComplete="username"
+                    value={identifier}
+                    onChange={(e) => setIdentifier(e.target.value)}
+                    autoFocus
+                  />
+                </div>
+              </CardContent>
+
+              <CardFooter className="flex flex-col gap-3">
+                <Button type="submit" className="w-full" disabled={resolving || googleLoading}>
+                  {resolving && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Continuar
+                </Button>
+                <p className="text-sm text-muted-foreground text-center">
+                  Não tem conta?{' '}
+                  <Link href="/register" className="text-primary hover:underline font-medium">
+                    Criar conta
+                  </Link>
+                </p>
+              </CardFooter>
+            </form>
+          </>
+        ) : (
+          <>
+            <CardHeader>
+              {/* Marca da empresa do parceiro (white-label) */}
+              <div className="flex flex-col items-center gap-3 pb-1">
+                {branding?.logoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={branding.logoUrl}
+                    alt={branding.name}
+                    className="h-14 max-w-[200px] object-contain"
+                  />
+                ) : branding?.name ? (
+                  <div
+                    className="text-xl font-bold text-center"
+                    style={accent ? { color: accent } : undefined}
+                  >
+                    {branding.name}
+                  </div>
+                ) : null}
               </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-card px-2 text-muted-foreground">ou</span>
-              </div>
-            </div>
+              <CardTitle className="text-center">
+                {branding?.name ? `Entrar — ${branding.name}` : 'Entrar'}
+              </CardTitle>
+              <CardDescription className="text-center break-all">{identifier.trim()}</CardDescription>
+            </CardHeader>
+            <form onSubmit={onLogin}>
+              <CardContent className="space-y-4">
+                {error && (
+                  <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+                )}
 
-            <div className="space-y-2">
-              <Label htmlFor="email">E-mail</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="seu@email.com"
-                autoComplete="email"
-                {...register('email')}
-              />
-              {errors.email && <p className="text-xs text-destructive">{errors.email.message}</p>}
-            </div>
+                <div className="space-y-2">
+                  <Label htmlFor="password">Senha</Label>
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? 'text' : 'password'}
+                      placeholder="••••••••"
+                      autoComplete="current-password"
+                      className="pr-10"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </div>
+              </CardContent>
 
-            <div className="space-y-2">
-              <Label htmlFor="password">Senha</Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="••••••••"
-                  autoComplete="current-password"
-                  className="pr-10"
-                  {...register('password')}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              <CardFooter className="flex flex-col gap-3">
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={submitting}
+                  style={accent ? { backgroundColor: accent } : undefined}
                 >
-                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
-            </div>
-          </CardContent>
-
-          <CardFooter className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" disabled={isSubmitting || googleLoading}>
-              {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
-              Entrar
-            </Button>
-            <p className="text-sm text-muted-foreground text-center">
-              <Link href="/esqueci-senha" className="text-primary hover:underline font-medium">
-                Esqueci minha senha
-              </Link>
-            </p>
-            <p className="text-sm text-muted-foreground text-center">
-              Não tem conta?{' '}
-              <Link href="/register" className="text-primary hover:underline font-medium">
-                Criar conta
-              </Link>
-            </p>
-          </CardFooter>
-        </form>
+                  {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Entrar
+                </Button>
+                <div className="flex items-center justify-between w-full text-sm">
+                  <button
+                    type="button"
+                    onClick={() => { setStep('identify'); setPassword(''); setError('') }}
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <ArrowLeft className="h-3.5 w-3.5" /> Trocar
+                  </button>
+                  <Link href="/esqueci-senha" className="text-primary hover:underline font-medium">
+                    Esqueci minha senha
+                  </Link>
+                </div>
+              </CardFooter>
+            </form>
+          </>
+        )}
       </Card>
+
+      {/* Marca AgoraEncontrei — sempre visível (mesmo em contas white-label) */}
+      <p className="mt-4 text-center text-xs text-muted-foreground">
+        Plataforma por{' '}
+        <a
+          href="https://www.agoraencontrei.com.br"
+          target="_blank"
+          rel="noreferrer"
+          className="font-semibold text-primary hover:underline"
+        >
+          AgoraEncontrei
+        </a>
+      </p>
     </>
   )
 }

--- a/apps/web/src/app/(dashboard)/dashboard/historico-alteracoes/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/historico-alteracoes/page.tsx
@@ -219,9 +219,24 @@ export default function HistoricoAlteracoesPage() {
   const [page, setPage]         = useState(1)
   const [resource, setResource] = useState('')
   const [action, setAction]     = useState('')
+  const [userId, setUserId]     = useState('')
   const [from, setFrom]         = useState('')
   const [to, setTo]             = useState('')
   const [showFilters, setShowFilters] = useState(false)
+  const [companyUsers, setCompanyUsers] = useState<{ id: string; name: string }[]>([])
+
+  // Lista de usuários da empresa para o filtro "por usuário". Sem isso o
+  // gestor não conseguia isolar o histórico de um colaborador específico.
+  useEffect(() => {
+    if (!token) return
+    fetch(`${API_URL}/api/v1/users`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(r => (r.ok ? r.json() : []))
+      .then((data) => {
+        const arr = Array.isArray(data) ? data : (data?.data ?? [])
+        setCompanyUsers(arr.map((u: any) => ({ id: u.id, name: u.name })))
+      })
+      .catch(() => {})
+  }, [token])
 
   const fetchLogs = useCallback(async () => {
     if (!token) return
@@ -230,6 +245,7 @@ export default function HistoricoAlteracoesPage() {
       const params = new URLSearchParams({ page: String(page), limit: '30' })
       if (resource) params.set('resource', resource)
       if (action)   params.set('action', action)
+      if (userId)   params.set('userId', userId)
       if (from)     params.set('from', from)
       if (to)       params.set('to', to)
 
@@ -242,15 +258,15 @@ export default function HistoricoAlteracoesPage() {
       setMeta(data.meta ?? null)
     } catch {}
     finally { setLoading(false) }
-  }, [token, page, resource, action, from, to, router])
+  }, [token, page, resource, action, userId, from, to, router])
 
   useEffect(() => { fetchLogs() }, [fetchLogs])
 
   function clearFilters() {
-    setResource(''); setAction(''); setFrom(''); setTo(''); setPage(1)
+    setResource(''); setAction(''); setUserId(''); setFrom(''); setTo(''); setPage(1)
   }
 
-  const hasFilters = resource || action || from || to
+  const hasFilters = resource || action || userId || from || to
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
@@ -292,6 +308,21 @@ export default function HistoricoAlteracoesPage() {
           style={{ backgroundColor: '#f8f7f5', border: '1px solid #ddd9d0' }}
         >
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Usuário</label>
+              <select
+                value={userId}
+                onChange={e => { setUserId(e.target.value); setPage(1) }}
+                className="w-full text-sm border rounded-xl px-3 py-2 bg-white focus:outline-none"
+                style={{ borderColor: '#ddd9d0' }}
+              >
+                <option value="">Todos</option>
+                {companyUsers.map(u => (
+                  <option key={u.id} value={u.id}>{u.name}</option>
+                ))}
+              </select>
+            </div>
+
             <div>
               <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Recurso</label>
               <select

--- a/apps/web/src/app/(dashboard)/dashboard/properties/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/properties/[id]/page.tsx
@@ -16,7 +16,7 @@ import {
   ArrowLeft, Edit, Save, X, MapPin, BedDouble, Bath, Car, Ruler, Eye,
   Calendar, ImagePlus, Trash2, Star, Upload, Phone, Mail, User as UserIcon, ZoomIn,
   Home, Globe, Settings, Shield, Briefcase, Building2, Search, MessageSquare, Clock, Wand2, Film, Download,
-  AlertCircle, Power,
+  AlertCircle, Power, CheckCircle,
 } from 'lucide-react'
 import Link from 'next/link'
 import { useState, useRef, useEffect, useCallback } from 'react'
@@ -213,6 +213,9 @@ export default function PropertyDetailPage() {
   const isAdmin = user?.role === 'ADMIN' || user?.role === 'SUPER_ADMIN'
   const [editing, setEditing] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  // Avisar o proprietário sobre a atualização (apenas no salvamento manual).
+  const [notifyOwner, setNotifyOwner] = useState(false)
+  const [ownerNotifyMsg, setOwnerNotifyMsg] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('cadastro')
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
 
@@ -342,7 +345,9 @@ export default function PropertyDetailPage() {
   const updateMutation = useMutation({
     mutationFn: async (data: any) => {
       const token = await getValidToken()
-      const { publishOlx, publishZap, publishVivaReal, publishFacebook, metaKeywords, ...rest } = data
+      // `__notifyOwner` é um flag de controle (não é campo do imóvel): quando
+      // true, o backend avisa o proprietário sobre a atualização.
+      const { publishOlx, publishZap, publishVivaReal, publishFacebook, metaKeywords, __notifyOwner, ...rest } = data
       const clean: Record<string, unknown> = {}
       for (const [k, v] of Object.entries(rest)) {
         if (v !== '' && v !== undefined && v !== null) clean[k] = v
@@ -356,13 +361,27 @@ export default function PropertyDetailPage() {
       if (metaKeywords) {
         clean.metaKeywords = metaKeywords.split(',').map((k: string) => k.trim()).filter(Boolean)
       }
+      if (__notifyOwner) clean.notifyOwner = true
       return propertiesApi.update(token!, id, clean)
     },
-    onSuccess: () => {
+    onSuccess: (result: any) => {
       qc.invalidateQueries({ queryKey: ['property', id] })
       qc.invalidateQueries({ queryKey: ['properties'] })
       setEditing(false)
       setSaveError(null)
+      setNotifyOwner(false)
+      // Feedback do envio ao proprietário, quando solicitado.
+      const on = result?._ownerNotify
+      if (on && typeof on.notified === 'number') {
+        setOwnerNotifyMsg(
+          on.notified > 0
+            ? `Proprietário${on.notified > 1 ? 's' : ''} avisado${on.notified > 1 ? 's' : ''} da atualização (${on.notified}).`
+            : on.owners > 0
+              ? 'Não foi possível avisar o proprietário (sem WhatsApp/e-mail válido).'
+              : 'Nenhum proprietário vinculado a este imóvel.',
+        )
+        setTimeout(() => setOwnerNotifyMsg(null), 6000)
+      }
       // Revalidar páginas públicas imediatamente
       revalidatePublicPages([`/imoveis/${property?.slug || id}`, ...PAGES.properties])
     },
@@ -549,9 +568,20 @@ export default function PropertyDetailPage() {
             <>
               {autoSaveStatus === 'saving' && <span className="text-xs text-yellow-400 animate-pulse">Salvando...</span>}
               {autoSaveStatus === 'saved' && <span className="text-xs text-green-400">Salvo automaticamente</span>}
-              <Button variant="ghost" size="sm" onClick={() => { setEditing(false); setAutoSaveStatus('idle'); setSaveError(null); reset() }}
+              {p?.owners && p.owners.length > 0 && (
+                <label className="flex items-center gap-1.5 text-xs text-white/70 cursor-pointer select-none" title="Envia WhatsApp/e-mail ao proprietário informando o que mudou">
+                  <input
+                    type="checkbox"
+                    checked={notifyOwner}
+                    onChange={(e) => setNotifyOwner(e.target.checked)}
+                    className="h-3.5 w-3.5 accent-[#C9A84C]"
+                  />
+                  Avisar proprietário
+                </label>
+              )}
+              <Button variant="ghost" size="sm" onClick={() => { setEditing(false); setAutoSaveStatus('idle'); setSaveError(null); setNotifyOwner(false); reset() }}
                 className="text-white/60 h-8">Cancelar</Button>
-              <Button size="sm" onClick={handleSubmit((d) => updateMutation.mutate(d))}
+              <Button size="sm" onClick={handleSubmit((d) => updateMutation.mutate({ ...d, __notifyOwner: notifyOwner }))}
                 disabled={updateMutation.isPending} className="gap-2 h-8">
                 <Save className="h-3.5 w-3.5" />
                 {updateMutation.isPending ? 'Salvando...' : 'Salvar'}
@@ -560,6 +590,17 @@ export default function PropertyDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Owner-notify feedback */}
+      {ownerNotifyMsg && (
+        <div className="flex items-center gap-2 bg-emerald-500/10 border border-emerald-500/20 rounded-xl px-4 py-3">
+          <CheckCircle className="h-4 w-4 text-emerald-400 flex-shrink-0" />
+          <p className="text-emerald-300/90 text-sm flex-1">{ownerNotifyMsg}</p>
+          <button onClick={() => setOwnerNotifyMsg(null)} className="text-emerald-400/60 hover:text-emerald-400 ml-2">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       {/* Error banner */}
       {saveError && (
@@ -1312,9 +1353,20 @@ export default function PropertyDetailPage() {
                 <p className="text-red-400/90 text-sm flex-1">{saveError}</p>
               </div>
             )}
-            <div className="flex justify-end gap-3">
-              <Button variant="ghost" onClick={() => { setEditing(false); setSaveError(null); reset() }} className="text-white/60">Cancelar</Button>
-              <Button onClick={handleSubmit((d) => updateMutation.mutate(d))}
+            <div className="flex justify-end items-center gap-3 flex-wrap">
+              {p?.owners && p.owners.length > 0 && (
+                <label className="flex items-center gap-1.5 text-xs text-white/70 cursor-pointer select-none mr-auto" title="Envia WhatsApp/e-mail ao proprietário informando o que mudou">
+                  <input
+                    type="checkbox"
+                    checked={notifyOwner}
+                    onChange={(e) => setNotifyOwner(e.target.checked)}
+                    className="h-3.5 w-3.5 accent-[#C9A84C]"
+                  />
+                  Avisar proprietário da atualização
+                </label>
+              )}
+              <Button variant="ghost" onClick={() => { setEditing(false); setSaveError(null); setNotifyOwner(false); reset() }} className="text-white/60">Cancelar</Button>
+              <Button onClick={handleSubmit((d) => updateMutation.mutate({ ...d, __notifyOwner: notifyOwner }))}
                 disabled={updateMutation.isPending} className="gap-2 min-w-[120px]">
                 <Save className="h-3.5 w-3.5" />
                 {updateMutation.isPending ? 'Salvando...' : 'Salvar Alterações'}

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -10,6 +10,7 @@ import { notFound } from 'next/navigation'
 import { MapPin, Home, Search, ChevronRight } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
 import { CitySeoContent } from '@/components/public/CitySeoContent'
+import { isBuildPhase } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
@@ -89,9 +90,14 @@ export async function generateMetadata(props: { params: Promise<{ estado: string
   }
 }
 
-export const revalidate = 86400
+// 1h: como os imóveis não são buscados no build (ISR preenche depois), um
+// revalidate curto faz o conteúdo real aparecer logo após o deploy em vez de
+// só em 24h.
+export const revalidate = 3600
 
 async function fetchProperties(cityName: string, cluster: string) {
+  // Nunca bloqueia o build na API — ISR preenche na 1ª requisição real.
+  if (isBuildPhase()) return []
   try {
     const purposeMap: Record<string, string> = {
       'imoveis-a-venda': 'SALE', 'casas-a-venda': 'SALE', 'apartamentos-a-venda': 'SALE',

--- a/apps/web/src/app/(public)/comparar/[cidadeA]-vs-[cidadeB]/page.tsx
+++ b/apps/web/src/app/(public)/comparar/[cidadeA]-vs-[cidadeB]/page.tsx
@@ -20,30 +20,45 @@ export const revalidate = 86400
 const ALL_CITIES_SORTED = IBGE_CITIES_152
   .sort((a, b) => b.populacao - a.populacao)
 
+// A pasta declara DOIS params no mesmo segmento (`[cidadeA]-vs-[cidadeB]`),
+// então o Next entrega `params.cidadeA` e `params.cidadeB` — não uma única
+// chave. Gerar/ler com a chave errada deixava `params[...]` undefined e o
+// `.split` estourava 500. Este tipo cobre as duas formas por segurança.
+type CompareParams = { cidadeA?: string; cidadeB?: string; 'cidadeA-vs-cidadeB'?: string }
+
 export function generateStaticParams() {
   if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
-  const params: { 'cidadeA-vs-cidadeB': string }[] = []
+  const params: { cidadeA: string; cidadeB: string }[] = []
   for (let i = 0; i < ALL_CITIES_SORTED.length; i++) {
     for (let j = i + 1; j < ALL_CITIES_SORTED.length; j++) {
       params.push({
-        'cidadeA-vs-cidadeB': `${ALL_CITIES_SORTED[i].slug}-vs-${ALL_CITIES_SORTED[j].slug}`,
+        cidadeA: ALL_CITIES_SORTED[i].slug,
+        cidadeB: ALL_CITIES_SORTED[j].slug,
       })
     }
   }
   return params
 }
 
-function parseSlugs(param: string): { slugA: string; slugB: string } | null {
-  const parts = param.split('-vs-')
-  if (parts.length !== 2) return null
-  return { slugA: parts[0], slugB: parts[1] }
+// Resolve os dois slugs qualquer que seja o formato de params entregue.
+function resolveSlugs(params: CompareParams): { slugA: string; slugB: string } | null {
+  if (params.cidadeA && params.cidadeB) {
+    return { slugA: params.cidadeA, slugB: params.cidadeB }
+  }
+  const combo = params['cidadeA-vs-cidadeB']
+    ?? Object.values(params).find((v) => typeof v === 'string' && v.includes('-vs-'))
+  if (typeof combo === 'string') {
+    const parts = combo.split('-vs-')
+    if (parts.length === 2 && parts[0] && parts[1]) return { slugA: parts[0], slugB: parts[1] }
+  }
+  return null
 }
 
 export async function generateMetadata(
-  props: { params: Promise<{ 'cidadeA-vs-cidadeB': string }> }
+  props: { params: Promise<CompareParams> }
 ): Promise<Metadata> {
   const params = await props.params
-  const parsed = parseSlugs(params['cidadeA-vs-cidadeB'])
+  const parsed = resolveSlugs(params)
   if (!parsed) return {}
   const cityA = IBGE_CITY_BY_SLUG[parsed.slugA]
   const cityB = IBGE_CITY_BY_SLUG[parsed.slugB]
@@ -60,7 +75,7 @@ export async function generateMetadata(
       siteName: 'AgoraEncontrei',
     },
     alternates: {
-      canonical: `https://agoraencontrei.com.br/comparar/${params['cidadeA-vs-cidadeB']}`,
+      canonical: `https://agoraencontrei.com.br/comparar/${cityA.slug}-vs-${cityB.slug}`,
     },
   }
 }
@@ -113,10 +128,10 @@ function CompareBar({ label, valueA, valueB, nameA, nameB, format = 'number' }: 
 }
 
 export default async function CompareCidadesPage(
-  props: { params: Promise<{ 'cidadeA-vs-cidadeB': string }> }
+  props: { params: Promise<CompareParams> }
 ) {
   const params = await props.params
-  const parsed = parseSlugs(params['cidadeA-vs-cidadeB'])
+  const parsed = resolveSlugs(params)
   if (!parsed) notFound()
 
   const cityA = IBGE_CITY_BY_SLUG[parsed.slugA]
@@ -128,7 +143,7 @@ export default async function CompareCidadesPage(
     '@type': 'Article',
     name: `${cityA.name} vs ${cityB.name} — Comparação`,
     description: `Comparação de custo de vida e mercado imobiliário entre ${cityA.name}/${cityA.state} e ${cityB.name}/${cityB.state}`,
-    url: `https://agoraencontrei.com.br/comparar/${params['cidadeA-vs-cidadeB']}`,
+    url: `https://agoraencontrei.com.br/comparar/${cityA.slug}-vs-${cityB.slug}`,
   }
 
   return (

--- a/apps/web/src/app/(public)/imoveis/em/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/em/[cidade]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { LoadMoreProperties } from '../../LoadMoreProperties'
 import { canonicalFromCitySlug, canonicalFromCityUf } from '@/lib/seo-canonical'
+import { isBuildPhase } from '@/lib/ssg-runtime'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -368,6 +369,10 @@ function cityToSlug(city: string): string {
 async function fetchCityData(citySlug: string) {
   const cidade = CIDADES[citySlug]
   const cityName = cidade?.nome ?? slugToCity(citySlug)
+
+  // Não bloqueia o build na API — ISR preenche os imóveis/bairros na 1ª
+  // revalidação. (Estes fetches nem tinham timeout, então travavam o build.)
+  if (isBuildPhase()) return { properties: [], total: 0, neighborhoods: [], cityName, citySlug }
 
   try {
     const [propertiesRes, neighborhoodsRes] = await Promise.all([

--- a/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/perto-de/[poi]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { MapPin, Home, School, Hospital, ShoppingBag, Building, MessageCircle, ArrowRight, Navigation } from 'lucide-react'
+import { isBuildPhase } from '@/lib/ssg-runtime'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const WEB_URL = 'https://www.agoraencontrei.com.br'
@@ -80,6 +81,7 @@ export function generateStaticParams() {
 }
 
 async function fetchNearbyProperties(city: string, neighborhood?: string) {
+  if (isBuildPhase()) return []  // não bloqueia o build na API; ISR preenche depois
   try {
     const params = new URLSearchParams({ city, limit: '12', sortBy: 'createdAt', sortOrder: 'desc' })
     if (neighborhood) params.set('neighborhood', neighborhood)

--- a/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/leilao-imoveis/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { MapPin, Home, Building, TrendingUp, MessageCircle, ArrowRight, Search } from 'lucide-react'
+import { isBuildPhase } from '@/lib/ssg-runtime'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const WEB_URL = 'https://www.agoraencontrei.com.br'
@@ -74,6 +75,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 async function fetchAuctions(bairro: string, cidade: string) {
+  if (isBuildPhase()) return []  // não bloqueia o build na API; ISR preenche depois
   // Try API
   try {
     const res = await fetch(`${API_URL}/api/v1/auctions?city=${encodeURIComponent(cidade)}&search=${encodeURIComponent(bairro)}&limit=20`, { next: { revalidate: 3600 }, signal: AbortSignal.timeout(5000) })

--- a/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/leilao/[estado]/[cidade]/page.tsx
@@ -7,6 +7,7 @@ import { Metadata } from 'next'
 import Link from 'next/link'
 import { generateAllBlocks } from '@/lib/seo-content-blocks'
 import { SEOFooterLinks } from '@/components/SEOFooterLinks'
+import { isBuildPhase } from '@/lib/ssg-runtime'
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ?? 'https://api-production-669c.up.railway.app'
@@ -62,6 +63,22 @@ async function fetchData(
   cidade: string,
   estado: string,
 ): Promise<PropertyIntel> {
+  // Não bloqueia o build na API — usa o fallback estático; ISR busca os dados
+  // reais na 1ª revalidação.
+  if (isBuildPhase()) {
+    return {
+      cityName: slugToName(cidade),
+      stateName: estado.toUpperCase(),
+      avgDiscount: 35,
+      avgPriceMarket: 4500,
+      avgPriceAuction: 2925,
+      avgRent: 1800,
+      totalListings: 12,
+      population: 0,
+      idhm: 0,
+      listings: [],
+    }
+  }
   try {
     const res = await fetch(
       `${API_URL}/api/v1/public/property-intelligence?city=${cidade}&state=${estado}`,

--- a/apps/web/src/app/(public)/meu-painel/page.tsx
+++ b/apps/web/src/app/(public)/meu-painel/page.tsx
@@ -77,35 +77,39 @@ const PORTFOLIO_STEPS = [
 export default function MeuPainelPage() {
   const [specialist, setSpecialist] = useState<Specialist | null>(null)
   const [loading, setLoading] = useState(true)
-  const [email, setEmail] = useState('')
+  const [token, setToken] = useState<string | null>(null)
   const [emailInput, setEmailInput] = useState('')
   const [error, setError] = useState('')
+  const [requestSent, setRequestSent] = useState(false)
+  const [requesting, setRequesting] = useState(false)
   const [upgrading, setUpgrading] = useState(false)
   const [upgradeSuccess, setUpgradeSuccess] = useState(false)
   const [analytics, setAnalytics] = useState<any>(null)
   const [territories, setTerritories] = useState<any[]>([])
   const [loadingAnalytics, setLoadingAnalytics] = useState(false)
 
-  // Buscar especialista pelo email (autenticação simples por email)
-  const handleEmailSearch = async () => {
+  // Login sem senha: o especialista pede um link por e-mail/WhatsApp. O
+  // servidor rotaciona o accessToken e envia o magic-link; nada de senha e
+  // nada de enumeração (resposta idêntica exista ou não o e-mail).
+  const handleRequestAccess = async () => {
     if (!emailInput.trim()) return
-    setLoading(true)
+    setRequesting(true)
     setError('')
     try {
-      const res = await fetch(`${API_URL}/api/v1/specialists/by-email/${encodeURIComponent(emailInput.trim())}`)
-      if (!res.ok) {
-        setError('Nenhum perfil encontrado com este e-mail. Verifique ou cadastre-se.')
-        setSpecialist(null)
+      const res = await fetch(`${API_URL}/api/v1/specialists/request-access`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailInput.trim() }),
+      })
+      if (!res.ok && res.status !== 200) {
+        setError('Não foi possível enviar o link agora. Tente novamente.')
       } else {
-        const data = await res.json()
-        setSpecialist(data)
-        setEmail(emailInput.trim())
-        localStorage.setItem('specialist_email', emailInput.trim())
+        setRequestSent(true)
       }
     } catch {
-      setError('Erro ao buscar perfil. Tente novamente.')
+      setError('Erro de conexão. Tente novamente.')
     } finally {
-      setLoading(false)
+      setRequesting(false)
     }
   }
 
@@ -113,31 +117,54 @@ export default function MeuPainelPage() {
   useEffect(() => {
     if (!specialist?.id) return
     setLoadingAnalytics(true)
+    const qs = token ? `?token=${encodeURIComponent(token)}` : ''
     Promise.all([
-      fetch(`${API_URL}/api/v1/public/partner-stats/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch(`${API_URL}/api/v1/public/partner-stats/${specialist.id}${qs}`).then(r => r.ok ? r.json() : null).catch(() => null),
       fetch(`${API_URL}/api/v1/public/territory/my/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
     ]).then(([analyticsData, territoryData]) => {
       if (analyticsData) setAnalytics(analyticsData)
       if (territoryData?.territories) setTerritories(territoryData.territories)
     }).finally(() => setLoadingAnalytics(false))
-  }, [specialist?.id])
+  }, [specialist?.id, token])
 
-  // Verificar email salvo no localStorage
+  // Resolver a sessão pelo magic-link (?token=) ou por um token já salvo.
   useEffect(() => {
-    const saved = localStorage.getItem('specialist_email')
-    if (saved) {
-      setEmailInput(saved)
-      setEmail(saved)
-      fetch(`${API_URL}/api/v1/specialists/by-email/${encodeURIComponent(saved)}`)
-        .then(r => r.ok ? r.json() : null)
-        .then(data => {
-          if (data) setSpecialist(data)
-          setLoading(false)
-        })
-        .catch(() => setLoading(false))
-    } else {
-      setLoading(false)
+    let activeToken: string | null = null
+    try {
+      const url = new URL(window.location.href)
+      const urlToken = url.searchParams.get('token')
+      if (urlToken) {
+        activeToken = urlToken
+        localStorage.setItem('specialist_token', urlToken)
+        // Limpa o token da barra de endereço (evita vazar em histórico/print).
+        url.searchParams.delete('token')
+        window.history.replaceState({}, '', url.pathname + url.search)
+      } else {
+        activeToken = localStorage.getItem('specialist_token')
+      }
+    } catch {
+      activeToken = null
     }
+
+    if (!activeToken) {
+      setLoading(false)
+      return
+    }
+
+    setToken(activeToken)
+    fetch(`${API_URL}/api/v1/specialists/session?token=${encodeURIComponent(activeToken)}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (data && data.id) {
+          setSpecialist(data)
+        } else {
+          // Token inválido/expirado — limpa para cair na tela de pedir link.
+          localStorage.removeItem('specialist_token')
+          setToken(null)
+        }
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
   }, [])
 
   const handleUpgrade = async (plan: 'PRIME' | 'VIP') => {
@@ -180,43 +207,66 @@ export default function MeuPainelPage() {
     return false
   }
 
-  // Estado: não logado
+  // Estado: não logado → pedir magic-link (login sem senha)
   if (!loading && !specialist) {
     return (
       <div className="min-h-screen bg-[#f8f6f1] flex items-center justify-center px-4">
         <div className="bg-white rounded-2xl border shadow-sm p-8 max-w-md w-full text-center">
-          <User className="w-12 h-12 text-[#143A1F] mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-[#143A1F] mb-2" style={{ fontFamily: 'Georgia, serif' }}>
-            Meu Painel de Parceiro
-          </h1>
-          <p className="text-gray-500 mb-6 text-sm">
-            Digite o e-mail cadastrado para acessar seu painel
-          </p>
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 rounded-xl p-3 mb-4 text-sm flex items-center gap-2">
-              <AlertCircle className="w-4 h-4 flex-shrink-0" /> {error}
-            </div>
+          {requestSent ? (
+            <>
+              <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-4" />
+              <h1 className="text-2xl font-bold text-[#143A1F] mb-2" style={{ fontFamily: 'Georgia, serif' }}>
+                Link enviado!
+              </h1>
+              <p className="text-gray-500 mb-6 text-sm">
+                Se houver um cadastro com <strong>{emailInput.trim()}</strong>, você vai receber um
+                link de acesso por e-mail e WhatsApp. Abra o link para entrar no seu painel — sem senha.
+              </p>
+              <button
+                onClick={() => { setRequestSent(false); setError('') }}
+                className="text-[#C9A84C] text-sm font-medium hover:underline"
+              >
+                Usar outro e-mail
+              </button>
+            </>
+          ) : (
+            <>
+              <Lock className="w-12 h-12 text-[#143A1F] mx-auto mb-4" />
+              <h1 className="text-2xl font-bold text-[#143A1F] mb-2" style={{ fontFamily: 'Georgia, serif' }}>
+                Meu Painel de Parceiro
+              </h1>
+              <p className="text-gray-500 mb-6 text-sm">
+                Informe o e-mail cadastrado e enviamos um link de acesso seguro
+                (sem senha) por e-mail e WhatsApp.
+              </p>
+              {error && (
+                <div className="bg-red-50 border border-red-200 text-red-600 rounded-xl p-3 mb-4 text-sm flex items-center gap-2">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0" /> {error}
+                </div>
+              )}
+              <input
+                type="email"
+                value={emailInput}
+                onChange={e => setEmailInput(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleRequestAccess()}
+                placeholder="seu@email.com"
+                className="w-full border rounded-xl px-4 py-3 text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-[#143A1F]"
+              />
+              <button
+                onClick={handleRequestAccess}
+                disabled={requesting}
+                className="w-full bg-[#143A1F] text-white rounded-xl py-3 font-bold text-sm hover:bg-[#0E2A15] transition-colors disabled:opacity-60"
+              >
+                {requesting ? 'Enviando...' : 'Enviar link de acesso'}
+              </button>
+              <p className="text-gray-400 text-xs mt-4">
+                Ainda não tem perfil?{' '}
+                <Link href="/parceiros/cadastro" className="text-[#C9A84C] font-medium hover:underline">
+                  Cadastre-se grátis
+                </Link>
+              </p>
+            </>
           )}
-          <input
-            type="email"
-            value={emailInput}
-            onChange={e => setEmailInput(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleEmailSearch()}
-            placeholder="seu@email.com"
-            className="w-full border rounded-xl px-4 py-3 text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-[#143A1F]"
-          />
-          <button
-            onClick={handleEmailSearch}
-            className="w-full bg-[#143A1F] text-white rounded-xl py-3 font-bold text-sm hover:bg-[#0E2A15] transition-colors"
-          >
-            Acessar meu painel
-          </button>
-          <p className="text-gray-400 text-xs mt-4">
-            Ainda não tem perfil?{' '}
-            <Link href="/parceiros/cadastro" className="text-[#C9A84C] font-medium hover:underline">
-              Cadastre-se grátis
-            </Link>
-          </p>
         </div>
       </div>
     )

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -32,9 +32,10 @@ export function useAuth() {
     return refreshPromise
   }, [accessToken, refreshToken, isTokenExpired, setAuth, clearAuth])
 
+  // `identifier` = e-mail, telefone ou CPF (login white-label).
   const login = useCallback(
-    async (email: string, password: string) => {
-      const data = await authApi.login(email, password)
+    async (identifier: string, password: string) => {
+      const data = await authApi.login(identifier, password)
       setAuth(data.user as any, data.accessToken, data.expiresIn, data.refreshToken)
       router.push('/dashboard')
     },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -93,9 +93,16 @@ export const authApi = {
     '/api/v1/auth/register', { method: 'POST', body: JSON.stringify(body) }
   ),
 
-  login: (email: string, password: string) =>
+  // `identifier` pode ser e-mail, telefone ou CPF (login white-label).
+  login: (identifier: string, password: string) =>
     request<{ user: User; accessToken: string; refreshToken: string; expiresIn: number }>(
-      '/api/v1/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }
+      '/api/v1/auth/login', { method: 'POST', body: JSON.stringify({ identifier, password }) }
+    ),
+
+  // Etapa 1 do login white-label: resolve a marca da empresa do parceiro.
+  resolveCompany: (identifier: string) =>
+    request<{ company: { name: string; logoUrl: string | null; primaryColor: string | null } | null }>(
+      '/api/v1/auth/resolve-company', { method: 'POST', body: JSON.stringify({ identifier }) }
     ),
 
   logout: () => request('/api/v1/auth/logout', { method: 'POST' }),

--- a/apps/web/src/lib/ssg-runtime.ts
+++ b/apps/web/src/lib/ssg-runtime.ts
@@ -1,0 +1,18 @@
+/**
+ * Detecta se o código está rodando durante o `next build` (fase de geração
+ * estática) em vez de em uma requisição real (ISR/SSR).
+ *
+ * As páginas programáticas de SEO buscam imóveis na API para renderizar. Fazer
+ * essa chamada durante o build multiplicada por milhares de cidades deixa o
+ * build refém da API: uma resposta lenta/fria estoura o limite de tempo por
+ * página do Next (60s) e quebra o deploy inteiro.
+ *
+ * Pulando o fetch no build, a página é gerada instantaneamente (sem dados) e o
+ * ISR preenche os imóveis na primeira revalidação. As páginas geradas sob
+ * demanda (fora do generateStaticParams) continuam buscando normalmente, pois
+ * aí não é fase de build.
+ */
+export function isBuildPhase(): boolean {
+  return process.env.NEXT_PHASE === 'phase-production-build'
+    || process.env.SSG_SKIP_FETCH === '1'
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "lint": "pnpm --parallel --filter './apps/*' lint",
     "typecheck": "pnpm --parallel --filter './apps/*' typecheck",
     "scrape:caixa": "npx tsx scripts/scrape-caixa.ts",
-    "scrape:all": "npx tsx scripts/scrape-caixa.ts"
+    "scrape:all": "npx tsx scripts/scrape-caixa.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test tests/public-pages-smoke.spec.ts"
   },
   "engines": {
     "node": "22.x",

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -178,6 +178,7 @@ model User {
   name              String
   email             String      @unique
   phone             String?
+  cpf               String?     @unique
   passwordHash      String?
   avatarUrl         String?
   role              UserRole    @default(BROKER)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2545,6 +2545,12 @@ model Specialist {
   buildings          SpecialistBuilding[]
   welcomeEmailSentAt DateTime?
 
+  // Magic-link de acesso ao painel do especialista. O especialista não usa
+  // JWT/senha da plataforma — pede um link por e-mail/WhatsApp e esse token
+  // (rotacionável) autentica o acesso aos próprios dados privados.
+  accessToken        String?            @unique
+  accessTokenSentAt  DateTime?
+
   // Pagamentos Asaas
   cpfCnpj            String?
   plan               SpecialistPlan     @default(START)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright E2E — smoke/regressão contra um ambiente já publicado.
+ *
+ * Base URL vem de E2E_BASE_URL (default: produção). Para rodar contra um
+ * deploy de preview: `E2E_BASE_URL=https://<preview> pnpm test:e2e`.
+ * Chromium já vem instalado no ambiente (PLAYWRIGHT_BROWSERS_PATH).
+ */
+const BASE_URL = process.env.E2E_BASE_URL || 'https://agoraencontrei.com.br'
+
+// Usa o Chromium já instalado no ambiente quando presente (evita o download do
+// browser, que é bloqueado). Em outros ambientes cai no browser padrão do
+// Playwright. Ajuste/remova via PW_CHROMIUM_PATH se necessário.
+const CHROMIUM_PATH = process.env.PW_CHROMIUM_PATH || '/opt/pw-browsers/chromium'
+let executablePath: string | undefined
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  if (require('node:fs').existsSync(CHROMIUM_PATH)) executablePath = CHROMIUM_PATH
+} catch { /* usa o default do Playwright */ }
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: ['tests/**/*.spec.ts', 'e2e/**/*.spec.ts'],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    ignoreHTTPSErrors: true,
+    // Roteia o tráfego do browser pelo proxy do ambiente quando presente (sem
+    // ele, page.goto para hosts externos leva ERR_CONNECTION_RESET).
+    ...(process.env.HTTPS_PROXY || process.env.https_proxy
+      ? { proxy: { server: (process.env.HTTPS_PROXY || process.env.https_proxy) as string } }
+      : {}),
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(executablePath ? { launchOptions: { executablePath } } : {}),
+      },
+    },
+  ],
+})

--- a/tests/e2e-agoraencontrei.spec.ts
+++ b/tests/e2e-agoraencontrei.spec.ts
@@ -5,14 +5,30 @@ const DASHBOARD_URL = 'https://agoraencontrei.com.br/dashboard';
 const EMAIL = process.env.E2E_EMAIL || 'tomas@agoraencontrei.com.br';
 const PASSWORD = process.env.E2E_PASSWORD || 'Lemos2026@';
 
+// Login white-label em 2 etapas: 1) identificador (e-mail/telefone/CPF) →
+// "Continuar"; 2) senha → "Entrar". Mantém fallback para o fluxo antigo de
+// um passo caso a página ainda não tenha o novo layout.
+async function doLogin(page: Page) {
+  // Etapa 1 — identificador
+  const identifier = page.locator('#identifier, input[name="email"], input[type="email"]').first();
+  await identifier.fill(EMAIL);
+  const continuar = page.locator('button:has-text("Continuar")');
+  if (await continuar.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await continuar.click();
+    // Etapa 2 — senha aparece após resolver a empresa
+    await page.locator('#password, input[type="password"]').first().waitFor({ timeout: 10000 });
+  }
+  // Etapa 2 (ou fluxo antigo) — senha
+  await page.locator('#password, input[type="password"]').first().fill(PASSWORD);
+  await page.click('button[type="submit"], button:has-text("Entrar"), button:has-text("Acessar")');
+  await page.waitForLoadState('networkidle');
+}
+
 async function loginIfNeeded(page: Page) {
   await page.goto(DASHBOARD_URL);
   await page.waitForLoadState('networkidle');
   if (page.url().includes('login') || page.url().includes('auth')) {
-    await page.fill('input[type="email"], input[name="email"]', EMAIL);
-    await page.fill('input[type="password"], input[name="password"]', PASSWORD);
-    await page.click('button[type="submit"], button:has-text("Entrar"), button:has-text("Login"), button:has-text("Acessar")');
-    await page.waitForLoadState('networkidle');
+    await doLogin(page);
   }
 }
 
@@ -64,15 +80,11 @@ test.describe('AgoraEncontrei — Testes E2E Completos', () => {
     expect(count).toBeGreaterThan(2);
   });
 
-  test('6. Login no dashboard', async ({ page }) => {
+  test('6. Login no dashboard (fluxo white-label em 2 etapas)', async ({ page }) => {
     await page.goto(`${BASE_URL}/login`);
     await page.waitForLoadState('networkidle');
     await page.screenshot({ path: 'screenshots/06-pre-login.png' });
-    await page.fill('input[type="email"], input[name="email"]', EMAIL);
-    await page.fill('input[type="password"], input[name="password"]', PASSWORD);
-    await page.screenshot({ path: 'screenshots/06-login-preenchido.png' });
-    await page.click('button[type="submit"], button:has-text("Entrar"), button:has-text("Acessar")');
-    await page.waitForLoadState('networkidle');
+    await doLogin(page);
     await page.screenshot({ path: 'screenshots/06-pos-login.png', fullPage: false });
     console.log('URL pos-login:', page.url());
   });

--- a/tests/public-pages-smoke.spec.ts
+++ b/tests/public-pages-smoke.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, request as pwRequest } from '@playwright/test'
+
+/**
+ * Smoke de páginas públicas + rotas que já quebraram em produção. Roda contra
+ * E2E_BASE_URL (default produção). Valida que nenhuma responde 5xx — em
+ * especial /comparar (que retornava 500 por ler o param errado) e os sitemaps
+ * (que já ficaram 404/timeout).
+ */
+const BASE_URL = process.env.E2E_BASE_URL || 'https://agoraencontrei.com.br'
+
+// Rotas públicas críticas — devem responder 2xx (ou 3xx), nunca 5xx.
+const PUBLIC_ROUTES = [
+  '/',
+  '/leiloes',
+  '/imoveis-a-venda',
+  '/imoveis-para-alugar',
+  '/comparar',
+  '/comparar/franca-vs-ribeirao-preto', // combinação city-vs-city (regressão do 500)
+  '/especialistas',
+  '/meu-painel',                          // painel do especialista (magic-link)
+  '/login',
+  '/parceiros/cadastro',
+]
+
+// Sitemaps que precisam responder 200 e conter XML.
+const SITEMAP_ROUTES = [
+  '/sitemap-index.xml',
+  '/sitemaps/cidades',
+  '/sitemaps/blog',
+]
+
+test.describe('Público — smoke de disponibilidade', () => {
+  for (const route of PUBLIC_ROUTES) {
+    test(`GET ${route} não retorna 5xx`, async () => {
+      const ctx = await pwRequest.newContext()
+      const res = await ctx.get(`${BASE_URL}${route}`, { maxRedirects: 5, timeout: 30_000 })
+      const status = res.status()
+      console.log(`${route} → ${status}`)
+      expect(status, `${route} deveria responder < 500`).toBeLessThan(500)
+      await ctx.dispose()
+    })
+  }
+
+  for (const route of SITEMAP_ROUTES) {
+    test(`sitemap ${route} responde 200 XML`, async () => {
+      const ctx = await pwRequest.newContext()
+      const res = await ctx.get(`${BASE_URL}${route}`, { timeout: 30_000 })
+      console.log(`${route} → ${res.status()}`)
+      expect(res.status()).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('<')
+      await ctx.dispose()
+    })
+  }
+})
+
+test.describe('Comparar cidades — conteúdo', () => {
+  test('/comparar/franca-vs-ribeirao-preto renderiza os dois nomes', async ({ page }) => {
+    const res = await page.goto(`${BASE_URL}/comparar/franca-vs-ribeirao-preto`, { waitUntil: 'domcontentloaded' })
+    // A correção do 500: a página deve montar (não 5xx) e mostrar o comparativo.
+    expect(res?.status() ?? 200).toBeLessThan(500)
+    await expect(page.locator('h1')).toContainText('vs')
+    await expect(page.locator('text=Comparação Detalhada')).toBeVisible()
+  })
+})
+
+test.describe('Login white-label — etapa 1', () => {
+  test('/login mostra campo de identificador e marca AgoraEncontrei', async ({ page }) => {
+    await page.goto(`${BASE_URL}/login`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator('#identifier, input[name="email"], input[type="email"]').first()).toBeVisible()
+    // Selo de propaganda AgoraEncontrei sempre presente.
+    await expect(page.locator('text=AgoraEncontrei').first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
## 🔴 Correção prioritária — build de produção quebrado

O `next build` estava falhando no Railway (deploys #256/#257): a geração estática das páginas programáticas de SEO travava (ex.: `/mg/para-de-minas/imoveis-para-alugar`). Cada página buscava a API **durante o build** e, para cidades da cauda longa, uma resposta lenta/fria estourava o limite de 60s por página do Next (3 tentativas) e abortava o `next build` inteiro. `imoveis/em/[cidade]` ainda tinha **dois `fetch` sem timeout nenhum**.

**Fix:** `lib/ssg-runtime.ts` (`isBuildPhase()`) — as 5 páginas que rodam no build pulam a chamada à API durante o build (`NEXT_PHASE=phase-production-build` ou `SSG_SKIP_FETCH=1`). A página renderiza na hora com o conteúdo estático e o **ISR preenche os imóveis na 1ª requisição real** (onde o fetch roda normalmente, com timeout de 5s). Páginas geradas sob demanda não mudam.
- Guardadas: `[estado]/[cidade]/[cluster]`, `imoveis/perto-de/[poi]`, `imoveis/em/[cidade]`, `leilao/[estado]/[cidade]`, `leilao-imoveis/[slug]`.
- `[cluster]` `revalidate` 24h → 1h para os imóveis reais aparecerem logo após o deploy.

## 🔒 Segurança (isolamento de tenant / credenciais)

- **Senha em texto puro removida** do onboarding SaaS (`tempPasswordPlain`) — o webhook de pagamento já usa link de 1º acesso (`createPasswordSetupToken`), o texto puro era exposição redundante em repouso.
- **Login por magic-link do especialista**: `Specialist.accessToken` (único). Novas rotas `/specialists/request-access` (envia o link por e-mail + WhatsApp, resposta genérica sem enumeração) e `/specialists/session?token=`. As rotas `/by-email`, pagamentos `/status/:id` e `/cancel/:id` agora exigem o token do próprio especialista **OU** admin autenticado (comparação em tempo constante).

## ✨ Login white-label em 2 etapas

- Etapa 1: identificador (e-mail, telefone **ou CPF**) → `POST /auth/resolve-company` resolve a empresa do parceiro.
- Etapa 2: tela de senha com o **logo/cor da empresa**; selo **"Plataforma por AgoraEncontrei" sempre visível** (propaganda, conforme o modelo white-label).
- `User.cpf` (único) + migração idempotente; `AuthService.findUserByIdentifier` (e-mail/CPF por índice único, telefone por dígitos via SQL); `login()` aceita `identifier`. O checkout SaaS passa a gravar o CPF no admin criado (pulado para CNPJ ou CPF já usado).

## 🏠 Histórico por usuário + notificação ao proprietário

- **Filtro "por usuário"** no Histórico de Alterações (a API já aceitava `?userId=`; a UI não enviava).
- Nova opção **"Avisar proprietário"** ao editar um imóvel: no salvamento manual, a API notifica cada proprietário vinculado (`PropertyOwner → Contact`) por WhatsApp + e-mail com os campos alterados. Best-effort, não-bloqueante; o auto-save nunca dispara.

## 🐛 Correção do 500 em `/comparar`

A pasta `[cidadeA]-vs-[cidadeB]` declara **dois** params, mas o código lia uma chave única (`params['cidadeA-vs-cidadeB']`, `undefined`) → `parseSlugs(undefined).split()` estourava 500 em toda página de comparação. `generateStaticParams`/`resolveSlugs` corrigidos.

## 🧪 E2E

- `playwright.config.ts` (baseURL via `E2E_BASE_URL`, usa o Chromium pré-instalado, passa pelo proxy do ambiente) + `tests/public-pages-smoke.spec.ts` (rotas públicas nunca 5xx, sitemaps 200). Scripts `test:e2e` / `test:e2e:smoke`.
- O e2e de login existente foi atualizado para o fluxo white-label de 2 etapas.
- O smoke **confirmou** o 500 em `/comparar` em produção — fica verde quando este PR subir.

## Validação

- Typecheck web: os arquivos alterados ficam **sem erros novos** (os erros restantes são baseline pré-existente do ambiente). API: os erros são ambientais (Prisma client não gerado no sandbox); produção roda `db:generate` antes do build.
- Migrações de schema aplicadas via `ALTER TABLE ... IF NOT EXISTS` idempotente em `runMigrations` (padrão do projeto), além do `schema.prisma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dobj1d9q3PJCiSNi1ZHSih)_