### PR TITLE
fix(web): blinda filtros de busca de Leilões e cadastro contra campos nulos

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/leiloes/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/leiloes/page.tsx
@@ -186,7 +186,7 @@ export default function LeiloesAdminPage() {
 
   // Filtrar leilões
   const filteredAuctions = (stats?.latestAuctions || []).filter(a => {
-    const matchSearch = !searchFilter || a.title.toLowerCase().includes(searchFilter.toLowerCase()) ||
+    const matchSearch = !searchFilter || (a.title || '').toLowerCase().includes(searchFilter.toLowerCase()) ||
       (a.city || '').toLowerCase().includes(searchFilter.toLowerCase())
     const matchSource = sourceFilter === 'ALL' || a.source === sourceFilter
     return matchSearch && matchSource

--- a/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
@@ -145,7 +145,7 @@ function CadastroParceirosContent() {
   }, [])
 
   const filteredBuildings = buildings.filter(b =>
-    b.name.toLowerCase().includes(buildingSearch.toLowerCase()) ||
+    (b.name || '').toLowerCase().includes(buildingSearch.toLowerCase()) ||
     (b.neighborhood || '').toLowerCase().includes(buildingSearch.toLowerCase())
   )
 


### PR DESCRIPTION
Prevenção proativa do mesmo crash da tela de Parceiros & Tenants (PR #263) em outras telas com filtro de busca: **Leilões** (`a.title`) e **cadastro de parceiro** (`b.name`) faziam `.toLowerCase()` sem guarda — um item com campo nulo derrubaria a página. Guarda com `(campo || '')`.

Validado: typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZwaLKNWcrSr2VDTp9V7r)_