### PR TITLE
fix(settings): upload de imagem nos campos de logo do site

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
@@ -1242,8 +1242,24 @@ export function SystemConfigPanel() {
                     para o topo legado das settings, de onde a home pública lê
                     (ver GET /api/v1/public/site-settings). */}
                 <div className="space-y-3">
-                  <DarkInput label="URL do Ícone (logo redondo — cabeçalho do site público)" value={cfg.company?.logoIconUrl ?? ''} onChange={e => updateCfg('company','logoIconUrl',e.target.value)} placeholder="https://..." hint="Ícone circular exibido no topo do site. Deixe em branco para usar o ícone padrão." />
-                  <DarkInput label="URL da Marca Escrita (imagem 'Agora Encontrei Marketplace')" value={cfg.company?.logoWordmarkUrl ?? ''} onChange={e => updateCfg('company','logoWordmarkUrl',e.target.value)} placeholder="https://..." hint="Substitui o texto padrão ao lado do ícone por uma imagem da marca escrita." />
+                  <MediaUploadInput
+                    label="Ícone (logo redondo — cabeçalho do site público)"
+                    hint="Ícone circular exibido no topo do site. Envie uma imagem ou cole uma URL. Deixe em branco para usar o ícone padrão."
+                    value={cfg.company?.logoIconUrl ?? ''}
+                    onChange={v => updateCfg('company','logoIconUrl', v)}
+                    kind="image"
+                    token={apiToken}
+                    placeholder="Cole uma URL ou envie uma imagem"
+                  />
+                  <MediaUploadInput
+                    label="Marca Escrita (imagem 'Agora Encontrei Marketplace')"
+                    hint="Substitui o texto padrão ao lado do ícone por uma imagem da marca escrita. Envie uma imagem ou cole uma URL."
+                    value={cfg.company?.logoWordmarkUrl ?? ''}
+                    onChange={v => updateCfg('company','logoWordmarkUrl', v)}
+                    kind="image"
+                    token={apiToken}
+                    placeholder="Cole uma URL ou envie uma imagem"
+                  />
                 </div>
 
                 <div className="border-t border-white/10 pt-4 space-y-3">
@@ -1276,8 +1292,22 @@ export function SystemConfigPanel() {
                 {/* Campos legados — uso geral (e-mails, fallback quando o
                     ícone acima não estiver definido). */}
                 <div className="border-t border-white/10 pt-4 space-y-3">
-                  <DarkInput label="URL do Logo (uso geral — e-mails, fallback)" value={cfg.company?.logoUrl ?? ''} onChange={e => updateCfg('company','logoUrl',e.target.value)} placeholder="https://..." />
-                  <DarkInput label="URL do Logo Branco (fundo escuro)" value={cfg.company?.logoWhiteUrl ?? ''} onChange={e => updateCfg('company','logoWhiteUrl',e.target.value)} placeholder="https://..." />
+                  <MediaUploadInput
+                    label="Logo (uso geral — e-mails, fallback)"
+                    value={cfg.company?.logoUrl ?? ''}
+                    onChange={v => updateCfg('company','logoUrl', v)}
+                    kind="image"
+                    token={apiToken}
+                    placeholder="Cole uma URL ou envie uma imagem"
+                  />
+                  <MediaUploadInput
+                    label="Logo Branco (fundo escuro)"
+                    value={cfg.company?.logoWhiteUrl ?? ''}
+                    onChange={v => updateCfg('company','logoWhiteUrl', v)}
+                    kind="image"
+                    token={apiToken}
+                    placeholder="Cole uma URL ou envie uma imagem"
+                  />
                 </div>
 
                 <div className="border-t border-white/10 pt-4">


### PR DESCRIPTION
## Problema

Em **Configurações → Empresa → Logotipos** só era possível **colar uma URL** — não havia botão para **enviar um arquivo**. Como os campos ficavam vazios (o operador não tinha onde hospedar a imagem), o site continuava mostrando a marca padrão: *"não tem como fazer upload, e não trocou o logo"*.

O #261 (sessão anterior) tornou o logo configurável no admin e já consertou o reflexo no site (a home lê `company.logoIconUrl`/`logoWordmarkUrl` via `GET /site-settings`), mas deixou os campos como entrada de URL apenas. Este PR completa esse trabalho adicionando o upload.

## Correção

Troca os 4 campos de logo (Ícone redondo, Marca Escrita, Logo geral, Logo Branco) de `DarkInput` (só URL) por `MediaUploadInput` — o **mesmo componente já usado nesta tela** para o vídeo/imagem do hero. Ele aceita **upload de imagem** (via `POST /api/v1/upload` → S3, com fallback inline) **e** continua aceitando URL colada.

Fluxo do usuário agora: escolher arquivo → sobe e vira URL no campo → **Salvar** → o cabeçalho do site troca (encanamento já existente).

## Fora do escopo (observação)

O erro `getaddrinfo ENOTFOUND image-processor.railway.internal` visto na tela é de **outra funcionalidade** — a *"Biblioteca de logos para fotos de imóveis"*, que aplica marca d'água nas **fotos dos imóveis** através do microserviço `image-processor` (Railway). Este PR **não** depende desse serviço. Aquele erro é de infraestrutura (o serviço `image-processor` está fora do ar ou `IMAGE_PROCESSOR_URL` está incorreta) e precisa de ação no Railway — tratado à parte.

## Validação

- `pnpm --filter web typecheck` — **zero** erros novos em `SystemConfigPanel.tsx` (os erros restantes são baseline pré-existente do ambiente).
- `MediaUploadInput` já é usado e importado nesta mesma tela, com o mesmo `apiToken`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPCKQHQwxUZSEJsMC3rsE1)_