### PR TITLE
fix(admin): Parceiros & Tenants quebrava com tenant sem name/subdomain

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/admin/tenants/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/admin/tenants/page.tsx
@@ -198,7 +198,10 @@ export default function AdminTenantsPage() {
 
   const filtered = tenants.filter((t) => {
     const q = search.toLowerCase().trim();
-    return !q || t.name.toLowerCase().includes(q) || t.subdomain.toLowerCase().includes(q);
+    // Guarda contra name/subdomain nulos — um único tenant sem esses campos
+    // fazia o .toLowerCase() estourar em render e derrubava a página inteira
+    // ("Erro no Dashboard").
+    return !q || (t.name ?? '').toLowerCase().includes(q) || (t.subdomain ?? '').toLowerCase().includes(q);
   });
 
   return (


### PR DESCRIPTION
A página **Admin → Parceiros & Tenants** quebrava com "Erro no Dashboard" ao carregar, impedindo o uso do botão "Reenviar acesso".

**Causa:** o filtro de busca fazia `t.name.toLowerCase()` / `t.subdomain.toLowerCase()` sem guarda. Um único tenant com `name` ou `subdomain` **nulo** (um cadastro de teste gerou um assim) estourava `TypeError` em render → derrubava a página inteira.

**Fix:** `(t.name ?? '').toLowerCase()` / `(t.subdomain ?? '').toLowerCase()`.

Validado: typecheck limpo. Desbloqueia a página e o botão de reenviar acesso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_