### PR TITLE
fix(comparar): rota de segmento único — destrava o build do main

### DIFF
--- a/apps/web/src/app/(public)/comparar/[comparacao]/page.tsx
+++ b/apps/web/src/app/(public)/comparar/[comparacao]/page.tsx
@@ -1,10 +1,12 @@
 /**
- * Rota: /comparar/[cidadeA]-vs-[cidadeB]
- * Comparação de custo de vida, PIB, população entre duas cidades
+ * Rota: /comparar/[comparacao]  (slug único no formato `cidadeA-vs-cidadeB`)
+ * Comparação de custo de vida, PIB, população entre duas cidades.
  * ISR: revalidate 86400 (24h)
  *
- * Potencial: 500 cidades × 500 = 499.500 páginas únicas
- * Cada página resolve dados via city-resolver (static → API fallback)
+ * IMPORTANTE: o Next NÃO suporta dois params dinâmicos no mesmo segmento
+ * (`[cidadeA]-vs-[cidadeB]`) — ele gerava caminhos quebrados como
+ * `orlandia-vs-[cidadeB]` e o build (prerender) estourava. Por isso o segmento
+ * é UM único param (`comparacao`) e nós separamos os dois slugs manualmente.
  */
 import { Metadata } from 'next'
 import Link from 'next/link'
@@ -14,43 +16,33 @@ import { IBGE_CITIES_152, IBGE_CITY_BY_SLUG, type IbgeCityData } from '@/data/se
 
 export const revalidate = 86400
 
-// Todas as 152 cidades para generateStaticParams
-// 152 × 151 / 2 = 11.476 páginas pré-geradas no build
-// Demais combinações via ISR (fallback blocking)
 const ALL_CITIES_SORTED = IBGE_CITIES_152
   .sort((a, b) => b.populacao - a.populacao)
 
-// A pasta declara DOIS params no mesmo segmento (`[cidadeA]-vs-[cidadeB]`),
-// então o Next entrega `params.cidadeA` e `params.cidadeB` — não uma única
-// chave. Gerar/ler com a chave errada deixava `params[...]` undefined e o
-// `.split` estourava 500. Este tipo cobre as duas formas por segurança.
-type CompareParams = { cidadeA?: string; cidadeB?: string; 'cidadeA-vs-cidadeB'?: string }
+type CompareParams = { comparacao: string }
 
 export function generateStaticParams() {
   if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
-  const params: { cidadeA: string; cidadeB: string }[] = []
-  for (let i = 0; i < ALL_CITIES_SORTED.length; i++) {
-    for (let j = i + 1; j < ALL_CITIES_SORTED.length; j++) {
-      params.push({
-        cidadeA: ALL_CITIES_SORTED[i].slug,
-        cidadeB: ALL_CITIES_SORTED[j].slug,
-      })
+  // Pré-gera as combinações entre as ~40 maiores cidades (40×39/2 = 780
+  // páginas). As demais combinações são geradas sob demanda via ISR
+  // (dynamicParams = true por padrão) — mantém o build rápido sem perder
+  // cobertura de SEO.
+  const TOP = ALL_CITIES_SORTED.slice(0, 40)
+  const params: { comparacao: string }[] = []
+  for (let i = 0; i < TOP.length; i++) {
+    for (let j = i + 1; j < TOP.length; j++) {
+      params.push({ comparacao: `${TOP[i].slug}-vs-${TOP[j].slug}` })
     }
   }
   return params
 }
 
-// Resolve os dois slugs qualquer que seja o formato de params entregue.
+// Segmento único → separamos os dois slugs no `-vs-`.
 function resolveSlugs(params: CompareParams): { slugA: string; slugB: string } | null {
-  if (params.cidadeA && params.cidadeB) {
-    return { slugA: params.cidadeA, slugB: params.cidadeB }
-  }
-  const combo = params['cidadeA-vs-cidadeB']
-    ?? Object.values(params).find((v) => typeof v === 'string' && v.includes('-vs-'))
-  if (typeof combo === 'string') {
-    const parts = combo.split('-vs-')
-    if (parts.length === 2 && parts[0] && parts[1]) return { slugA: parts[0], slugB: parts[1] }
-  }
+  const combo = params?.comparacao
+  if (typeof combo !== 'string') return null
+  const parts = combo.split('-vs-')
+  if (parts.length === 2 && parts[0] && parts[1]) return { slugA: parts[0], slugB: parts[1] }
   return null
 }
 


### PR DESCRIPTION
## 🔴 Destrava o build de produção (regressão do #258)

O `next build` no `main` está **falhando** desde o merge do #258:

```
[TypeError: Cannot read properties of undefined (reading 'startsWith')]
Error occurred prerendering page "/comparar/orlandia-vs-[cidadeB]"
Export encountered an error on /(public)/comparar/[cidadeA]-vs-[cidadeB]/page, exiting the build.
```

**Causa raiz:** o Next.js **não suporta dois params dinâmicos no mesmo segmento** de rota (`[cidadeA]-vs-[cidadeB]`). Ao pré-gerar, ele produzia caminhos quebrados como `orlandia-vs-[cidadeB]` (o segundo param não resolve) e o export estourava. O `generateStaticParams` que o #258 introduziu (emitindo `{ cidadeA, cidadeB }`) fez o Next tentar prerenderizar essas rotas inválidas.

## Correção

- Segmento renomeado para **um único param** `[comparacao]` (slug `cidadeA-vs-cidadeB`), que o Next suporta nativamente; os dois slugs são separados manualmente no `-vs-`.
- `generateStaticParams` emite chaves de param válidas — pré-gera as combinações entre as ~40 maiores cidades (780 páginas); as demais saem sob demanda via ISR (`dynamicParams` padrão).
- **A URL pública não muda** (`/comparar/{a}-vs-{b}`), então sitemaps e links internos continuam funcionando; corrige também o 500 em runtime que essa rota já dava.

## Validação

- O arquivo da rota compila sem erros. (Os erros de typecheck no sandbox são artefatos de `.next/types` apontando para o nome de pasta antigo — some ao rebuildar.)
- Sem esta correção, todo deploy do `main` continua vermelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dobj1d9q3PJCiSNi1ZHSih)_