### PR TITLE
feat(seo): pipeline de SEO programático (ingestão draft-first + dados vivos)

### DIFF
--- a/.github/workflows/seo-tests.yml
+++ b/.github/workflows/seo-tests.yml
@@ -23,6 +23,10 @@ on:
       - '.github/workflows/seo-tests.yml'
   workflow_dispatch:
 
+# Least-privilege: o job só lê o conteúdo do repo.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/seo-tests.yml
+++ b/.github/workflows/seo-tests.yml
@@ -1,0 +1,49 @@
+name: SEO Pipeline Tests
+
+# Roda a suíte de testes do pipeline de SEO programático:
+#  - packages/database: transform puro + varredura do dataset inteiro
+#  - apps/api: lógica do endpoint /bairro-stats
+# Nenhum teste precisa de banco (lógica pura + dataset versionado).
+
+on:
+  push:
+    branches:
+      - main
+      - claude/seo-programmatic-analysis-1ym5tq
+    paths:
+      - 'packages/database/**'
+      - 'apps/api/src/routes/public/**'
+      - 'scripts/seo-import/**'
+      - '.github/workflows/seo-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/database/**'
+      - 'apps/api/src/routes/public/**'
+      - 'scripts/seo-import/**'
+      - '.github/workflows/seo-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Database — transform + dataset sweep
+        run: pnpm --filter @agoraencontrei/database test
+
+      - name: API — bairro-stats + suíte existente
+        run: pnpm --filter @agoraencontrei/api test

--- a/apps/api/src/routes/public/bairro-stats.util.ts
+++ b/apps/api/src/routes/public/bairro-stats.util.ts
@@ -1,0 +1,29 @@
+/**
+ * Lógica pura do endpoint /bairro-stats — isolada para teste unitário.
+ */
+
+export interface PriceRow {
+  price?: number | { toString(): string } | null
+  builtArea?: number | null
+  totalArea?: number | null
+  landArea?: number | null
+}
+
+/**
+ * Mediana do preço por m² (robusta a outliers). Usa área construída; na
+ * ausência, área total; por fim, terreno. Ignora linhas sem preço/área válidos.
+ */
+export function medianPricePerM2(rows: PriceRow[]): { precoMedioM2: number | null; amostra: number } {
+  const perM2: number[] = []
+  for (const p of rows) {
+    const price = Number(p.price ?? 0)
+    const area = Number(p.builtArea ?? 0) || Number(p.totalArea ?? 0) || Number(p.landArea ?? 0)
+    if (price > 0 && area > 0) perM2.push(price / area)
+  }
+  if (perM2.length === 0) return { precoMedioM2: null, amostra: 0 }
+  perM2.sort((a, b) => a - b)
+  return {
+    precoMedioM2: Math.round(perM2[Math.floor(perM2.length / 2)]),
+    amostra: perM2.length,
+  }
+}

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { env } from '../../utils/env.js'
+import { medianPricePerM2 } from './bairro-stats.util.js'
 
 const PROPERTY_TYPES  = ['HOUSE','APARTMENT','LAND','FARM','RANCH','WAREHOUSE','OFFICE','STORE','STUDIO','PENTHOUSE','CONDO','KITNET'] as const
 const PROPERTY_PURPOSES = ['SALE','RENT','BOTH','SEASON'] as const
@@ -666,25 +667,15 @@ export default async function publicRoutes(app: FastifyInstance) {
       }),
     ])
 
-    // Mediana do preço/m² (robusta a outliers) — usa área construída, senão
-    // área total, senão terreno.
-    const perM2: number[] = []
-    for (const p of priceRows) {
-      const price = Number(p.price ?? 0)
-      const area = Number(p.builtArea ?? 0) || Number(p.totalArea ?? 0) || Number(p.landArea ?? 0)
-      if (price > 0 && area > 0) perM2.push(price / area)
-    }
-    perM2.sort((a, b) => a - b)
-    const precoMedioM2 = perM2.length
-      ? Math.round(perM2[Math.floor(perM2.length / 2)])
-      : null
+    // Mediana do preço/m² (robusta a outliers) — ver bairro-stats.util.ts
+    const { precoMedioM2, amostra } = medianPricePerM2(priceRows)
 
     const payload = {
       city,
       neighborhood,
       totalAtivos: total,
       precoMedioM2,
-      amostraPreco: perM2.length,
+      amostraPreco: amostra,
       recentes: recent.map(applyLocationPrivacy),
       atualizadoEm: new Date().toISOString(),
     }

--- a/apps/api/test/bairro-stats.test.ts
+++ b/apps/api/test/bairro-stats.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { medianPricePerM2 } from '../src/routes/public/bairro-stats.util.js'
+
+test('mediana: valor central de preço/m²', () => {
+  // áreas 100 → preços/m²: 1000, 2000, 3000 → mediana 2000
+  const { precoMedioM2, amostra } = medianPricePerM2([
+    { price: 100000, builtArea: 100 },
+    { price: 200000, builtArea: 100 },
+    { price: 300000, builtArea: 100 },
+  ])
+  assert.equal(precoMedioM2, 2000)
+  assert.equal(amostra, 3)
+})
+
+test('mediana: prioriza builtArea > totalArea > landArea', () => {
+  const { precoMedioM2 } = medianPricePerM2([{ price: 100000, builtArea: 50, totalArea: 200, landArea: 500 }])
+  assert.equal(precoMedioM2, 2000) // usa builtArea=50 → 2000, não 500/200
+})
+
+test('mediana: cai para totalArea quando builtArea ausente/zero', () => {
+  const { precoMedioM2 } = medianPricePerM2([{ price: 100000, builtArea: 0, totalArea: 200 }])
+  assert.equal(precoMedioM2, 500)
+})
+
+test('mediana: cai para landArea quando as demais ausentes', () => {
+  const { precoMedioM2 } = medianPricePerM2([{ price: 100000, landArea: 400 }])
+  assert.equal(precoMedioM2, 250)
+})
+
+test('mediana: ignora linhas sem preço ou sem área', () => {
+  const { precoMedioM2, amostra } = medianPricePerM2([
+    { price: 0, builtArea: 100 },
+    { price: 100000, builtArea: 0, totalArea: 0, landArea: 0 },
+    { price: 100000, builtArea: 100 }, // única válida → 1000
+  ])
+  assert.equal(amostra, 1)
+  assert.equal(precoMedioM2, 1000)
+})
+
+test('mediana: lista vazia → null', () => {
+  assert.deepEqual(medianPricePerM2([]), { precoMedioM2: null, amostra: 0 })
+})
+
+test('mediana: aceita Decimal (objeto com toString)', () => {
+  // Prisma retorna Decimal; Number(decimal) usa toString.
+  const decimal = { toString: () => '150000' }
+  const { precoMedioM2 } = medianPricePerM2([{ price: decimal, builtArea: 100 }])
+  assert.equal(precoMedioM2, 1500)
+})

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "scrape:caixa": "npx tsx scripts/scrape-caixa.ts",
     "scrape:all": "npx tsx scripts/scrape-caixa.ts",
     "test:e2e": "playwright test",
-    "test:e2e:smoke": "playwright test tests/public-pages-smoke.spec.ts"
+    "test:e2e:smoke": "playwright test tests/public-pages-smoke.spec.ts",
+    "seo:smoke": "tsx scripts/seo-import/smoke-test.ts"
   },
   "engines": {
     "node": "22.x",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,7 +13,8 @@
     "import:seo": "tsx prisma/import-seo-programmatic.ts",
     "publish:seo": "tsx prisma/publish-seo-wave.ts",
     "studio": "prisma studio",
-    "reset": "prisma migrate reset --force"
+    "reset": "prisma migrate reset --force",
+    "test": "tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0"

--- a/packages/database/prisma/import-seo-programmatic.ts
+++ b/packages/database/prisma/import-seo-programmatic.ts
@@ -25,6 +25,7 @@ import { createInterface } from 'readline'
 import { createGunzip } from 'zlib'
 import path from 'path'
 import { PrismaClient } from '@prisma/client'
+import { CATEGORIES, buildPostData, type SeoRecord } from './seo-transform'
 
 const prisma = new PrismaClient()
 
@@ -34,64 +35,6 @@ const DATA_FILE =
 const COMPANY_ID = process.env.SEO_COMPANY_ID ?? null
 const LIMIT = process.env.SEO_LIMIT ? parseInt(process.env.SEO_LIMIT, 10) : Infinity
 const BATCH_SIZE = 500
-const SOURCE_TAG = 'seo-programmatic'
-
-interface SeoRecord {
-  extId: string
-  slug: string
-  tema: string
-  categoria: string
-  cidade: string
-  uf: string
-  bairro: string
-  titulo: string
-  keywords: string
-  metaDesc: string
-  conteudo: string
-}
-
-// Categorias que os posts referenciam. As duas últimas não existem no
-// seed-blog padrão e são criadas aqui.
-const CATEGORIES = [
-  { slug: 'financiamento-imobiliario', name: 'Financiamento Imobiliário', description: 'Guias e orientações sobre financiamento de imóveis.' },
-  { slug: 'compra-de-imoveis', name: 'Compra de Imóveis', description: 'Processo de compra: documentação, avaliação, negociação.' },
-  { slug: 'venda-de-imoveis', name: 'Venda de Imóveis', description: 'Como vender imóvel com estratégia.' },
-  { slug: 'aluguel-de-imoveis', name: 'Aluguel de Imóveis', description: 'Locação residencial e comercial: contrato, garantias, vistoria.' },
-  { slug: 'leilao-de-imoveis', name: 'Leilão de Imóveis', description: 'Como comprar imóveis em leilão com segurança.' },
-  { slug: 'investimento-imobiliario', name: 'Investimento Imobiliário', description: 'ROI, yield, avaliação patrimonial e alto padrão.' },
-  { slug: 'seo-local', name: 'Mercado Local', description: 'Mercado imobiliário local: bairros, planejamento e infraestrutura.' },
-  { slug: 'reformas-e-arquitetura', name: 'Reformas e Arquitetura', description: 'Tendências de reforma, arquitetura, sustentabilidade e retrofit.' },
-  { slug: 'regularizacao-e-documentacao', name: 'Regularização e Documentação', description: 'Regularização, tributação (ITBI/IPTU), vistorias e segurança jurídica.' },
-]
-
-function slugify(text: string, maxlen = 100): string {
-  return String(text)
-    .normalize('NFD').replace(/[̀-ͯ]/g, '')
-    .toLowerCase().trim()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .slice(0, maxlen).replace(/^-|-$/g, '')
-}
-
-/** Texto corrido -> HTML com parágrafos legíveis (sem inventar conteúdo). */
-function textToHtml(text: string): string {
-  const clean = String(text).replace(/\r/g, '').trim()
-  if (!clean) return ''
-  // Quebra em sentenças e agrupa ~2 por parágrafo para dar respiro visual.
-  const sentences = clean.match(/[^.!?]+[.!?]+(\s|$)/g) ?? [clean]
-  const paras: string[] = []
-  for (let i = 0; i < sentences.length; i += 2) {
-    paras.push(sentences.slice(i, i + 2).join('').trim())
-  }
-  return paras.filter(Boolean).map((p) => `<p>${p}</p>`).join('\n')
-}
-
-function excerptFrom(rec: SeoRecord): string {
-  const base = rec.metaDesc || rec.conteudo
-  const s = String(base).trim()
-  return s.length > 220 ? s.slice(0, 217).trimEnd() + '…' : s
-}
 
 async function resolveCompanyId(): Promise<string> {
   if (COMPANY_ID) {
@@ -118,40 +61,6 @@ async function ensureCategories(companyId: string): Promise<Record<string, strin
     map[cat.slug] = created.id
   }
   return map
-}
-
-function buildPostData(rec: SeoRecord, companyId: string, categoryMap: Record<string, string>) {
-  const keywords = rec.keywords || ''
-  const keywordPrincipal = keywords.split(/[,;]/)[0]?.trim() || null
-  return {
-    companyId,
-    title: rec.titulo,
-    slug: rec.slug,
-    excerpt: excerptFrom(rec),
-    content: textToHtml(rec.conteudo),
-    bodyMarkdown: rec.conteudo,
-    categoryId: categoryMap[rec.categoria] ?? categoryMap['seo-local'] ?? null,
-    tags: keywords ? keywords.replace(/;/g, ',') : null,
-    seoTitle: rec.titulo,
-    seoDescription: rec.metaDesc || null,
-    seoKeywords: keywords || null,
-    keywordPrincipal,
-    schemaType: 'BlogPosting',
-    cidade: rec.cidade || 'Franca',
-    bairro: rec.bairro || null,
-    tipoImovel: 'geral',
-    // rastreabilidade p/ publicação em ondas e rollback
-    source: SOURCE_TAG,
-    sourceUrl: rec.extId ? `seo:${rec.extId}` : null,
-    isAutoImported: true,
-    editorialNotes: `[SEO programático] tema=${rec.tema} · id=${rec.extId}`,
-    // SEGURANÇA: entra como rascunho, fora do índice.
-    status: 'draft',
-    published: false,
-    noindex: true,
-    featured: false,
-    authorName: 'Equipe AgoraEncontrei',
-  }
 }
 
 async function main() {
@@ -207,6 +116,10 @@ async function main() {
   console.log('\n👉 Próximo passo: publicar em ondas com publish-seo-wave.ts')
 }
 
-main()
-  .catch((e) => { console.error(e); process.exit(1) })
-  .finally(() => prisma.$disconnect())
+// Só executa quando rodado diretamente (permite importar os helpers puros
+// em testes sem disparar conexão com o banco).
+if (require.main === module) {
+  main()
+    .catch((e) => { console.error(e); process.exit(1) })
+    .finally(() => prisma.$disconnect())
+}

--- a/packages/database/prisma/seo-transform.ts
+++ b/packages/database/prisma/seo-transform.ts
@@ -1,0 +1,102 @@
+/**
+ * Transformações puras do SEO programático (sem dependência de Prisma/DB).
+ * Isolado para permitir testes de unidade/smoke sem gerar o client Prisma.
+ */
+
+export interface SeoRecord {
+  extId: string
+  slug: string
+  tema: string
+  categoria: string
+  cidade: string
+  uf: string
+  bairro: string
+  titulo: string
+  keywords: string
+  metaDesc: string
+  conteudo: string
+}
+
+// Categorias que os posts referenciam. As duas últimas não existem no
+// seed-blog padrão e são criadas na ingestão.
+export const CATEGORIES = [
+  { slug: 'financiamento-imobiliario', name: 'Financiamento Imobiliário', description: 'Guias e orientações sobre financiamento de imóveis.' },
+  { slug: 'compra-de-imoveis', name: 'Compra de Imóveis', description: 'Processo de compra: documentação, avaliação, negociação.' },
+  { slug: 'venda-de-imoveis', name: 'Venda de Imóveis', description: 'Como vender imóvel com estratégia.' },
+  { slug: 'aluguel-de-imoveis', name: 'Aluguel de Imóveis', description: 'Locação residencial e comercial: contrato, garantias, vistoria.' },
+  { slug: 'leilao-de-imoveis', name: 'Leilão de Imóveis', description: 'Como comprar imóveis em leilão com segurança.' },
+  { slug: 'investimento-imobiliario', name: 'Investimento Imobiliário', description: 'ROI, yield, avaliação patrimonial e alto padrão.' },
+  { slug: 'seo-local', name: 'Mercado Local', description: 'Mercado imobiliário local: bairros, planejamento e infraestrutura.' },
+  { slug: 'reformas-e-arquitetura', name: 'Reformas e Arquitetura', description: 'Tendências de reforma, arquitetura, sustentabilidade e retrofit.' },
+  { slug: 'regularizacao-e-documentacao', name: 'Regularização e Documentação', description: 'Regularização, tributação (ITBI/IPTU), vistorias e segurança jurídica.' },
+]
+
+export const SOURCE_TAG = 'seo-programmatic'
+
+export function slugify(text: string, maxlen = 100): string {
+  return String(text)
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase().trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, maxlen).replace(/^-|-$/g, '')
+}
+
+/** Texto corrido -> HTML com parágrafos legíveis (sem inventar conteúdo). */
+export function textToHtml(text: string): string {
+  const clean = String(text).replace(/\r/g, '').trim()
+  if (!clean) return ''
+  // Quebra em sentenças e agrupa ~2 por parágrafo para dar respiro visual.
+  const sentences = clean.match(/[^.!?]+[.!?]+(\s|$)/g) ?? [clean]
+  const paras: string[] = []
+  for (let i = 0; i < sentences.length; i += 2) {
+    paras.push(sentences.slice(i, i + 2).join('').trim())
+  }
+  return paras.filter(Boolean).map((p) => `<p>${p}</p>`).join('\n')
+}
+
+export function excerptFrom(rec: SeoRecord): string {
+  const base = rec.metaDesc || rec.conteudo
+  const s = String(base).trim()
+  return s.length > 220 ? s.slice(0, 217).trimEnd() + '…' : s
+}
+
+/** Monta o objeto de dados de um BlogPost a partir de um registro SEO. */
+export function buildPostData(
+  rec: SeoRecord,
+  companyId: string,
+  categoryMap: Record<string, string>,
+) {
+  const keywords = rec.keywords || ''
+  const keywordPrincipal = keywords.split(/[,;]/)[0]?.trim() || null
+  return {
+    companyId,
+    title: rec.titulo,
+    slug: rec.slug,
+    excerpt: excerptFrom(rec),
+    content: textToHtml(rec.conteudo),
+    bodyMarkdown: rec.conteudo,
+    categoryId: categoryMap[rec.categoria] ?? categoryMap['seo-local'] ?? null,
+    tags: keywords ? keywords.replace(/;/g, ',') : null,
+    seoTitle: rec.titulo,
+    seoDescription: rec.metaDesc || null,
+    seoKeywords: keywords || null,
+    keywordPrincipal,
+    schemaType: 'BlogPosting',
+    cidade: rec.cidade || 'Franca',
+    bairro: rec.bairro || null,
+    tipoImovel: 'geral',
+    // rastreabilidade p/ publicação em ondas e rollback
+    source: SOURCE_TAG,
+    sourceUrl: rec.extId ? `seo:${rec.extId}` : null,
+    isAutoImported: true,
+    editorialNotes: `[SEO programático] tema=${rec.tema} · id=${rec.extId}`,
+    // SEGURANÇA: entra como rascunho, fora do índice.
+    status: 'draft',
+    published: false,
+    noindex: true,
+    featured: false,
+    authorName: 'Equipe AgoraEncontrei',
+  }
+}

--- a/packages/database/test/seo-transform.test.ts
+++ b/packages/database/test/seo-transform.test.ts
@@ -1,0 +1,136 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createReadStream, readFileSync } from 'fs'
+import { createInterface } from 'readline'
+import { createGunzip } from 'zlib'
+import path from 'path'
+import {
+  slugify,
+  textToHtml,
+  excerptFrom,
+  buildPostData,
+  CATEGORIES,
+  type SeoRecord,
+} from '../prisma/seo-transform'
+
+const ROOT = path.join(__dirname, '..')
+const DATA = path.join(ROOT, 'data/seo-posts/franca-seo-posts.ndjson.gz')
+const SCHEMA = path.join(ROOT, 'prisma/schema.prisma')
+
+function blogPostFields(): Set<string> {
+  const block = readFileSync(SCHEMA, 'utf8').match(/model BlogPost \{([\s\S]*?)\n\}/)![1]
+  const fields = new Set<string>()
+  for (const raw of block.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('//') || line.startsWith('@@')) continue
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s+\S/)
+    if (m) fields.add(m[1])
+  }
+  return fields
+}
+
+const rec = (over: Partial<SeoRecord> = {}): SeoRecord => ({
+  extId: 'AE-001', slug: 'x', tema: 'Leilões de Imóveis', categoria: 'leilao-de-imoveis',
+  cidade: 'Franca', uf: 'SP', bairro: 'Centro', titulo: 'Título',
+  keywords: 'a, b; c', metaDesc: 'meta', conteudo: 'Frase um. Frase dois! Frase três?', ...over,
+})
+
+// ── slugify ──────────────────────────────────────────────────────────────
+test('slugify: remove acentos, minúsculo, hífens', () => {
+  assert.equal(slugify('Leilão no Jardim São Sebastião'), 'leilao-no-jardim-sao-sebastiao')
+})
+test('slugify: sem hífen no início/fim e sem duplicados', () => {
+  assert.equal(slugify('  --Olá  Mundo--  '), 'ola-mundo')
+})
+test('slugify: respeita maxlen', () => {
+  assert.ok(slugify('a'.repeat(200)).length <= 100)
+})
+
+// ── textToHtml ───────────────────────────────────────────────────────────
+test('textToHtml: envolve em <p> e agrupa ~2 frases', () => {
+  const html = textToHtml('Uma frase. Duas frases. Três frases. Quatro frases.')
+  assert.equal((html.match(/<p>/g) ?? []).length, 2)
+  assert.ok(html.startsWith('<p>'))
+})
+test('textToHtml: vazio -> string vazia', () => {
+  assert.equal(textToHtml('   '), '')
+})
+test('textToHtml: texto sem pontuação vira um <p>', () => {
+  assert.equal(textToHtml('sem pontuacao final'), '<p>sem pontuacao final</p>')
+})
+
+// ── excerptFrom ──────────────────────────────────────────────────────────
+test('excerptFrom: usa metaDesc quando presente', () => {
+  assert.equal(excerptFrom(rec({ metaDesc: 'resumo curto' })), 'resumo curto')
+})
+test('excerptFrom: trunca em 220 com reticências', () => {
+  const long = 'x'.repeat(400)
+  const out = excerptFrom(rec({ metaDesc: long }))
+  assert.ok(out.length <= 220)
+  assert.ok(out.endsWith('…'))
+})
+test('excerptFrom: cai no conteúdo quando metaDesc vazio', () => {
+  assert.equal(excerptFrom(rec({ metaDesc: '', conteudo: 'do corpo' })), 'do corpo')
+})
+
+// ── buildPostData ────────────────────────────────────────────────────────
+test('buildPostData: sempre draft/noindex e rastreável', () => {
+  const d = buildPostData(rec(), 'co1', { 'leilao-de-imoveis': 'catX' })
+  assert.equal(d.status, 'draft')
+  assert.equal(d.published, false)
+  assert.equal(d.noindex, true)
+  assert.equal(d.source, 'seo-programmatic')
+  assert.equal(d.sourceUrl, 'seo:AE-001')
+  assert.equal(d.companyId, 'co1')
+  assert.equal(d.categoryId, 'catX')
+  assert.equal(d.keywordPrincipal, 'a')
+})
+test('buildPostData: categoria desconhecida cai em seo-local', () => {
+  const d = buildPostData(rec({ categoria: 'inexistente' }), 'co1', { 'seo-local': 'fallback' })
+  assert.equal(d.categoryId, 'fallback')
+})
+test('buildPostData: tags trocam ; por ,', () => {
+  const d = buildPostData(rec({ keywords: 'a;b;c' }), 'co1', {})
+  assert.equal(d.tags, 'a,b,c')
+})
+
+// ── Varredura do dataset REAL inteiro ───────────────────────────────────
+test('dataset: todos os posts geram colunas válidas, slug único e conteúdo não-vazio', async () => {
+  const fields = blogPostFields()
+  const catSlugs = new Set(CATEGORIES.map((c) => c.slug))
+  const catMap: Record<string, string> = {}
+  for (const c of CATEGORIES) catMap[c.slug] = `cat_${c.slug}`
+
+  const rl = createInterface({
+    input: createReadStream(DATA).pipe(createGunzip()),
+    crlfDelay: Infinity,
+  })
+
+  const slugs = new Set<string>()
+  let n = 0, dupSlug = 0, emptyContent = 0, emptyTitle = 0, badKey = 0, badCat = 0, unmappedCat = 0
+
+  for await (const line of rl) {
+    if (!line.trim()) continue
+    const r = JSON.parse(line) as SeoRecord
+    const d = buildPostData(r, 'co1', catMap)
+    n++
+    if (slugs.has(d.slug)) dupSlug++; else slugs.add(d.slug)
+    if (!d.content || d.content.length < 10) emptyContent++
+    if (!d.title) emptyTitle++
+    for (const k of Object.keys(d)) if (!fields.has(k)) badKey++
+    if (!catSlugs.has(r.categoria)) badCat++
+    if (d.categoryId === null) unmappedCat++
+  }
+
+  console.log(`      posts=${n} slugs únicos=${slugs.size} dupSlug=${dupSlug} ` +
+    `emptyContent=${emptyContent} emptyTitle=${emptyTitle} badKey=${badKey} ` +
+    `categoriaForaDoMapa=${badCat} categoryIdNull=${unmappedCat}`)
+
+  assert.ok(n > 52000, `esperado >52k posts, veio ${n}`)
+  assert.equal(dupSlug, 0, 'slugs devem ser únicos')
+  assert.equal(emptyContent, 0, 'nenhum conteúdo vazio')
+  assert.equal(emptyTitle, 0, 'nenhum título vazio')
+  assert.equal(badKey, 0, 'nenhuma chave fora do schema BlogPost')
+  assert.equal(badCat, 0, 'toda categoria do dataset existe no mapa')
+  assert.equal(unmappedCat, 0, 'todo post recebe categoryId')
+})

--- a/scripts/seo-import/smoke-test.ts
+++ b/scripts/seo-import/smoke-test.ts
@@ -1,0 +1,72 @@
+/**
+ * Smoke-test do pipeline de SEO programático — SEM banco.
+ *
+ * Roda a MESMA lógica pura da ingestão (seo-transform.ts) sobre os primeiros
+ * N registros do dataset e valida que cada post gerado só contém colunas reais
+ * do modelo BlogPost (lidas de schema.prisma). Serve para conferir a carga
+ * antes de rodar o import:seo de verdade.
+ *
+ * Uso:  pnpm --filter @agoraencontrei/database exec tsx ../../scripts/seo-import/smoke-test.ts
+ *   ou: node_modules/.bin/tsx scripts/seo-import/smoke-test.ts [N]
+ */
+import { createReadStream, readFileSync } from 'fs'
+import { createInterface } from 'readline'
+import { createGunzip } from 'zlib'
+import path from 'path'
+import { buildPostData, type SeoRecord } from '../../packages/database/prisma/seo-transform'
+
+const N = parseInt(process.argv[2] ?? '5', 10)
+const ROOT = path.join(__dirname, '..', '..')
+const DATA = path.join(ROOT, 'packages/database/data/seo-posts/franca-seo-posts.ndjson.gz')
+const SCHEMA = path.join(ROOT, 'packages/database/prisma/schema.prisma')
+
+// Campos escalares reais do modelo BlogPost (parse simples do schema).
+function blogPostFields(): Set<string> {
+  const src = readFileSync(SCHEMA, 'utf8')
+  const block = src.match(/model BlogPost \{([\s\S]*?)\n\}/)![1]
+  const fields = new Set<string>()
+  for (const raw of block.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('//') || line.startsWith('@@')) continue
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s+\S/)
+    if (m) fields.add(m[1])
+  }
+  return fields
+}
+
+async function main() {
+  const fields = blogPostFields()
+  const categoryMap: Record<string, string> = { 'seo-local': 'cat_fake_id' } // stub p/ teste
+  const rl = createInterface({
+    input: createReadStream(DATA).pipe(createGunzip()),
+    crlfDelay: Infinity,
+  })
+
+  let count = 0
+  const badKeys = new Set<string>()
+  for await (const line of rl) {
+    if (!line.trim() || count >= N) { if (count >= N) break; else continue }
+    const rec = JSON.parse(line) as SeoRecord
+    const data = buildPostData(rec, 'company_fake_id', categoryMap)
+    for (const k of Object.keys(data)) if (!fields.has(k)) badKeys.add(k)
+    count++
+    console.log(`\n─── POST ${count} ─────────────────────────────`)
+    console.log('slug        :', data.slug)
+    console.log('categoria   :', rec.categoria, '→ categoryId', data.categoryId)
+    console.log('cidade/bairro:', data.cidade, '/', data.bairro)
+    console.log('title       :', data.title)
+    console.log('status      :', data.status, '| noindex:', data.noindex, '| source:', data.source)
+    console.log('excerpt     :', data.excerpt.slice(0, 90))
+    console.log('content[0..160]:', data.content.slice(0, 160))
+  }
+
+  console.log('\n══════════════════════════════════════════════')
+  console.log(`Posts gerados: ${count}`)
+  if (badKeys.size) {
+    console.error('❌ Chaves que NÃO existem em BlogPost:', [...badKeys])
+    process.exit(1)
+  }
+  console.log('✅ Todas as chaves geradas são colunas reais de BlogPost.')
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Contexto

Análise + implementação a partir dos 4 bancos `.xlsx` (~52,8 mil posts combinatórios: 20 temas × 40 bairros de Franca) e do "Prompt Mestre" do Gemini.

**Decisão de arquitetura:** o prompt do Gemini foi escrito para a stack legada (Vite + react-router + react-helmet + Supabase). A produção é **Next.js `apps/web`**, que já faz nativamente e melhor ~80% do que o prompt pede (rotas dinâmicas, `generateMetadata`, sitemaps, `robots.ts`, blog `[slug]`/categoria/cluster). Este PR **reaproveita** essa base — não duplica a stack do prompt.

**Segurança de SEO:** publicar 52k páginas quase-template de uma vez é o gatilho nº 1 de *scaled content abuse* do Google (pode desindexar o domínio). Por isso o pipeline é **draft-first + publicação em ondas + dados vivos**.

## O que muda

- **`scripts/seo-import/extract_seo_xlsx.py`** — xlsx → NDJSON gzip, com dedup (tema|bairro|título) e slug estável/único.
- **`packages/database/data/seo-posts/franca-seo-posts.ndjson.gz`** — dataset versionado (52.770 posts, ~3,4 MB). Os `.xlsx` de origem não são versionados.
- **`packages/database/prisma/seo-transform.ts`** — lógica pura (slug/HTML/`buildPostData`), sem Prisma, testável isoladamente.
- **`packages/database/prisma/import-seo-programmatic.ts`** — ingestão idempotente (`createMany({ skipDuplicates })` + `@@unique([companyId, slug])`), tudo como **`draft` / `noindex`**. Nada vai ao ar.
- **`packages/database/prisma/publish-seo-wave.ts`** — publicação **em ondas** (dry-run por padrão; filtro por `--bairro`/`--tema`/`--limit`; `--confirm` para aplicar).
- **`GET /api/v1/public/bairro-stats`** — estatísticas ao vivo por bairro (total ativos, mediana do preço/m², 3 recentes), cache 10 min.
- **`apps/web/.../blog/[slug]/BairroLiveData.tsx`** — painel de **dados vivos** que funde o texto do post com o inventário real do bairro (núcleo anti-duplicidade). Degrada em silêncio se a API falhar; some se não há inventário.
- **`docs/SEO_PROGRAMATICO.md`** — fluxo, estratégia de ondas e rollback.
- Scripts: `import:seo`, `publish:seo` (database) e `seo:smoke` (raiz).

## Validação executada

- `pnpm seo:smoke` — roda a **mesma lógica de ingestão** nos primeiros posts: categorias mapeadas corretamente, `draft`/`noindex` setados, **0 chaves fora do schema `BlogPost`**.
- Cross-check estático: todas as chaves de `import`/`publish` são colunas reais de `BlogPost`; campos de `Property` e enum `PropertyPurpose` do endpoint conferem; rotas referenciadas existem.
- Dataset: 52.770 linhas parseadas, HTML de saída verificado.
- Compilação (esbuild) OK nos arquivos TS/TSX novos/alterados.

> Nota: a carga real (`import:seo`) roda no ambiente com `DATABASE_URL` — não foi executada contra produção. Passo a passo em `docs/SEO_PROGRAMATICO.md`.

## Como rodar (resumo)

```bash
pnpm install && pnpm db:generate
SEO_LIMIT=500 SEO_COMPANY_ID=<id> pnpm --filter @agoraencontrei/database run import:seo   # teste
pnpm --filter @agoraencontrei/database run import:seo                                      # carga completa (draft)
pnpm --filter @agoraencontrei/database run publish:seo -- --bairro="Centro" --limit=100 --confirm  # Onda 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPCKQHQwxUZSEJsMC3rsE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPCKQHQwxUZSEJsMC3rsE1)_