### PR TITLE
Separação Plataforma × Parceiro + provisionamento Imobiliária Lemos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ screenshots/
 __pycache__/
 *.pyc
 apps/image-processor/logos_store/
+
+# Snapshots/rollback de provisionamento (contêm IDs de produção)
+.migration-runs/

--- a/apps/api/src/routes/affiliates/index.ts
+++ b/apps/api/src/routes/affiliates/index.ts
@@ -14,6 +14,7 @@ import type { FastifyInstance } from 'fastify'
 import crypto from 'crypto'
 import { resolveAffiliateFromCode, trackAffiliateReferral } from '../../services/affiliate-tracking.service.js'
 import { recalculateAffiliateLevel } from '../../services/affiliate-level.service.js'
+import { requireSuperAdmin } from '../../utils/permissions.js'
 
 // Gamification: comissão por nível
 const LEVEL_RATES: Record<string, number> = {
@@ -75,7 +76,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── GET / — Listar afiliados (admin) ───────────────────────────────────────���
-  app.get('/', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.get('/', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const query = req.query as { limit?: string; offset?: string; isActive?: string }
     const limit = Math.min(parseInt(query.limit || '50'), 100)
     const offset = parseInt(query.offset || '0')
@@ -112,7 +113,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── GET /:id — Detalhe do afiliado ──────────────────────────────────────────
-  app.get('/:id', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.get('/:id', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const affiliate = await prisma.affiliate.findUnique({ where: { id } })
     if (!affiliate) return reply.status(404).send({ error: 'Afiliado não encontrado' })
@@ -120,7 +121,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── GET /:id/earnings — Ganhos do afiliado ──────────────────────────────────
-  app.get('/:id/earnings', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.get('/:id/earnings', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const query = req.query as { limit?: string; status?: string }
     const limit = Math.min(parseInt(query.limit || '50'), 100)
@@ -138,7 +139,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── GET /:id/stats — Estatísticas do afiliado ──────────────────────────────
-  app.get('/:id/stats', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.get('/:id/stats', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
 
     const affiliate = await prisma.affiliate.findUnique({ where: { id } })
@@ -174,7 +175,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── PUT /:id — Atualizar afiliado ──────────────────────────────────────────
-  app.put('/:id', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.put('/:id', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const body = req.body as { name?: string; phone?: string; level?: string; isActive?: boolean }
 
@@ -235,7 +236,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── GET /:id/referrals — Lista de indicações do afiliado ─────────────────��─
-  app.get('/:id/referrals', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.get('/:id/referrals', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
     const query = req.query as { limit?: string; status?: string }
     const limit = Math.min(parseInt(query.limit || '50'), 100)
@@ -253,7 +254,7 @@ export default async function affiliateRoutes(app: FastifyInstance) {
   })
 
   // ── POST /:id/recalculate-level — Recalcular nível ────────────────────────
-  app.post('/:id/recalculate-level', { preHandler: [app.authenticate] }, async (req, reply) => {
+  app.post('/:id/recalculate-level', { preHandler: [app.authenticate, requireSuperAdmin()] }, async (req, reply) => {
     const { id } = req.params as { id: string }
 
     const result = await recalculateAffiliateLevel(prisma, id)

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -146,7 +146,8 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
     }
     // Planos internos (ex.: "fundador") NUNCA podem ser adquiridos via checkout
     // público — são atribuídos só por processo interno (provisionamento/master).
-    if ((plan.metadata as any)?.internal === true) {
+    // Defensivo: bloqueia por slug E por metadata.internal.
+    if (plan.slug === 'fundador' || (plan.metadata as any)?.internal === true) {
       return reply.status(403).send({
         error: 'PLAN_NOT_AVAILABLE',
         message: `Plano "${plan.name}" não está disponível para contratação.`,

--- a/apps/api/src/routes/billing/saas-checkout.ts
+++ b/apps/api/src/routes/billing/saas-checkout.ts
@@ -144,6 +144,14 @@ export default async function saasBillingRoutes(app: FastifyInstance) {
         message: `Plano "${plan.name}" está marcado como inativo.`,
       })
     }
+    // Planos internos (ex.: "fundador") NUNCA podem ser adquiridos via checkout
+    // público — são atribuídos só por processo interno (provisionamento/master).
+    if ((plan.metadata as any)?.internal === true) {
+      return reply.status(403).send({
+        error: 'PLAN_NOT_AVAILABLE',
+        message: `Plano "${plan.name}" não está disponível para contratação.`,
+      })
+    }
 
     // 2. Validate subdomain uniqueness
     const existingTenant = await prisma.tenant.findUnique({

--- a/apps/api/src/routes/billing/saas-webhook.ts
+++ b/apps/api/src/routes/billing/saas-webhook.ts
@@ -18,6 +18,7 @@
 
 import type { FastifyInstance } from 'fastify'
 import { env } from '../../utils/env.js'
+import { isBillingExempt } from '../../services/billing-exempt.js'
 import type { AsaasWebhookEvent } from '../../services/asaas.service.js'
 import { safeStringEqual } from '../../utils/crypto-safe.js'
 import { createPasswordSetupToken } from '../auth/first-access.js'
@@ -355,6 +356,11 @@ async function handleTenantEvent(
     }
 
     case 'PAYMENT_OVERDUE': {
+      // Parceira isenta (ex.: fundadora Imobiliária Lemos) nunca é rebaixada.
+      if (isBillingExempt({ tenant })) {
+        app.log.info(`[saas-webhook] Tenant ${subdomain} é isento de cobrança — ignorando PAYMENT_OVERDUE`)
+        return
+      }
       if (tenant.planStatus === 'PAST_DUE') return // Already marked
 
       await prisma.tenant.update({
@@ -386,6 +392,11 @@ async function handleTenantEvent(
 
     case 'PAYMENT_DELETED':
     case 'PAYMENT_REFUNDED': {
+      // Parceira isenta (ex.: fundadora Imobiliária Lemos) nunca é suspensa.
+      if (isBillingExempt({ tenant })) {
+        app.log.info(`[saas-webhook] Tenant ${subdomain} é isento de cobrança — ignorando ${event}`)
+        return
+      }
       // Suspend tenant on refund/cancellation
       await prisma.tenant.update({
         where: { id: tenant.id },

--- a/apps/api/src/routes/market/index.ts
+++ b/apps/api/src/routes/market/index.ts
@@ -11,9 +11,15 @@
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { getMarketStats, estimatePrice } from '../../services/market-stats.service.js'
+import { requireSuperAdmin } from '../../utils/permissions.js'
 
 export default async function marketRoutes(app: FastifyInstance) {
+  // Radar de Mercado é ferramenta EXCLUSIVA da plataforma (agrega dados de todo
+  // o marketplace, cross-tenant). Só o super-admin acessa — o parceiro nem vê o
+  // item no menu. (Precificação por comparáveis do próprio parceiro é feita por
+  // outras rotas, ex.: public/valuation.)
   app.addHook('preHandler', app.authenticate)
+  app.addHook('preHandler', requireSuperAdmin())
 
   app.get('/stats', { schema: { tags: ['market'] } }, async (req, reply) => {
     const q = req.query as { city?: string; neighborhood?: string; type?: string; purpose?: string }

--- a/apps/api/src/routes/master/admin-config.ts
+++ b/apps/api/src/routes/master/admin-config.ts
@@ -384,6 +384,9 @@ export async function publicCatalogRoutes(app: FastifyInstance) {
         where: {
           isActive: true,
           // Nunca exibir planos internos (ex.: "fundador") no catálogo público.
+          // Defensivo: bloqueia por slug E por metadata.internal (mesmo se metadata
+          // estiver ausente/inconsistente).
+          slug: { not: 'fundador' },
           NOT: { metadata: { path: ['internal'], equals: true } },
           ...(nicheSlug && {
             OR: [

--- a/apps/api/src/routes/master/admin-config.ts
+++ b/apps/api/src/routes/master/admin-config.ts
@@ -383,6 +383,8 @@ export async function publicCatalogRoutes(app: FastifyInstance) {
       prisma.planDefinition.findMany({
         where: {
           isActive: true,
+          // Nunca exibir planos internos (ex.: "fundador") no catálogo público.
+          NOT: { metadata: { path: ['internal'], equals: true } },
           ...(nicheSlug && {
             OR: [
               { nicheFilter: { isEmpty: true } },

--- a/apps/api/src/routes/saas-finance/index.ts
+++ b/apps/api/src/routes/saas-finance/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { EXCLUDE_INTERNAL_TENANT } from '../../services/tenant.service.js'
 
 export default async function saasFinanceRoutes(app: FastifyInstance) {
   const prisma = app.prisma as any
@@ -81,9 +82,9 @@ export default async function saasFinanceRoutes(app: FastifyInstance) {
       }),
     ])
 
-    // MRR: sum of active recurring subscriptions
+    // MRR: sum of active recurring subscriptions (exclui internos/isentos, ex.: fundadora Lemos)
     const activeTenants = await prisma.tenant.findMany({
-      where: { planStatus: 'ACTIVE' },
+      where: { planStatus: 'ACTIVE', ...EXCLUDE_INTERNAL_TENANT },
       select: { planPrice: true },
     }).catch(() => [])
 
@@ -119,19 +120,20 @@ export default async function saasFinanceRoutes(app: FastifyInstance) {
     const dailyAvg = dayOfMonth > 0 ? monthRevenueVal / dayOfMonth : 0
     const forecast = dailyAvg * daysInMonth
 
-    // Tenants by status
+    // Tenants by status (exclui internos/isentos, ex.: fundadora Lemos)
     const tenantStats = await prisma.tenant.groupBy({
       by: ['planStatus'],
+      where: { ...EXCLUDE_INTERNAL_TENANT },
       _count: true,
     }).catch(() => [])
 
     const tenantByStatus: Record<string, number> = {}
     tenantStats.forEach((s: any) => { tenantByStatus[s.planStatus] = s._count })
 
-    // Tenants by plan
+    // Tenants by plan (exclui internos/isentos → Fundador não aparece na distribuição)
     const tenantPlans = await prisma.tenant.groupBy({
       by: ['plan'],
-      where: { planStatus: 'ACTIVE' },
+      where: { planStatus: 'ACTIVE', ...EXCLUDE_INTERNAL_TENANT },
       _count: true,
       _sum: { planPrice: true },
     }).catch(() => [])
@@ -148,9 +150,9 @@ export default async function saasFinanceRoutes(app: FastifyInstance) {
       where: { isActive: true },
     }).catch(() => 0)
 
-    // MRR
+    // MRR (exclui internos/isentos, ex.: fundadora Lemos)
     const activeTenants = await prisma.tenant.findMany({
-      where: { planStatus: 'ACTIVE' },
+      where: { planStatus: 'ACTIVE', ...EXCLUDE_INTERNAL_TENANT },
       select: { planPrice: true },
     }).catch(() => [])
     const mrr = activeTenants.reduce((sum: number, t: any) => sum + Number(t.planPrice || 0), 0)

--- a/apps/api/src/routes/tenants/index.ts
+++ b/apps/api/src/routes/tenants/index.ts
@@ -130,13 +130,22 @@ export default async function tenantRoutes(app: FastifyInstance) {
   app.get('/mine', {
     schema: { tags: ['tenants'], summary: 'Get the tenant owned by the logged-in user' },
   }, async (req, reply) => {
-    // Resolve o tenant do usuário: por ownerId OU pela empresa dele — assim
-    // qualquer membro da empresa (ex.: os 4 admins da Lemos) acha o site da empresa.
+    // O objeto tenant carrega settings/dados financeiros/assinatura/repasses —
+    // portanto NÃO é para corretor. Só quem GERE o site pode recebê-lo:
+    // owner, ADMIN/MANAGER da mesma empresa, ou SUPER_ADMIN.
+    const isManagerRole = ['ADMIN', 'MANAGER', 'SUPER_ADMIN'].includes(req.user.role)
+    // Owner pode ser resolvido por ownerId; gestores da empresa, por companyId.
+    const or: any[] = [{ ownerId: req.user.sub }]
+    if (isManagerRole) or.push({ companyId: req.user.cid })
     const tenant = await (app.prisma as any).tenant.findFirst({
-      where: { OR: [{ ownerId: req.user.sub }, { companyId: req.user.cid }] },
+      where: { OR: or },
       orderBy: { createdAt: 'desc' },
     })
     if (!tenant) return reply.status(404).send({ error: 'NO_TENANT_FOR_USER' })
+    // Defesa extra: se casou por empresa, exige papel de gestão (nunca BROKER).
+    const canManage = tenant.ownerId === req.user.sub
+      || (tenant.companyId === req.user.cid && isManagerRole)
+    if (!canManage) return reply.status(403).send({ error: 'FORBIDDEN' })
     return reply.send({ success: true, data: tenant })
   })
 

--- a/apps/api/src/routes/tenants/index.ts
+++ b/apps/api/src/routes/tenants/index.ts
@@ -44,6 +44,13 @@ export default async function tenantRoutes(app: FastifyInstance) {
   app.post('/', {
     schema: { tags: ['tenants'], summary: 'Create a new tenant (clone site)' },
   }, async (req, reply) => {
+    // Criação direta de tenant é ação de PLATAFORMA (SUPER_ADMIN). Parceiros que
+    // contratam um site passam pelo checkout (/api/v1/billing/saas/checkout),
+    // que aplica plano/pagamento. Sem este guard, qualquer usuário autenticado
+    // poderia auto-provisionar um tenant sem regra de plano/permissão.
+    if (req.user.role !== 'SUPER_ADMIN') {
+      return reply.status(403).send({ error: 'FORBIDDEN', message: 'SUPER_ADMIN access required' })
+    }
     const body = z.object({
       name: z.string().min(2),
       subdomain: z.string().min(3).max(50).regex(/^[a-z0-9-]+$/),
@@ -123,8 +130,10 @@ export default async function tenantRoutes(app: FastifyInstance) {
   app.get('/mine', {
     schema: { tags: ['tenants'], summary: 'Get the tenant owned by the logged-in user' },
   }, async (req, reply) => {
+    // Resolve o tenant do usuário: por ownerId OU pela empresa dele — assim
+    // qualquer membro da empresa (ex.: os 4 admins da Lemos) acha o site da empresa.
     const tenant = await (app.prisma as any).tenant.findFirst({
-      where: { ownerId: req.user.sub },
+      where: { OR: [{ ownerId: req.user.sub }, { companyId: req.user.cid }] },
       orderBy: { createdAt: 'desc' },
     })
     if (!tenant) return reply.status(404).send({ error: 'NO_TENANT_FOR_USER' })
@@ -157,8 +166,11 @@ export default async function tenantRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: 'TENANT_NOT_FOUND' })
     }
 
-    // Allow access for tenant owner or SUPER_ADMIN
-    if (tenant.ownerId !== req.user.sub && req.user.role !== 'SUPER_ADMIN') {
+    // Owner, ADMIN/MANAGER da mesma empresa, ou SUPER_ADMIN.
+    const canManage = tenant.ownerId === req.user.sub
+      || (tenant.companyId === req.user.cid && ['ADMIN', 'MANAGER'].includes(req.user.role))
+      || req.user.role === 'SUPER_ADMIN'
+    if (!canManage) {
       return reply.status(403).send({ error: 'FORBIDDEN' })
     }
 
@@ -192,11 +204,23 @@ export default async function tenantRoutes(app: FastifyInstance) {
     const tenant = await (app.prisma as any).tenant.findUnique({ where: { id } })
     if (!tenant) return reply.status(404).send({ error: 'TENANT_NOT_FOUND' })
 
-    if (tenant.ownerId !== req.user.sub && req.user.role !== 'SUPER_ADMIN') {
+    // Owner, ADMIN/MANAGER da mesma empresa, ou SUPER_ADMIN podem editar o site.
+    const isSuperAdmin = req.user.role === 'SUPER_ADMIN'
+    const canManage = tenant.ownerId === req.user.sub
+      || (tenant.companyId === req.user.cid && ['ADMIN', 'MANAGER'].includes(req.user.role))
+      || isSuperAdmin
+    if (!canManage) {
       return reply.status(403).send({ error: 'FORBIDDEN' })
     }
 
     const { logoWordmarkUrl, logoVisible, logoShowText, logoPosition, settings, ...columns } = body
+    // Campos financeiros/comerciais (split e regras de repasse) só o SUPER_ADMIN
+    // altera — um parceiro NÃO pode reduzir o próprio split da plataforma.
+    if (!isSuperAdmin) {
+      delete (columns as any).splitPercent
+      delete (columns as any).repasseDelayDays
+      delete (columns as any).repasseFixedDay
+    }
     const brandingSettings: Record<string, any> = {}
     if (logoWordmarkUrl !== undefined) brandingSettings.logoWordmarkUrl = logoWordmarkUrl
     if (logoVisible !== undefined) brandingSettings.logoVisible = logoVisible

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -150,10 +150,17 @@ const app = Fastify({
 })
 
 async function runMigrations(prisma: any) {
-  // ── Admin role enforcement ──────────────────────────────────────────────
-  // Ensures admin users have correct role on boot (no password reset in code)
+  // ── Platform super-admin enforcement ────────────────────────────────────
+  // Garante que O ÚNICO super-admin da PLATAFORMA AgoraEncontrei tenha o papel
+  // correto no boot (sem reset de senha em código).
+  //
+  // IMPORTANTE: `tomascesarlemossilva@gmail.com` foi REMOVIDO desta lista de
+  // propósito — esse e-mail passou a ser ADMIN da empresa Imobiliária Lemos
+  // (parceiro), não super-admin da plataforma. Reintroduzi-lo aqui reverteria,
+  // a cada deploy/restart, a separação plataforma × parceiro. O papel do gmail
+  // é definido pelo script scripts/provision-imobiliaria-lemos.ts.
   try {
-    for (const email of ['tomas@agoraencontrei.com.br', 'tomascesarlemossilva@gmail.com']) {
+    for (const email of ['tomas@agoraencontrei.com.br']) {
       await prisma.$executeRawUnsafe(
         `UPDATE users SET role = 'SUPER_ADMIN', status = 'ACTIVE', "emailVerifiedAt" = COALESCE("emailVerifiedAt", NOW()) WHERE email = $1 AND role != 'SUPER_ADMIN'`,
         email

--- a/apps/api/src/services/billing-exempt.ts
+++ b/apps/api/src/services/billing-exempt.ts
@@ -1,0 +1,34 @@
+/**
+ * Isenção de cobrança SaaS — fonte única de decisão.
+ *
+ * A parceira fundadora (Imobiliária Lemos) usa o AgoraEncontrei sem cobrança.
+ * A isenção NÃO deve ser espalhada como flags soltas por vários caminhos de
+ * billing (checkout, webhook, cron, sync Asaas): centralize aqui.
+ *
+ * Sinais de isenção (o provisionamento da Lemos grava TODOS):
+ *   • plano interno: `plan.metadata.billingExempt === true` (plano "fundador"), ou
+ *   • tenant:        `tenant.settings.billingExempt === true`, ou
+ *   • company:       `company.settings.billingExempt === true`.
+ *
+ * Basta UM sinal para isentar (os caminhos de billing nem sempre têm o plano
+ * carregado). Para reduzir o risco de uma flag acidental isentar um cliente
+ * real, o provisionamento sempre grava os três de forma coerente.
+ */
+
+type WithSettings = { settings?: unknown } | null | undefined
+type WithMetadata = { metadata?: unknown } | null | undefined
+
+function flag(obj: unknown, key: string): boolean {
+  return !!obj && typeof obj === 'object' && (obj as Record<string, unknown>)[key] === true
+}
+
+export function isBillingExempt(input: {
+  plan?: WithMetadata
+  tenant?: WithSettings
+  company?: WithSettings
+}): boolean {
+  const planExempt = flag(input.plan?.metadata, 'billingExempt') || flag(input.plan?.metadata, 'internal')
+  const tenantExempt = flag(input.tenant?.settings, 'billingExempt')
+  const companyExempt = flag(input.company?.settings, 'billingExempt')
+  return planExempt || tenantExempt || companyExempt
+}

--- a/apps/api/src/services/bootstrap-plans.ts
+++ b/apps/api/src/services/bootstrap-plans.ts
@@ -29,9 +29,48 @@ interface PlanSeed {
   features: string[]
   highlighted: boolean
   sortOrder: number
+  /** Metadados opcionais. `internal:true` esconde do catálogo público. */
+  metadata?: Record<string, unknown>
 }
 
+// Todos os temas e módulos reais do sistema — usados pelo plano interno
+// "Fundador" para liberar tudo explicitamente (sem depender só do wildcard 'all').
+const ALL_THEME_SLUGS = [
+  'urban_tech', 'classic_trust', 'luxury_gold', 'fast_sales_pro',
+  'landscape_living', 'signature_estate', 'minimal_studio', 'bold_agency',
+  'editorial_journal',
+]
+const ALL_MODULE_SLUGS = [
+  'site_basico', 'crm_basico', 'crm_avancado', 'ia_tomas', 'whatsapp',
+  'leiloes', 'dominio_proprio', 'split_pagamentos', 'video_editor',
+]
+
 const DEFAULT_PLANS: PlanSeed[] = [
+  {
+    // Plano INTERNO da parceira fundadora (Imobiliária Lemos). R$0, tudo
+    // ilimitado, todos os módulos e temas, e NUNCA gera cobrança (billingExempt).
+    // metadata.internal esconde este plano do catálogo comercial público.
+    slug: 'fundador',
+    name: 'Fundador',
+    description: 'Plano interno da parceira fundadora — acesso total, sem cobrança.',
+    priceMonthly: 0,
+    priceYearly: 0,
+    maxProperties: -1,
+    maxLeadViews: -1,
+    maxUsers: -1,
+    maxAIRequests: -1,
+    themes: ['all', ...ALL_THEME_SLUGS],
+    modules: [...ALL_MODULE_SLUGS],
+    features: [
+      'Acesso completo e ilimitado a todos os módulos',
+      'Usuários, imóveis, leads e IA ilimitados',
+      'Todos os temas de site liberados',
+      'Isento de cobrança (parceira fundadora)',
+    ],
+    highlighted: false,
+    sortOrder: 0,
+    metadata: { internal: true, billingExempt: true, allModules: true, allThemes: true },
+  },
   {
     slug: 'lite',
     name: 'Simples',
@@ -216,6 +255,7 @@ export async function bootstrapDefaultPlans(prisma: PrismaClient): Promise<void>
         highlighted: plan.highlighted,
         sortOrder: plan.sortOrder,
         isActive: true,
+        ...(plan.metadata ? { metadata: plan.metadata as any } : {}),
       },
     }).catch(() => null)
     createdPlans++

--- a/apps/api/src/services/master/forecast.service.ts
+++ b/apps/api/src/services/master/forecast.service.ts
@@ -69,9 +69,9 @@ export async function buildForecast(prisma: any): Promise<ForecastMetrics> {
     tendencia = 'estavel'
   }
 
-  // MRR next month: current MRR + growth trend
+  // MRR next month (exclui parceiros internos/isentos, ex.: fundadora Lemos)
   const activeTenants = await prisma.tenant.findMany({
-    where: { planStatus: 'ACTIVE' },
+    where: { planStatus: 'ACTIVE', plan: { not: 'fundador' }, NOT: { settings: { path: ['billingExempt'], equals: true } } },
     select: { planPrice: true },
   }).catch(() => [])
   const currentMrr = activeTenants.reduce((sum: number, t: any) => sum + Number(t.planPrice || 0), 0)

--- a/apps/api/src/services/master/intelligence.service.ts
+++ b/apps/api/src/services/master/intelligence.service.ts
@@ -30,9 +30,9 @@ async function buildRevenue(prisma: any): Promise<RevenueMetrics> {
   const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
 
-  // Active tenants for MRR
+  // Active tenants for MRR (exclui parceiros internos/isentos, ex.: fundadora Lemos)
   const activeTenants = await prisma.tenant.findMany({
-    where: { planStatus: 'ACTIVE' },
+    where: { planStatus: 'ACTIVE', plan: { not: 'fundador' }, NOT: { settings: { path: ['billingExempt'], equals: true } } },
     select: { plan: true, planPrice: true },
   }).catch(() => [])
 

--- a/apps/api/src/services/master/retention.service.ts
+++ b/apps/api/src/services/master/retention.service.ts
@@ -12,17 +12,19 @@ export async function buildRetention(prisma: any): Promise<RetentionMetrics> {
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
 
+  // Exclui parceiros internos/isentos (ex.: fundadora Lemos) das métricas de churn.
+  const notInternal = { plan: { not: 'fundador' }, NOT: { settings: { path: ['billingExempt'], equals: true } } }
   // Tenant counts by status
   const [active, trial, pastDue, suspended] = await Promise.all([
-    prisma.tenant.count({ where: { planStatus: 'ACTIVE' } }).catch(() => 0),
-    prisma.tenant.count({ where: { planStatus: 'TRIAL' } }).catch(() => 0),
-    prisma.tenant.count({ where: { planStatus: 'PAST_DUE' } }).catch(() => 0),
-    prisma.tenant.count({ where: { planStatus: 'SUSPENDED' } }).catch(() => 0),
+    prisma.tenant.count({ where: { planStatus: 'ACTIVE', ...notInternal } }).catch(() => 0),
+    prisma.tenant.count({ where: { planStatus: 'TRIAL', ...notInternal } }).catch(() => 0),
+    prisma.tenant.count({ where: { planStatus: 'PAST_DUE', ...notInternal } }).catch(() => 0),
+    prisma.tenant.count({ where: { planStatus: 'SUSPENDED', ...notInternal } }).catch(() => 0),
   ])
 
   // Tenants without recent activity (updatedAt as proxy for activity)
   const allActiveTenants = await prisma.tenant.findMany({
-    where: { planStatus: { in: ['ACTIVE', 'TRIAL'] } },
+    where: { planStatus: { in: ['ACTIVE', 'TRIAL'] }, ...notInternal },
     select: {
       id: true,
       name: true,

--- a/apps/api/src/services/tenant.service.ts
+++ b/apps/api/src/services/tenant.service.ts
@@ -8,6 +8,17 @@
 import type { PrismaClient } from '@prisma/client'
 import { env } from '../utils/env.js'
 
+/**
+ * Filtro Prisma para EXCLUIR parceiros internos/isentos (ex.: a fundadora
+ * Imobiliária Lemos, plano "fundador") das métricas COMERCIAIS — MRR, churn,
+ * inadimplência, retenção, forecast. Eles não são clientes pagantes.
+ * Reutilizado em tenant.service, retention.service, forecast.service, intelligence.
+ */
+export const EXCLUDE_INTERNAL_TENANT = {
+  plan: { not: 'fundador' },
+  NOT: { settings: { path: ['billingExempt'], equals: true } },
+} as const
+
 // ── Types ───────────────────────────────────────────────────────────────────
 
 export interface CreateTenantInput {
@@ -225,9 +236,15 @@ export async function calculateMRR(
   arr: number
   churnRate: number
 }> {
-  const allTenants = await (prisma as any).tenant.findMany({
-    select: { planStatus: true, planPrice: true, suspendedAt: true, createdAt: true },
+  const rawTenants = await (prisma as any).tenant.findMany({
+    select: { planStatus: true, planPrice: true, suspendedAt: true, createdAt: true, plan: true, settings: true },
   })
+
+  // Exclui parceiros INTERNOS/isentos (ex.: fundadora Imobiliária Lemos) das
+  // métricas comerciais — não são clientes pagantes e poluiriam MRR/churn/ativos.
+  const allTenants = rawTenants.filter((t: any) =>
+    t.plan !== 'fundador' && (t.settings as any)?.billingExempt !== true,
+  )
 
   const active = allTenants.filter((t: any) => t.planStatus === 'ACTIVE')
   const suspended = allTenants.filter((t: any) => t.planStatus === 'SUSPENDED')

--- a/apps/api/src/utils/permissions.ts
+++ b/apps/api/src/utils/permissions.ts
@@ -21,6 +21,39 @@ const FIELD: Record<PermAction, 'canView' | 'canEdit' | 'canDelete'> = {
   delete: 'canDelete',
 }
 
+/**
+ * preHandler que exige SUPER_ADMIN (super-admin da PLATAFORMA AgoraEncontrei).
+ * Use nas rotas exclusivas de plataforma (master, tenants, afiliados, repasses,
+ * saas-finance, system-events, outgoing-webhooks, outbound). Espelha o padrão
+ * de `routes/master/index.ts` (403 + auditLog `admin.access_denied`).
+ *
+ * IMPORTANTE: assume que `app.authenticate` já rodou antes (req.user populado).
+ */
+export function requireSuperAdmin() {
+  return async function superAdminGuard(req: FastifyRequest, reply: FastifyReply) {
+    const user = (req as any).user
+    if (!user) return reply.status(401).send({ error: 'UNAUTHORIZED' })
+    if (user.role !== 'SUPER_ADMIN') {
+      const prisma = (req.server as any).prisma
+      await prisma?.auditLog
+        ?.create({
+          data: {
+            companyId: 'platform',
+            userId: user.sub ?? 'unknown',
+            action: 'admin.access_denied' as any,
+            resource: 'platform',
+            resourceId: req.url,
+            payload: { role: user.role, method: req.method, url: req.url, ip: req.ip } as any,
+          },
+        })
+        .catch(() => {})
+      return reply
+        .status(403)
+        .send({ error: 'FORBIDDEN', message: 'SUPER_ADMIN access required' })
+    }
+  }
+}
+
 export function requirePermission(module: string, action: PermAction) {
   return async function permissionGuard(req: FastifyRequest, reply: FastifyReply) {
     const user = (req as any).user

--- a/apps/web/src/components/dashboard/guard.tsx
+++ b/apps/web/src/components/dashboard/guard.tsx
@@ -1,14 +1,23 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useAuthStore } from '@/stores/auth.store'
 import { authApi } from '@/lib/api'
+import { isPlatformOnly, isPlatformAdmin } from '@/lib/platform-routes'
 import { Loader2 } from 'lucide-react'
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
+  const pathname = usePathname()
   const { user, accessToken, refreshToken, isAuthenticated, isTokenExpired, setAuth, clearAuth } = useAuthStore()
+
+  // Defesa em profundidade: rotas exclusivas da plataforma só para super-admin.
+  // Um parceiro que tentar acessar por URL direta é redirecionado ao dashboard.
+  const blockedPlatformRoute = !!user && isPlatformOnly(pathname) && !isPlatformAdmin(user)
+  useEffect(() => {
+    if (blockedPlatformRoute) router.replace('/dashboard')
+  }, [blockedPlatformRoute, router])
 
   useEffect(() => {
     async function check() {
@@ -110,6 +119,15 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
             Voltar para login
           </button>
         </div>
+      </div>
+    )
+  }
+
+  // Enquanto redireciona uma rota de plataforma bloqueada, não renderiza o conteúdo.
+  if (blockedPlatformRoute) {
+    return (
+      <div className="min-h-[100dvh] flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     )
   }

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/hooks/useAuth'
+import { isPlatformOnly, isPlatformAdmin } from '@/lib/platform-routes'
 import { useState, useEffect } from 'react'
 import {
   Handshake, Split, FileWarning, ShieldCheck, Wallet,
@@ -181,6 +182,14 @@ function NavContent({ onClose }: { onClose?: () => void }) {
     if (!mod) return true // items without module mapping are always visible
     return moduleAccess.includes(mod)
   }
+  // Ferramentas exclusivas da plataforma (Admin Master, Tenants, Afiliados,
+  // Repasses, Master Intel, Site Factory, etc.) só aparecem para o super-admin
+  // da plataforma. Um parceiro (mesmo ADMIN com full access) nunca as vê.
+  const canSeePlatform = isPlatformAdmin(user)
+  function isVisible(href: string): boolean {
+    if (isPlatformOnly(href) && !canSeePlatform) return false
+    return hasModuleAccess(href)
+  }
   const lemosbankActive = pathname.startsWith('/dashboard/lemosbank') ||
     pathname.startsWith('/dashboard/contratos') ||
     pathname.startsWith('/dashboard/clientes')
@@ -329,8 +338,8 @@ function NavContent({ onClose }: { onClose?: () => void }) {
           )}
         </div>}
 
-        {/* ── Mid items: Imóveis → Blog (filtered by module access) ── */}
-        {midNavItems.filter(item => hasModuleAccess(item.href)).map(({ href, icon: Icon, label, highlight }) => {
+        {/* ── Mid items: Imóveis → Blog (filtered by module + platform access) ── */}
+        {midNavItems.filter(item => isVisible(item.href)).map(({ href, icon: Icon, label, highlight }) => {
           const active = pathname === href || (href !== '/dashboard' && pathname.startsWith(href))
           return (
             <Link

--- a/apps/web/src/lib/platform-routes.ts
+++ b/apps/web/src/lib/platform-routes.ts
@@ -1,0 +1,51 @@
+/**
+ * Platform-only routes — fonte única de verdade.
+ *
+ * Estas rotas do dashboard administram a PLATAFORMA AgoraEncontrei (parceiros,
+ * planos, afiliados, tenants, eventos, saúde de integrações, filas de repasse,
+ * inteligência de mercado, financeiro SaaS, fábrica de site). Só podem ser
+ * vistas/acessadas pelo super-admin da plataforma (`SUPER_ADMIN`).
+ *
+ * Um PARCEIRO contratado (incluindo a Imobiliária Lemos, que é ADMIN da própria
+ * empresa) NUNCA deve enxergar estas ferramentas — ele gere apenas o próprio
+ * site, sistema e dados de clientes. Ele continua editando o próprio site pelos
+ * itens "Meu Site (Parceiro)" (`/dashboard/meu-site`) e "Editar meu site"
+ * (`/dashboard/settings`), que não fazem parte desta lista.
+ *
+ * A sidebar (esconde) e o guard de rota (redireciona) consomem estas funções;
+ * a defesa real continua no backend (403 por SUPER_ADMIN em cada rota).
+ */
+
+/** Prefixos de rota exclusivos da plataforma. */
+export const PLATFORM_ONLY_HREFS = [
+  '/dashboard/admin/master',      // Admin Master (catálogo planos/nichos/módulos/serviços)
+  '/dashboard/admin/tenants',     // Parceiros & Tenants
+  '/dashboard/admin/events',      // Eventos do Sistema
+  '/dashboard/admin/webhooks',    // Saúde das Integrações
+  '/dashboard/admin/repasses',    // Fila de Repasses
+  '/dashboard/afiliados',         // Programa de Afiliados
+  '/dashboard/saas-financeiro',   // Financeiro SaaS
+  '/dashboard/master',            // Master Intel (BI / inteligência de mercado)
+  '/dashboard/market',            // Radar de Mercado
+  '/dashboard/parceiros',         // Painel de Parceiros da plataforma
+  '/dashboard/site-factory',      // Fábrica de Site (criação de clones/tenants)
+] as const
+
+/**
+ * Retorna true se `pathname` pertence a uma rota exclusiva da plataforma.
+ * Faz match por prefixo (normalizado) para cobrir sub-rotas e parâmetros
+ * dinâmicos (ex.: /dashboard/admin/tenants/abc123, /dashboard/admin/repasses?x=1).
+ */
+export function isPlatformOnly(pathname: string | null | undefined): boolean {
+  if (!pathname) return false
+  // Normaliza: remove query string/hash e barra final.
+  const normalized = pathname.split(/[?#]/)[0].replace(/\/+$/, '')
+  return PLATFORM_ONLY_HREFS.some(
+    (base) => normalized === base || normalized.startsWith(base + '/'),
+  )
+}
+
+/** Só o super-admin da plataforma vê/acessa as rotas platform-only. */
+export function isPlatformAdmin(user: { role?: string | null } | null | undefined): boolean {
+  return user?.role === 'SUPER_ADMIN'
+}

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -26,7 +26,11 @@ async function main() {
 
   console.log('✅ Company:', company.name)
 
-  // Create admin user
+  // Create the PLATFORM super-admin (AgoraEncontrei).
+  // tomas@agoraencontrei.com.br é o único super-admin da plataforma — o mesmo
+  // e-mail é promovido a SUPER_ADMIN no boot da API (apps/api/src/server.ts).
+  // Os usuários/dados da Imobiliária Lemos (parceira) são provisionados à parte
+  // por scripts/provision-imobiliaria-lemos.ts, e NÃO por este seed.
   const passwordHash = await argon2.hash('Lemos2024', { type: argon2.argon2id })
 
   const admin = await prisma.user.upsert({
@@ -38,7 +42,7 @@ async function main() {
       email: 'tomas@agoraencontrei.com.br',
       phone: '(16) 98101-0004',
       passwordHash,
-      role: 'ADMIN',
+      role: 'SUPER_ADMIN',
       status: 'ACTIVE',
       emailVerifiedAt: new Date(),
     },

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -23,8 +23,12 @@ Este runbook descreve a implantação segura da mudança que:
 | `noemialemos3@gmail.com` | `ADMIN` | Imobiliária Lemos |
 | `lorensesso@gmail.com` + 4 corretores | `BROKER` | Imobiliária Lemos |
 
-Senha provisória padrão: **`lemos2026`** (flag `mustChangePassword` marcada — cada pessoa
-troca no primeiro acesso e completa foto/telefone/dados).
+Senhas: **individuais e aleatórias** por usuário (sem senha coletiva). O script imprime
+cada senha **uma única vez** ao final da execução real — entregue a cada pessoa por canal
+seguro. Todos têm `mustChangePassword` marcado (trocam no primeiro acesso e completam
+foto/telefone/dados). Usuário que já existe **não** tem a senha sobrescrita (a menos de
+`RESET_EXISTING_PASSWORDS=true`). Para forçar uma senha comum (não recomendado), use
+`FORCE_PASSWORD`.
 
 ---
 
@@ -82,7 +86,9 @@ dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (reverten
 | `SKIP_PROPERTIES` | `false` | só provisiona estrutura, não mexe em imóveis |
 | `MAX_MOVE` | `100000` | aborta se a seleção exceder (guarda anti-erro) |
 | `BATCH_SIZE` | `200` | tamanho do lote de update de imóveis |
-| `RESET_EXISTING_PASSWORDS` | `false` | redefine senha de usuários já existentes p/ a padrão |
+| `EXPECTED_PROPERTY_COUNT` | — | se definido, ABORTA se a seleção divergir |
+| `RESET_EXISTING_PASSWORDS` | `false` | redefine senha de usuários já existentes (senha individual) |
+| `FORCE_PASSWORD` | — | força uma senha comum (não recomendado; padrão = aleatória individual) |
 | `SUBDOMAIN` | `lemos` | subdomínio do tenant Lemos |
 
 ---
@@ -115,7 +121,7 @@ em lotes, e valide antes numa cópia do banco.
 - [ ] Nenhum contato-proprietário órfão entre empresas.
 
 **Operação**
-- [ ] Os 9 usuários conseguem logar com `lemos2026` e são forçados a trocar a senha.
+- [ ] Os 9 usuários conseguem logar com a senha individual entregue e são forçados a trocá-la.
 - [ ] Cada corretor (`BROKER`) enxerga só o próprio escopo.
 - [ ] O site continua publicando os imóveis; formulários criam leads na company Lemos.
 - [ ] Lemos não gera cobrança (nenhuma assinatura/subscription Asaas criada).

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -63,8 +63,11 @@ dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (reverten
    CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
    npx tsx scripts/provision-imobiliaria-lemos.ts
    ```
-   O script grava um arquivo de rollback em `./.migration-runs/` (mapa antes→depois de
-   usuários e imóveis) e revoga as sessões dos usuários provisionados.
+   O script grava um snapshot em `./.migration-runs/` **ANTES da primeira escrita**
+   (`status: "started"` com o estado ANTERIOR completo — plano/empresa/tenant/usuários/
+   imóveis/contatos), atualiza o progresso por lote, e finaliza como `"completed"`
+   (ou `"failed"` com o último lote concluído, em caso de erro). Ao final imprime as
+   **senhas individuais UMA única vez** (nunca no snapshot) e revoga as sessões dos usuários.
 6. **Reinicie a API** e confirme que o gmail permanece `ADMIN` (não volta a `SUPER_ADMIN`):
    `SELECT email, role FROM users WHERE email IN ('tomas@agoraencontrei.com.br','tomascesarlemossilva@gmail.com');`
 7. **Invalidação de sessões antigas** — o script já apaga `sessions` + `refresh_tokens`
@@ -131,7 +134,17 @@ em lotes, e valide antes numa cópia do banco.
 
 ## Rollback
 
-Cada execução real grava `./.migration-runs/lemos-provision-<stamp>.json` com o mapa
-antes→depois (usuários: `wasCompanyId`/`wasRole`; imóveis: `oldCompanyId`/`oldUserId`).
-Para reverter, restaure o backup do banco (opção mais segura) ou use o arquivo para
-reescrever `companyId`/`userId`/`role` aos valores originais.
+Cada execução real grava `./.migration-runs/lemos-provision-<stamp>.json`. O snapshot é
+escrito **antes da primeira escrita** (`status: "started"`) e contém o estado ANTERIOR:
+- `before.planExisted`, `before.company` (existed/id), `before.tenant` (existed/id/before)
+- `before.users[]` — `{ email, existed, id, oldCompanyId, oldRole }`
+- `before.properties[]` — `{ id, oldCompanyId, oldUserId }`
+- `before.contacts[]` — `{ id, oldCompanyId }` (proprietários movidos)
+- `before.sharedOwnersKept[]` — proprietários compartilhados que **não** foram movidos
+- `progress` — `{ propertiesTotal, propertiesDone, lastBatchIndex, contactsMoved, sessionsRevoked }`
+- `status` final: `completed` (sucesso) ou `failed` (com o último lote concluído)
+
+Para reverter, a opção mais segura é **restaurar o backup do Neon**. Alternativamente,
+use o snapshot para reescrever `companyId`/`userId`/`role` aos valores originais.
+> Observação: hoje existe **snapshot pré-escrita** (obrigatório), não um rollback
+> executável automático. Um modo `--rollback <arquivo>` pode ser adicionado se desejado.

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -23,12 +23,25 @@ Este runbook descreve a implantação segura da mudança que:
 | `noemialemos3@gmail.com` | `ADMIN` | Imobiliária Lemos |
 | `lorensesso@gmail.com` + 4 corretores | `BROKER` | Imobiliária Lemos |
 
-Senhas: **individuais e aleatórias** por usuário (sem senha coletiva). O script imprime
-cada senha **uma única vez** ao final da execução real — entregue a cada pessoa por canal
-seguro. Todos têm `mustChangePassword` marcado (trocam no primeiro acesso e completam
+Senhas: **individuais e aleatórias** por usuário (sem senha coletiva). Por **segurança, as
+senhas NÃO são impressas no console** (evita vazamento em stdout/CI/logs). Na execução real,
+elas são gravadas num **arquivo local restrito** (permissões `600`):
+
+```
+.migration-runs/lemos-credentials-<stamp>.txt
+```
+
+O arquivo é criado **apenas na execução real** (nunca no `DRY_RUN`), **não** é versionado
+(`.migration-runs/` está no `.gitignore`) e **nunca** entra no snapshot JSON de rollback.
+Entregue cada credencial ao respectivo usuário por **canal seguro** e **apague o arquivo**
+depois. No console aparecem só: a quantidade de credenciais, o caminho do arquivo e os
+avisos. Todos têm `mustChangePassword` marcado (trocam no primeiro acesso e completam
 foto/telefone/dados). Usuário que já existe **não** tem a senha sobrescrita (a menos de
 `RESET_EXISTING_PASSWORDS=true`). Para forçar uma senha comum (não recomendado), use
 `FORCE_PASSWORD`.
+
+> Modo excepcional (debug): `PRINT_TEMP_PASSWORDS=true` imprime as senhas em claro no
+> console. **NÃO** use em CI nem onde os logs sejam retidos/compartilhados.
 
 ---
 
@@ -66,8 +79,9 @@ dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (reverten
    O script grava um snapshot em `./.migration-runs/` **ANTES da primeira escrita**
    (`status: "started"` com o estado ANTERIOR completo — plano/empresa/tenant/usuários/
    imóveis/contatos), atualiza o progresso por lote, e finaliza como `"completed"`
-   (ou `"failed"` com o último lote concluído, em caso de erro). Ao final imprime as
-   **senhas individuais UMA única vez** (nunca no snapshot) e revoga as sessões dos usuários.
+   (ou `"failed"` com o último lote concluído, em caso de erro). Grava as **senhas
+   individuais em `.migration-runs/lemos-credentials-<stamp>.txt`** (permissões 600, nunca
+   no console/snapshot) e revoga as sessões dos usuários.
 6. **Reinicie a API** e confirme que o gmail permanece `ADMIN` (não volta a `SUPER_ADMIN`):
    `SELECT email, role FROM users WHERE email IN ('tomas@agoraencontrei.com.br','tomascesarlemossilva@gmail.com');`
 7. **Invalidação de sessões antigas** — o script já apaga `sessions` + `refresh_tokens`
@@ -92,6 +106,7 @@ dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (reverten
 | `EXPECTED_PROPERTY_COUNT` | — | se definido, ABORTA se a seleção divergir |
 | `RESET_EXISTING_PASSWORDS` | `false` | redefine senha de usuários já existentes (senha individual) |
 | `FORCE_PASSWORD` | — | força uma senha comum (não recomendado; padrão = aleatória individual) |
+| `PRINT_TEMP_PASSWORDS` | `false` | imprime senhas em claro no console (debug; NÃO usar em CI/logs) |
 | `SUBDOMAIN` | `lemos` | subdomínio do tenant Lemos |
 
 ---
@@ -124,7 +139,7 @@ em lotes, e valide antes numa cópia do banco.
 - [ ] Nenhum contato-proprietário órfão entre empresas.
 
 **Operação**
-- [ ] Os 9 usuários conseguem logar com a senha individual entregue e são forçados a trocá-la.
+- [ ] Os 9 usuários conseguem logar com a senha individual (do arquivo `.migration-runs/lemos-credentials-*.txt`) e são forçados a trocá-la; o arquivo foi entregue por canal seguro e apagado.
 - [ ] Cada corretor (`BROKER`) enxerga só o próprio escopo.
 - [ ] O site continua publicando os imóveis; formulários criam leads na company Lemos.
 - [ ] Lemos não gera cobrança (nenhuma assinatura/subscription Asaas criada).

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -132,6 +132,22 @@ em lotes, e valide antes numa cópia do banco.
 
 ---
 
+## Riscos conhecidos
+
+- **JWT antigo continua válido até expirar.** Revogar `Session`/`RefreshToken` não mata o
+  *access token* já emitido. Após a migração: exija **logout + login**, **reinicie a API** e
+  respeite uma **janela mínima de ~15 min** (TTL do access token) antes de confiar 100% na
+  nova topologia de papéis. Melhoria futura: `tokenVersion`/`sessionVersion`/`roleVersion`
+  no JWT para invalidação imediata.
+- **Contatos-proprietários compartilhados** (donos de imóveis dentro e fora da seleção) **não**
+  são movidos — permanecem na empresa de origem e continuarão sendo referência cross-tenant
+  até uma **segunda migração relacional** que os duplique/segregue por empresa.
+- **Não há rollback automático executável** — existe snapshot pré-escrita (obrigatório). O
+  **backup/branch do Neon é obrigatório** antes da execução real.
+- **Isolamento multi-tenant é manual** por `companyId` em todo o código; os módulos auditados
+  neste PR (webhooks, system-events, afiliados, saas-finance, market, tenants) foram
+  verificados endpoint a endpoint, mas uma auditoria ampla dos ~407 pontos segue como follow-up.
+
 ## Rollback
 
 Cada execução real grava `./.migration-runs/lemos-provision-<stamp>.json`. O snapshot é

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -1,0 +1,131 @@
+# Runbook — Separação Plataforma × Parceiro + Provisionamento Imobiliária Lemos
+
+Este runbook descreve a implantação segura da mudança que:
+
+1. Separa as ferramentas de **plataforma** (AgoraEncontrei) das ferramentas de **parceiro**.
+2. Cria a **Imobiliária Lemos** como parceira fundadora (plano `fundador`, sem cobrança).
+3. Move `tomascesarlemossilva@gmail.com` de super-admin da plataforma para **ADMIN da Lemos**.
+4. Reatribui os imóveis já anunciados para a empresa Lemos.
+
+> ⚠️ O maior risco NÃO é a UI — é a **migração relacional de dados**. Rode sempre o
+> `DRY_RUN` primeiro e, idealmente, teste antes numa **cópia do banco de produção**.
+
+---
+
+## Papéis e contas resultantes
+
+| Conta | Papel | Empresa |
+|---|---|---|
+| `tomas@agoraencontrei.com.br` | `SUPER_ADMIN` (plataforma) | AgoraEncontrei |
+| `imobiliarialemosfranca@gmail.com` | `ADMIN` (dono principal) | Imobiliária Lemos |
+| `tomascesarlemossilva@gmail.com` | `ADMIN` | Imobiliária Lemos |
+| `blognairalemos@gmail.com` | `ADMIN` | Imobiliária Lemos |
+| `noemialemos3@gmail.com` | `ADMIN` | Imobiliária Lemos |
+| `lorensesso@gmail.com` + 4 corretores | `BROKER` | Imobiliária Lemos |
+
+Senha provisória padrão: **`lemos2026`** (flag `mustChangePassword` marcada — cada pessoa
+troca no primeiro acesso e completa foto/telefone/dados).
+
+---
+
+## Ordem de execução (NÃO inverter)
+
+O deploy do **código vem ANTES** da migração. Enquanto a API antiga estiver rodando, o boot
+dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (revertendo a separação).
+
+1. **Backup do banco de produção** (Neon: branch/snapshot). Sem backup, não prossiga.
+2. **Deploy do código** (API + Web) desta branch. Confirme que TODAS as instâncias da API
+   subiram na nova versão (o boot agora só promove `tomas@agoraencontrei.com.br`).
+3. **Bootstrap do plano `fundador`** — acontece automaticamente no boot da API
+   (`bootstrapDefaultPlans`). Confirme que o plano existe:
+   `SELECT slug FROM plan_definitions WHERE slug='fundador';`
+4. **DRY-RUN da migração** (não grava nada). Descubra o `SOURCE_COMPANY_ID` real
+   (empresa que hoje detém os imóveis — ex.: import Univen):
+   ```bash
+   DATABASE_URL="<prod>" \
+   SOURCE_MODE=company \
+   SOURCE_COMPANY_ID="<id-da-empresa-de-origem>" \
+   npx tsx scripts/provision-imobiliaria-lemos.ts
+   ```
+   Analise MINUCIOSAMENTE o relatório: nº de imóveis a mover, amostra, empresas de origem
+   distintas, contatos-proprietários, e o REPORTE de dados relacionados. Se o número divergir
+   do esperado, PARE e revise o filtro (`SOURCE_MODE`/`SOURCE_COMPANY_ID`/`SOURCE_USER_EMAIL`).
+5. **Migração real** (exige confirmação forte):
+   ```bash
+   DATABASE_URL="<prod>" \
+   SOURCE_MODE=company \
+   SOURCE_COMPANY_ID="<id-da-empresa-de-origem>" \
+   DRY_RUN=false \
+   CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
+   npx tsx scripts/provision-imobiliaria-lemos.ts
+   ```
+   O script grava um arquivo de rollback em `./.migration-runs/` (mapa antes→depois de
+   usuários e imóveis) e revoga as sessões dos usuários provisionados.
+6. **Reinicie a API** e confirme que o gmail permanece `ADMIN` (não volta a `SUPER_ADMIN`):
+   `SELECT email, role FROM users WHERE email IN ('tomas@agoraencontrei.com.br','tomascesarlemossilva@gmail.com');`
+7. **Invalidação de sessões antigas** — o script já apaga `sessions` + `refresh_tokens`
+   dos 9 usuários. Ainda assim, avise a equipe para **fazer logout e login novamente**
+   (o JWT antigo do gmail pode conter `role: SUPER_ADMIN` até expirar — access token = 15 min).
+   Se houver cache Redis de sessão, limpe as chaves dos usuários afetados.
+
+---
+
+## Variáveis do script (resumo)
+
+| Var | Default | Descrição |
+|---|---|---|
+| `DATABASE_URL` | — | (obrigatória) conexão Postgres |
+| `DRY_RUN` | `true` | só `false` (exato) executa de verdade |
+| `CONFIRM_PRODUCTION_MIGRATION` | — | exija `IMOBILIARIA_LEMOS` quando `DRY_RUN=false` |
+| `SOURCE_MODE` | — | `company` \| `user` \| `company_and_user` |
+| `SOURCE_COMPANY_ID` / `SOURCE_USER_EMAIL` | — | origem dos imóveis (por modo) |
+| `SKIP_PROPERTIES` | `false` | só provisiona estrutura, não mexe em imóveis |
+| `MAX_MOVE` | `100000` | aborta se a seleção exceder (guarda anti-erro) |
+| `BATCH_SIZE` | `200` | tamanho do lote de update de imóveis |
+| `RESET_EXISTING_PASSWORDS` | `false` | redefine senha de usuários já existentes p/ a padrão |
+| `SUBDOMAIN` | `lemos` | subdomínio do tenant Lemos |
+
+---
+
+## Migração de dados operacionais (passo posterior, revisado)
+
+O script **NÃO** move em massa leads/deals/contratos/locações/transações/contatos só por
+`companyId` (risco de mover dados alheios da empresa de origem — ex.: Univen/Noêmia). Ele
+move apenas: **imóveis** (companyId + userId) e os **contatos-proprietários** ligados a esses
+imóveis (via `PropertyOwner`). O relatório do dry-run mostra as contagens dos demais dados
+relacionados aos imóveis movidos. Se for necessário migrar a carteira operacional completa,
+faça-o como passo separado, por relação com os imóveis migrados (nunca por `companyId` cego),
+em lotes, e valide antes numa cópia do banco.
+
+---
+
+## Checklist de validação pós-migração
+
+**Segurança**
+- [ ] `tomas@agoraencontrei.com.br` é o único `SUPER_ADMIN`.
+- [ ] gmail permanece `ADMIN` após restart da API.
+- [ ] ADMIN Lemos recebe 403 nas APIs de plataforma (`/api/v1/master`, `/api/v1/market`, `/api/v1/saas-finance`, `/api/v1/outbound`).
+- [ ] ADMIN/BROKER Lemos NÃO vê no menu: Afiliados, Admin Master, Tenants, Eventos, Saúde das Integrações, Fila de Repasses, Master Intel, Radar de Mercado, Financeiro SaaS, Site Factory.
+- [ ] Acesso direto por URL a rota de plataforma redireciona o parceiro para `/dashboard`.
+- [ ] Plano `fundador` não aparece em `/parceiros/planos` nem pode ser contratado no checkout.
+
+**Dados**
+- [ ] Contagem de imóveis antes = depois (nenhum perdido).
+- [ ] Imóveis agora sob a company Lemos; nenhum com company Lemos + usuário de outra empresa.
+- [ ] Nenhum contato-proprietário órfão entre empresas.
+
+**Operação**
+- [ ] Os 9 usuários conseguem logar com `lemos2026` e são forçados a trocar a senha.
+- [ ] Cada corretor (`BROKER`) enxerga só o próprio escopo.
+- [ ] O site continua publicando os imóveis; formulários criam leads na company Lemos.
+- [ ] Lemos não gera cobrança (nenhuma assinatura/subscription Asaas criada).
+- [ ] Super-admin continua administrando todos os parceiros.
+
+---
+
+## Rollback
+
+Cada execução real grava `./.migration-runs/lemos-provision-<stamp>.json` com o mapa
+antes→depois (usuários: `wasCompanyId`/`wasRole`; imóveis: `oldCompanyId`/`oldUserId`).
+Para reverter, restaure o backup do banco (opção mais segura) ou use o arquivo para
+reescrever `companyId`/`userId`/`role` aos valores originais.

--- a/scripts/RUNBOOK-imobiliaria-lemos.md
+++ b/scripts/RUNBOOK-imobiliaria-lemos.md
@@ -40,8 +40,8 @@ foto/telefone/dados). Usuário que já existe **não** tem a senha sobrescrita (
 `RESET_EXISTING_PASSWORDS=true`). Para forçar uma senha comum (não recomendado), use
 `FORCE_PASSWORD`.
 
-> Modo excepcional (debug): `PRINT_TEMP_PASSWORDS=true` imprime as senhas em claro no
-> console. **NÃO** use em CI nem onde os logs sejam retidos/compartilhados.
+> As senhas em claro **nunca** são impressas no console — existem apenas no arquivo restrito
+> acima. Não há variável de ambiente que habilite impressão de senha.
 
 ---
 
@@ -106,7 +106,6 @@ dela ainda promoveria `tomascesarlemossilva@gmail.com` a `SUPER_ADMIN` (reverten
 | `EXPECTED_PROPERTY_COUNT` | — | se definido, ABORTA se a seleção divergir |
 | `RESET_EXISTING_PASSWORDS` | `false` | redefine senha de usuários já existentes (senha individual) |
 | `FORCE_PASSWORD` | — | força uma senha comum (não recomendado; padrão = aleatória individual) |
-| `PRINT_TEMP_PASSWORDS` | `false` | imprime senhas em claro no console (debug; NÃO usar em CI/logs) |
 | `SUBDOMAIN` | `lemos` | subdomínio do tenant Lemos |
 
 ---

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -84,11 +84,6 @@ const RESET_EXISTING_PASSWORDS = process.env.RESET_EXISTING_PASSWORDS === 'true'
 // Senha comum só se FORÇADA explicitamente. NÃO há fallback legado de senha coletiva.
 const FORCE_PASSWORD = process.env.FORCE_PASSWORD || ''
 const SUBDOMAIN = (process.env.SUBDOMAIN || 'lemos').toLowerCase().trim()
-// Por PADRÃO as senhas provisórias NÃO são impressas no console (evita vazamento
-// em stdout/CI/logs) — vão para um arquivo local restrito. Só imprime em claro
-// se PRINT_TEMP_PASSWORDS=true (modo excepcional; NÃO usar em CI/onde há retenção
-// de logs).
-const PRINT_TEMP_PASSWORDS = process.env.PRINT_TEMP_PASSWORDS === 'true'
 
 const CANONICAL = 'imobiliaria-lemos'
 const MAIN_ADMIN_EMAIL = 'imobiliarialemosfranca@gmail.com'
@@ -564,20 +559,15 @@ async function main() {
       log('⚠️  Falha ao gravar o arquivo de credenciais:', (e as Error).message)
     }
 
+    // As senhas em claro NUNCA são impressas — existem apenas no arquivo restrito
+    // acima (nenhum caminho de código as envia a log/console).
     log('\n' + '═'.repeat(70))
     log(`🔑 ${creds.length} credencial(is) provisória(s) gerada(s).`)
     if (credWritten) log(`   Arquivo (permissões 600): ${credFile}`)
-    log('   Entregue cada uma ao respectivo usuário por CANAL SEGURO.')
+    else log('   ⚠️  Não foi possível gravar o arquivo de credenciais — verifique o diretório .migration-runs/.')
+    log('   Entregue cada uma ao respectivo usuário por CANAL SEGURO e apague o arquivo depois.')
     log('   Todos têm mustChangePassword = true (trocam a senha no 1º acesso).')
     log('═'.repeat(70))
-
-    if (PRINT_TEMP_PASSWORDS) {
-      log('\n⚠️  PRINT_TEMP_PASSWORDS=true — imprimindo senhas em CLARO no console.')
-      log('   NÃO use este modo em CI nem onde os logs sejam retidos/compartilhados.')
-      log('─'.repeat(70))
-      for (const c of creds) log(`   ${c.email.padEnd(38)} ${c.password}`)
-      log('═'.repeat(70))
-    }
   }
 
   log(`\n✅ Provisionamento concluído. Snapshot (status=completed): ${SNAP_FILE}`)

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -63,7 +63,7 @@
 import { PrismaClient } from '@prisma/client'
 import * as argon2 from 'argon2'
 import { randomBytes } from 'node:crypto'
-import { writeFileSync, mkdirSync, readFileSync } from 'node:fs'
+import { writeFileSync, mkdirSync, readFileSync, chmodSync } from 'node:fs'
 import { join } from 'node:path'
 
 // ── Config / env (parsing estrito e seguro) ───────────────────────────────
@@ -84,6 +84,11 @@ const RESET_EXISTING_PASSWORDS = process.env.RESET_EXISTING_PASSWORDS === 'true'
 // Senha comum só se FORÇADA explicitamente. NÃO há fallback legado de senha coletiva.
 const FORCE_PASSWORD = process.env.FORCE_PASSWORD || ''
 const SUBDOMAIN = (process.env.SUBDOMAIN || 'lemos').toLowerCase().trim()
+// Por PADRÃO as senhas provisórias NÃO são impressas no console (evita vazamento
+// em stdout/CI/logs) — vão para um arquivo local restrito. Só imprime em claro
+// se PRINT_TEMP_PASSWORDS=true (modo excepcional; NÃO usar em CI/onde há retenção
+// de logs).
+const PRINT_TEMP_PASSWORDS = process.env.PRINT_TEMP_PASSWORDS === 'true'
 
 const CANONICAL = 'imobiliaria-lemos'
 const MAIN_ADMIN_EMAIL = 'imobiliarialemosfranca@gmail.com'
@@ -537,13 +542,42 @@ async function main() {
   if (plan.sharedOwners.length) log(`\n⚠️  ${plan.sharedOwners.length} proprietário(s) compartilhado(s) NÃO movidos (também possuem imóveis fora da seleção).`)
 
   if (creds.length > 0) {
+    // Segurança: as senhas provisórias NÃO são logadas em claro por padrão
+    // (CodeQL: clear-text logging). Vão para um arquivo LOCAL restrito (modo
+    // 600) dentro de .migration-runs/ (git-ignorado) — nunca no snapshot JSON.
+    // Correlacionamos o nome com o stamp do snapshot para rastreabilidade.
+    const credFile = SNAP_FILE
+      ? SNAP_FILE.replace(/lemos-provision-(.*)\.json$/, 'lemos-credentials-$1.txt')
+      : join(process.cwd(), '.migration-runs', 'lemos-credentials.txt')
+    const fileBody =
+      '# Credenciais provisórias — Imobiliária Lemos\n' +
+      '# Entregue cada uma ao respectivo usuário por canal seguro e APAGUE este arquivo depois.\n' +
+      '# Todos os usuários têm mustChangePassword = true (trocam a senha no 1º acesso).\n' +
+      '# Este arquivo NÃO é versionado (.migration-runs/ está no .gitignore).\n\n' +
+      creds.map(c => `${c.email}\t${c.password}`).join('\n') + '\n'
+    let credWritten = false
+    try {
+      writeFileSync(credFile, fileBody, { mode: 0o600 })
+      try { chmodSync(credFile, 0o600) } catch { /* fs sem suporte a permissões POSIX */ }
+      credWritten = true
+    } catch (e) {
+      log('⚠️  Falha ao gravar o arquivo de credenciais:', (e as Error).message)
+    }
+
     log('\n' + '═'.repeat(70))
-    log('🔑 SENHAS PROVISÓRIAS INDIVIDUAIS (copie AGORA — não serão exibidas de novo)')
-    log('   Entregue cada uma ao respectivo usuário por canal seguro. Todos terão de')
-    log('   trocar a senha no primeiro acesso (mustChangePassword).')
-    log('─'.repeat(70))
-    for (const c of creds) log(`   ${c.email.padEnd(38)} ${c.password}`)
+    log(`🔑 ${creds.length} credencial(is) provisória(s) gerada(s).`)
+    if (credWritten) log(`   Arquivo (permissões 600): ${credFile}`)
+    log('   Entregue cada uma ao respectivo usuário por CANAL SEGURO.')
+    log('   Todos têm mustChangePassword = true (trocam a senha no 1º acesso).')
     log('═'.repeat(70))
+
+    if (PRINT_TEMP_PASSWORDS) {
+      log('\n⚠️  PRINT_TEMP_PASSWORDS=true — imprimindo senhas em CLARO no console.')
+      log('   NÃO use este modo em CI nem onde os logs sejam retidos/compartilhados.')
+      log('─'.repeat(70))
+      for (const c of creds) log(`   ${c.email.padEnd(38)} ${c.password}`)
+      log('═'.repeat(70))
+    }
   }
 
   log(`\n✅ Provisionamento concluído. Snapshot (status=completed): ${SNAP_FILE}`)

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -12,47 +12,51 @@
  *   6. Reatribuição dos imóveis (companyId + userId) da empresa/usuário de ORIGEM
  *      para a Company Lemos + o proprietário principal — EM LOTES, com guardas.
  *   7. Move os CONTATOS-PROPRIETÁRIOS (via PropertyOwner) dos imóveis movidos,
- *      para não deixar referência cross-tenant de dono.
+ *      exceto os compartilhados com imóveis fora da seleção.
  *   8. Revoga sessões/refresh tokens dos usuários provisionados (força novo login).
- *   9. Grava um arquivo de ROLLBACK (antes→depois) em ./.migration-runs/.
  *
- * O que este script NÃO faz automaticamente (por segurança — ver runbook):
+ * SEGURANÇA DE SENHA:
+ *   Cada usuário NOVO recebe uma senha ALEATÓRIA INDIVIDUAL, impressa UMA única
+ *   vez ao final (nunca no snapshot). NÃO existe senha coletiva. Usuário que já
+ *   existe NÃO tem a senha sobrescrita (salvo RESET_EXISTING_PASSWORDS=true).
+ *   Todos ficam com settings.mustChangePassword = true.
+ *
+ * SNAPSHOT/ROLLBACK:
+ *   Na execução real, o script grava um snapshot ANTES da primeira escrita
+ *   (status "started" com o estado ANTERIOR completo), atualiza o progresso por
+ *   lote e finaliza como "completed" (ou "failed" com o último lote concluído em
+ *   caso de erro). O backup do banco (Neon) continua OBRIGATÓRIO.
+ *
+ * O que este script NÃO faz automaticamente (ver runbook):
  *   • NÃO move em massa dados operacionais só por companyId (leads, deals,
- *     contratos, locações, transações, contatos genéricos). Ele apenas REPORTA
- *     no dry-run quantos registros da origem referenciam os imóveis movidos, para
- *     você decidir uma migração relacional revisada em passo separado.
- *   • NÃO cancela cobranças/assinaturas Asaas existentes (apenas reporta IDs).
- *   • NÃO sobrescreve senha de usuário que já existe (a menos de RESET_EXISTING_PASSWORDS).
+ *     contratos, locações, transações, contatos genéricos) — apenas REPORTA.
+ *   • NÃO cancela cobranças/assinaturas Asaas existentes.
  *
  * ──────────────────────────────────────────────────────────────────
  * COMO RODAR (numa máquina/CI que enxergue o banco de PRODUÇÃO):
  *
  *   # 1) Pré-visualizar (NÃO grava nada). DRY_RUN é o padrão seguro.
- *   DATABASE_URL=... \
- *   SOURCE_MODE=company \
- *   SOURCE_COMPANY_ID=cmnhzieqf0000mx1cqcqgfv4n \
+ *   DATABASE_URL=... SOURCE_MODE=company SOURCE_COMPANY_ID=<id> \
  *   npx tsx scripts/provision-imobiliaria-lemos.ts
  *
  *   # 2) Executar de verdade (exige confirmação forte):
- *   DATABASE_URL=... \
- *   SOURCE_MODE=company \
- *   SOURCE_COMPANY_ID=cmnhzieqf0000mx1cqcqgfv4n \
- *   DRY_RUN=false \
- *   CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
+ *   DATABASE_URL=... SOURCE_MODE=company SOURCE_COMPANY_ID=<id> \
+ *   DRY_RUN=false CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
  *   npx tsx scripts/provision-imobiliaria-lemos.ts
  *
  * VARIÁVEIS DE AMBIENTE:
  *   DATABASE_URL                 (obrigatória) conexão Postgres
  *   DRY_RUN                      default "true" — SÓ "false" (exato) executa
  *   CONFIRM_PRODUCTION_MIGRATION exija = "IMOBILIARIA_LEMOS" quando DRY_RUN=false
- *   SOURCE_MODE                  "company" | "user" | "company_and_user" (obrigatória p/ mover imóveis)
+ *   SOURCE_MODE                  "company" | "user" | "company_and_user"
  *   SOURCE_COMPANY_ID            id da company de origem dos imóveis
  *   SOURCE_USER_EMAIL            e-mail do usuário dono atual dos imóveis
  *   SKIP_PROPERTIES              "true" — só provisiona estrutura, não mexe em imóveis
+ *   EXPECTED_PROPERTY_COUNT      se definido, ABORTA se a seleção divergir
  *   MAX_MOVE                     limite de segurança (default 100000); aborta se exceder
  *   BATCH_SIZE                   lote de update de imóveis (default 200)
- *   RESET_EXISTING_PASSWORDS     "true" — redefine senha de usuários já existentes p/ a padrão
- *   DEFAULT_PASSWORD             senha provisória (default "lemos2026")
+ *   RESET_EXISTING_PASSWORDS     "true" — redefine senha (aleatória individual) de já existentes
+ *   FORCE_PASSWORD               força uma senha comum p/ NOVOS (NÃO recomendado)
  *   SUBDOMAIN                    subdomínio do tenant (default "lemos")
  */
 
@@ -72,23 +76,14 @@ const SOURCE_MODE = (process.env.SOURCE_MODE || '').trim() // company | user | c
 const SOURCE_COMPANY_ID = (process.env.SOURCE_COMPANY_ID || '').trim()
 const SOURCE_USER_EMAIL = (process.env.SOURCE_USER_EMAIL || '').trim().toLowerCase()
 const SKIP_PROPERTIES = process.env.SKIP_PROPERTIES === 'true'
+const EXPECTED_PROPERTY_COUNT = process.env.EXPECTED_PROPERTY_COUNT
+  ? Number(process.env.EXPECTED_PROPERTY_COUNT) : null
 const MAX_MOVE = Number(process.env.MAX_MOVE || 100000)
 const BATCH_SIZE = Math.max(1, Number(process.env.BATCH_SIZE || 200))
 const RESET_EXISTING_PASSWORDS = process.env.RESET_EXISTING_PASSWORDS === 'true'
-// Contagem esperada de imóveis: se definida, o script ABORTA caso a seleção
-// divirja (guarda anti-erro de filtro). Deixe vazio p/ não checar.
-const EXPECTED_PROPERTY_COUNT = process.env.EXPECTED_PROPERTY_COUNT
-  ? Number(process.env.EXPECTED_PROPERTY_COUNT) : null
-// Senha: por padrão, cada usuário NOVO recebe uma senha ALEATÓRIA INDIVIDUAL
-// (impressa uma única vez ao final). NÃO há mais senha coletiva. Um valor
-// explícito em FORCE_PASSWORD só é usado se você quiser forçar uma senha comum.
-const FORCE_PASSWORD = process.env.FORCE_PASSWORD || process.env.DEFAULT_PASSWORD || ''
+// Senha comum só se FORÇADA explicitamente. NÃO há fallback legado de senha coletiva.
+const FORCE_PASSWORD = process.env.FORCE_PASSWORD || ''
 const SUBDOMAIN = (process.env.SUBDOMAIN || 'lemos').toLowerCase().trim()
-
-// Gera uma senha forte, aleatória e individual (impressa uma vez; nunca no snapshot).
-function genPassword(): string {
-  return 'Lm-' + randomBytes(12).toString('base64url')
-}
 
 const CANONICAL = 'imobiliaria-lemos'
 const MAIN_ADMIN_EMAIL = 'imobiliarialemosfranca@gmail.com'
@@ -108,24 +103,41 @@ const BROKERS = [
   { email: 'lucasimobiliarialemos@gmail.com', name: 'Lucas' },
 ]
 
+// Dados CANÔNICOS do plano fundador (fonte de verdade — aplicados via upsert).
+const FUNDADOR_PLAN = {
+  slug: 'fundador',
+  name: 'Fundador',
+  description: 'Plano interno da parceira fundadora — acesso total, sem cobrança.',
+  priceMonthly: 0,
+  priceYearly: 0,
+  maxProperties: -1,
+  maxLeadViews: -1,
+  maxUsers: -1,
+  maxAIRequests: -1,
+  themes: ['all'],
+  modules: ['site_basico', 'crm_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos', 'video_editor'],
+  features: ['Acesso completo e ilimitado', 'Isento de cobrança (parceira fundadora)'],
+  isActive: true,
+  sortOrder: 0,
+  metadata: { internal: true, billingExempt: true, allModules: true, allThemes: true } as any,
+}
+
 // ── Utilitários ────────────────────────────────────────────────────────────
 const log = (...a: any[]) => console.log(...a)
 const norm = (e: string) => e.trim().toLowerCase()
 
 function mergeSettings(existing: unknown, patch: Record<string, unknown>): Record<string, unknown> {
   const base = existing && typeof existing === 'object' && !Array.isArray(existing)
-    ? (existing as Record<string, unknown>)
-    : {}
+    ? (existing as Record<string, unknown>) : {}
   return { ...base, ...patch }
 }
-
-function dbHost(url: string): string {
-  try { return new URL(url).host } catch { return '(não parseável)' }
-}
-
-function abort(msg: string): never {
-  console.error(`\n❌ ABORTADO: ${msg}\n`)
-  process.exit(1)
+function dbHost(url: string): string { try { return new URL(url).host } catch { return '(não parseável)' } }
+function abort(msg: string): never { console.error(`\n❌ ABORTADO: ${msg}\n`); process.exit(1) }
+function genPassword(): string { return 'Lm-' + randomBytes(12).toString('base64url') }
+function firstDuplicates(arr: string[]): string[] {
+  const seen = new Set<string>(); const dup = new Set<string>()
+  for (const v of arr) { if (seen.has(v)) dup.add(v); else seen.add(v) }
+  return [...dup]
 }
 
 // ── Guardas de segurança ────────────────────────────────────────────────────
@@ -153,229 +165,119 @@ function preflight() {
   }
 }
 
-// Constrói o WHERE de seleção de imóveis a mover, com semântica explícita.
+// WHERE de seleção de imóveis, com semântica explícita (AND estrito no modo duplo).
 async function buildPropertyWhere(): Promise<any | null> {
   if (SKIP_PROPERTIES || !SOURCE_MODE) return null
   const sourceUser = SOURCE_USER_EMAIL
-    ? await prisma.user.findUnique({ where: { email: SOURCE_USER_EMAIL }, select: { id: true, companyId: true } })
+    ? await prisma.user.findUnique({ where: { email: SOURCE_USER_EMAIL }, select: { id: true } })
     : null
   if ((SOURCE_MODE === 'user' || SOURCE_MODE === 'company_and_user') && !sourceUser)
     abort(`SOURCE_USER_EMAIL não encontrado: ${SOURCE_USER_EMAIL}`)
-
   if (SOURCE_MODE === 'company') return { companyId: SOURCE_COMPANY_ID }
   if (SOURCE_MODE === 'user') return { userId: sourceUser!.id }
-  // company_and_user → AND estrito (mais seguro)
-  return { AND: [{ companyId: SOURCE_COMPANY_ID }, { userId: sourceUser!.id }] }
+  return { AND: [{ companyId: SOURCE_COMPANY_ID }, { userId: sourceUser!.id }] } // AND estrito
 }
 
-// ── Provisionamento estrutural (idempotente) ────────────────────────────────
-async function ensureFundadorPlan() {
-  const existing = await prisma.planDefinition.findUnique({ where: { slug: 'fundador' } })
-  if (existing) return existing
-  if (DRY_RUN) { log('• [dry] criaria PlanDefinition "fundador"'); return null }
-  return prisma.planDefinition.create({
-    data: {
-      slug: 'fundador', name: 'Fundador',
-      description: 'Plano interno da parceira fundadora — acesso total, sem cobrança.',
-      priceMonthly: 0, priceYearly: 0,
-      maxProperties: -1, maxLeadViews: -1, maxUsers: -1, maxAIRequests: -1,
-      themes: ['all'], modules: ['site_basico', 'crm_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos', 'video_editor'],
-      features: ['Acesso completo e ilimitado', 'Isento de cobrança (parceira fundadora)'],
-      isActive: true, sortOrder: 0,
-      metadata: { internal: true, billingExempt: true, allModules: true, allThemes: true } as any,
-    },
-  })
+// ═══════════════════════════════════════════════════════════════════════════
+// PASS 1 — build plan (SOMENTE LEITURAS; nenhuma escrita).
+// Coleta o estado ANTERIOR completo para o snapshot pré-escrita.
+// ═══════════════════════════════════════════════════════════════════════════
+interface UserPlan { email: string; name: string; role: 'ADMIN' | 'BROKER'; existed: boolean; id: string | null; oldCompanyId: string | null; oldRole: string | null; hadPassword: boolean }
+interface Plan {
+  planExisted: boolean
+  company: { existed: boolean; id: string | null }
+  tenant: { existed: boolean; id: string | null; before: any | null }
+  users: UserPlan[]
+  properties: { id: string; oldCompanyId: string; oldUserId: string; slug: string; reference: string | null; title: string | null }[]
+  movableOwners: { id: string; oldCompanyId: string }[]
+  sharedOwners: string[]
 }
 
-async function ensureCompany() {
-  const found = await prisma.company.findFirst({
-    where: { settings: { path: ['canonical'], equals: CANONICAL } },
+async function buildPlan(): Promise<Plan> {
+  const planExisted = !!(await prisma.planDefinition.findUnique({ where: { slug: 'fundador' }, select: { id: true } }).catch(() => null))
+
+  const companyRow = await prisma.company.findFirst({
+    where: { settings: { path: ['canonical'], equals: CANONICAL } }, select: { id: true },
   }).catch(() => null)
-  if (found) {
-    if (!DRY_RUN) {
-      await prisma.company.update({
-        where: { id: found.id },
-        data: { plan: 'fundador', isActive: true, settings: mergeSettings(found.settings, { canonical: CANONICAL, billingExempt: true }) as any },
-      })
-    }
-    return found
-  }
-  if (DRY_RUN) { log('• [dry] criaria Company "Imobiliária Lemos"'); return null }
-  return prisma.company.create({
-    data: {
-      name: 'Imobiliária Lemos', tradeName: 'Imobiliária Lemos',
-      creci: '279051-F', city: 'Franca', state: 'SP',
-      email: 'contato@imobiliarialemos.com.br', website: 'https://www.imobiliarialemos.com.br',
-      plan: 'fundador', isActive: true,
-      settings: { canonical: CANONICAL, billingExempt: true } as any,
-    },
-  })
-}
+  const company = { existed: !!companyRow, id: companyRow?.id ?? null }
 
-// Cria/atualiza um usuário de forma idempotente por email (normalizado).
-// `creds` acumula {email, password} das senhas geradas, p/ impressão única.
-async function upsertUser(
-  u: { email: string; name: string },
-  role: 'ADMIN' | 'BROKER',
-  companyId: string | null,
-  creds: { email: string; password: string }[],
-) {
-  const email = norm(u.email)
-  const existing = await prisma.user.findUnique({ where: { email } })
-  const settingsPatch: Record<string, unknown> = { mustChangePassword: true }
-  if (role === 'ADMIN') { settingsPatch.accessLevel = 'full' }
-
-  if (existing) {
-    const report = { email, action: 'update', wasCompanyId: existing.companyId, wasRole: existing.role }
-    if (!DRY_RUN && companyId) {
-      const data: any = {
-        companyId, role, status: 'ACTIVE',
-        emailVerifiedAt: existing.emailVerifiedAt ?? new Date(),
-        settings: mergeSettings(existing.settings, settingsPatch) as any,
-      }
-      // Usuário EXISTENTE: NÃO sobrescreve a senha (a menos de RESET_EXISTING_PASSWORDS
-      // ou se ele não tem senha alguma — ex.: só login social).
-      if (RESET_EXISTING_PASSWORDS || !existing.passwordHash) {
-        const pw = FORCE_PASSWORD || genPassword()
-        data.passwordHash = await argon2.hash(pw, { type: argon2.argon2id })
-        creds.push({ email, password: pw })
-      }
-      await prisma.user.update({ where: { id: existing.id }, data })
-    }
-    return { ...report, id: existing.id }
-  }
-
-  // Usuário NOVO: senha ALEATÓRIA INDIVIDUAL (ou FORCE_PASSWORD se explicitado).
-  const pw = FORCE_PASSWORD || genPassword()
-  if (DRY_RUN || !companyId) { log(`• [dry] criaria user ${email} (${role})`); return { email, action: 'create', id: null, wasCompanyId: null, wasRole: null } }
-  const created = await prisma.user.create({
-    data: {
-      companyId, email, name: u.name, role, status: 'ACTIVE',
-      emailVerifiedAt: new Date(),
-      passwordHash: await argon2.hash(pw, { type: argon2.argon2id }),
-      settings: settingsPatch as any,
-    },
-  })
-  creds.push({ email, password: pw })
-  return { email, action: 'create', id: created.id, wasCompanyId: null, wasRole: null }
-}
-
-async function ensureTenant(companyId: string | null, ownerId: string | null) {
-  // Guarda contra colisão de subdomínio com outro tenant.
+  // Guarda de subdomínio (colisão com outro tenant).
   const bySub = await prisma.tenant.findUnique({ where: { subdomain: SUBDOMAIN } }).catch(() => null)
   if (bySub) {
-    const isOurs = (bySub.settings as any)?.canonical === CANONICAL || (companyId && bySub.companyId === companyId)
+    const isOurs = (bySub.settings as any)?.canonical === CANONICAL || (company.id && bySub.companyId === company.id)
     if (!isOurs) abort(`Subdomínio "${SUBDOMAIN}" já pertence a outro tenant (${bySub.id}). Escolha outro SUBDOMAIN.`)
-    if (!DRY_RUN) {
-      await prisma.tenant.update({
-        where: { id: bySub.id },
-        data: {
-          plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
-          companyId: companyId ?? bySub.companyId, ownerId: ownerId ?? bySub.ownerId,
-          settings: mergeSettings(bySub.settings, { canonical: CANONICAL, billingExempt: true }) as any,
-        },
-      })
-    }
-    return bySub
   }
-  if (DRY_RUN || !companyId) { log(`• [dry] criaria Tenant "${SUBDOMAIN}"`); return null }
-  return prisma.tenant.create({
-    data: {
-      name: 'Imobiliária Lemos', subdomain: SUBDOMAIN, companyId, ownerId,
-      plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
-      activatedAt: new Date(),
-      settings: { canonical: CANONICAL, billingExempt: true } as any,
-    },
-  })
-}
+  const tenant = { existed: !!bySub, id: bySub?.id ?? null, before: bySub ? { companyId: bySub.companyId, ownerId: bySub.ownerId, plan: bySub.plan, planStatus: bySub.planStatus } : null }
 
-// ── Migração de imóveis (em lotes, com rollback) ────────────────────────────
-async function migrateProperties(where: any, targetCompanyId: string | null, targetUserId: string | null) {
-  const ids = await prisma.property.findMany({ where, select: { id: true, companyId: true, userId: true, reference: true, slug: true, title: true } })
-  log(`\n📦 Imóveis selecionados para mover: ${ids.length}`)
-  if (ids.length === 0) { log('   (nenhum imóvel corresponde ao filtro — nada a mover)'); return { moved: [], movedOwners: [], sharedOwners: [] } }
-  if (ids.length > MAX_MOVE) abort(`Seleção (${ids.length}) excede MAX_MOVE (${MAX_MOVE}). Confira o filtro antes de prosseguir.`)
-  // Guarda anti-erro: se a contagem esperada foi informada e diverge, aborta.
-  if (EXPECTED_PROPERTY_COUNT != null && ids.length !== EXPECTED_PROPERTY_COUNT) {
-    abort(`Contagem (${ids.length}) diverge de EXPECTED_PROPERTY_COUNT (${EXPECTED_PROPERTY_COUNT}). Revise o filtro.`)
-  }
-
-  // Amostra para conferência
-  log('   Amostra (até 5):')
-  ids.slice(0, 5).forEach(p => log(`     - ${p.id} | ${p.reference ?? '—'} | ${p.title?.slice(0, 50) ?? ''} | company=${p.companyId} user=${p.userId}`))
-  const fromCompanies = [...new Set(ids.map(p => p.companyId))]
-  log(`   Empresas de origem distintas: ${fromCompanies.length} → ${fromCompanies.join(', ')}`)
-
-  // ── Detecção de colisão de slug/reference no destino ─────────────────────
-  // Property tem @@unique([companyId, slug]) e @@unique([companyId, reference]).
-  // (a) duplicados dentro da própria seleção (só ocorre se a origem for multi-empresa)
-  const dupSlugs = firstDuplicates(ids.map(p => p.slug))
-  const dupRefs = firstDuplicates(ids.map(p => p.reference).filter(Boolean) as string[])
-  if (dupSlugs.length) abort(`Colisão de slug dentro da seleção: ${dupSlugs.slice(0, 10).join(', ')}. Origem multi-empresa? Restrinja o filtro.`)
-  if (dupRefs.length) abort(`Colisão de reference dentro da seleção: ${dupRefs.slice(0, 10).join(', ')}.`)
-  // (b) colisão com imóveis já existentes na company de destino
-  if (targetCompanyId) {
-    const clashSlug = await prisma.property.count({ where: { companyId: targetCompanyId, slug: { in: ids.map(p => p.slug) }, id: { notIn: ids.map(p => p.id) } } })
-    const refs = ids.map(p => p.reference).filter(Boolean) as string[]
-    const clashRef = refs.length ? await prisma.property.count({ where: { companyId: targetCompanyId, reference: { in: refs }, id: { notIn: ids.map(p => p.id) } } }) : 0
-    if (clashSlug > 0 || clashRef > 0) abort(`Destino já possui imóveis com slug/reference em conflito (slug=${clashSlug}, ref=${clashRef}).`)
-  }
-
-  // ── Contatos-proprietários (via PropertyOwner) ───────────────────────────
-  const movedSet = new Set(ids.map(p => p.id))
-  const owners = await prisma.propertyOwner.findMany({
-    where: { propertyId: { in: ids.map(p => p.id) } },
-    select: { contactId: true },
-  })
-  const ownerContactIds = [...new Set(owners.map(o => o.contactId))]
-  // Proprietário COMPARTILHADO: possui também imóvel FORA da seleção → NÃO mover
-  // (senão o imóvel não-migrado passaria a referenciar contato de outra empresa).
-  const sharedOwners: string[] = []
-  const movableOwnerIds: string[] = []
-  for (const cid of ownerContactIds) {
-    const otherLinks = await prisma.propertyOwner.findMany({ where: { contactId: cid }, select: { propertyId: true } })
-    const ownsOutside = otherLinks.some(l => !movedSet.has(l.propertyId))
-    if (ownsOutside) sharedOwners.push(cid); else movableOwnerIds.push(cid)
-  }
-  log(`   Contatos-proprietários vinculados: ${ownerContactIds.length} (movíveis: ${movableOwnerIds.length}, compartilhados/mantidos: ${sharedOwners.length})`)
-  if (sharedOwners.length) log(`   ⚠️  ${sharedOwners.length} proprietário(s) também possuem imóveis fora da seleção — NÃO serão movidos (evita ref cross-tenant).`)
-
-  // Snapshot dos contatos movíveis (para rollback) ANTES de alterar.
-  const movableOwners = movableOwnerIds.length
-    ? await prisma.contact.findMany({ where: { id: { in: movableOwnerIds } }, select: { id: true, companyId: true } })
-    : []
-
-  if (DRY_RUN || !targetCompanyId || !targetUserId) {
-    log('   [dry] NÃO gravou (dry-run ou destino ainda não materializado). Rode com DRY_RUN=false para aplicar.')
-    return { moved: ids, movedOwners: movableOwners, sharedOwners }
-  }
-
-  // Aplica em lotes (evita transação gigante/locks longos).
-  let done = 0
-  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-    const batch = ids.slice(i, i + BATCH_SIZE).map(p => p.id)
-    await prisma.property.updateMany({
-      where: { id: { in: batch } },
-      data: { companyId: targetCompanyId, userId: targetUserId },
+  // Usuários: estado anterior (idempotência por email normalizado; aborta duplicado).
+  const users: UserPlan[] = []
+  for (const u of [...ADMINS.map(a => ({ ...a, role: 'ADMIN' as const })), ...BROKERS.map(b => ({ ...b, role: 'BROKER' as const }))]) {
+    const email = norm(u.email)
+    const dupes = await prisma.user.count({ where: { email } })
+    if (dupes > 1) abort(`Mais de um usuário com email ${u.email} — resolva a duplicidade antes.`)
+    const existing = await prisma.user.findUnique({ where: { email }, select: { id: true, companyId: true, role: true, passwordHash: true } })
+    users.push({
+      email, name: u.name, role: u.role, existed: !!existing, id: existing?.id ?? null,
+      oldCompanyId: existing?.companyId ?? null, oldRole: existing?.role ?? null, hadPassword: !!existing?.passwordHash,
     })
-    done += batch.length
-    log(`   ...movidos ${done}/${ids.length}`)
   }
-  // Move os contatos-proprietários (só os NÃO compartilhados) para a company Lemos.
-  if (movableOwnerIds.length > 0) {
-    await prisma.contact.updateMany({ where: { id: { in: movableOwnerIds } }, data: { companyId: targetCompanyId } })
+
+  // Imóveis + colisões + owners (movíveis vs compartilhados).
+  let properties: Plan['properties'] = []
+  let movableOwners: Plan['movableOwners'] = []
+  let sharedOwners: string[] = []
+  const where = await buildPropertyWhere()
+  if (where) {
+    const ids = await prisma.property.findMany({ where, select: { id: true, companyId: true, userId: true, slug: true, reference: true, title: true } })
+    if (ids.length > MAX_MOVE) abort(`Seleção (${ids.length}) excede MAX_MOVE (${MAX_MOVE}). Confira o filtro.`)
+    if (EXPECTED_PROPERTY_COUNT != null && ids.length !== EXPECTED_PROPERTY_COUNT)
+      abort(`Contagem (${ids.length}) diverge de EXPECTED_PROPERTY_COUNT (${EXPECTED_PROPERTY_COUNT}). Revise o filtro.`)
+
+    // Colisão de slug/reference dentro da seleção (só ocorre se origem multi-empresa).
+    const dupSlugs = firstDuplicates(ids.map(p => p.slug))
+    const dupRefs = firstDuplicates(ids.map(p => p.reference).filter(Boolean) as string[])
+    if (dupSlugs.length) abort(`Colisão de slug dentro da seleção: ${dupSlugs.slice(0, 10).join(', ')}. Origem multi-empresa? Restrinja o filtro.`)
+    if (dupRefs.length) abort(`Colisão de reference dentro da seleção: ${dupRefs.slice(0, 10).join(', ')}.`)
+    // Colisão com imóveis já existentes na company de destino (se ela já existe).
+    if (company.id && ids.length) {
+      const selIds = ids.map(p => p.id)
+      const clashSlug = await prisma.property.count({ where: { companyId: company.id, slug: { in: ids.map(p => p.slug) }, id: { notIn: selIds } } })
+      const refs = ids.map(p => p.reference).filter(Boolean) as string[]
+      const clashRef = refs.length ? await prisma.property.count({ where: { companyId: company.id, reference: { in: refs }, id: { notIn: selIds } } }) : 0
+      if (clashSlug > 0 || clashRef > 0) abort(`Destino já possui imóveis com slug/reference em conflito (slug=${clashSlug}, ref=${clashRef}).`)
+    }
+    properties = ids.map(p => ({ id: p.id, oldCompanyId: p.companyId, oldUserId: p.userId, slug: p.slug, reference: p.reference, title: p.title }))
+
+    // Owners via PropertyOwner: compartilhados (donos de imóveis fora da seleção) NÃO movem.
+    const movedSet = new Set(ids.map(p => p.id))
+    const owners = await prisma.propertyOwner.findMany({ where: { propertyId: { in: ids.map(p => p.id) } }, select: { contactId: true } })
+    const ownerContactIds = [...new Set(owners.map(o => o.contactId))]
+    const movableIds: string[] = []
+    for (const cid of ownerContactIds) {
+      const links = await prisma.propertyOwner.findMany({ where: { contactId: cid }, select: { propertyId: true } })
+      if (links.some(l => !movedSet.has(l.propertyId))) sharedOwners.push(cid); else movableIds.push(cid)
+    }
+    movableOwners = movableIds.length
+      ? (await prisma.contact.findMany({ where: { id: { in: movableIds } }, select: { id: true, companyId: true } })).map(c => ({ id: c.id, oldCompanyId: c.companyId }))
+      : []
   }
-  return { moved: ids, movedOwners: movableOwners, sharedOwners }
+
+  return { planExisted, company, tenant, users, properties, movableOwners, sharedOwners }
 }
 
-// Retorna os valores que aparecem mais de uma vez em `arr`.
-function firstDuplicates(arr: string[]): string[] {
-  const seen = new Set<string>(); const dup = new Set<string>()
-  for (const v of arr) { if (seen.has(v)) dup.add(v); else seen.add(v) }
-  return [...dup]
+// ── Report (dry-run) ────────────────────────────────────────────────────────
+function reportPlan(plan: Plan) {
+  log('\n📋 PLANO (dry-run — nada será gravado):')
+  log(`   • Plano fundador: ${plan.planExisted ? 'existe (será atualizado)' : 'será criado'}`)
+  log(`   • Company Lemos: ${plan.company.existed ? `existe (${plan.company.id})` : 'será criada'}`)
+  log(`   • Tenant "${SUBDOMAIN}": ${plan.tenant.existed ? `existe (${plan.tenant.id})` : 'será criado'}`)
+  log(`   • Usuários: ${plan.users.length} (${plan.users.filter(u => u.existed).length} já existem → serão movidos/atualizados; ${plan.users.filter(u => !u.existed).length} novos)`)
+  for (const u of plan.users) log(`       - ${u.email.padEnd(38)} ${u.role} ${u.existed ? `(existe: company=${u.oldCompanyId} role=${u.oldRole})` : '(novo)'}`)
+  log(`   • Imóveis a mover: ${plan.properties.length}`)
+  plan.properties.slice(0, 5).forEach(p => log(`       - ${p.id} | ${p.reference ?? '—'} | ${p.title?.slice(0, 40) ?? ''} | company=${p.oldCompanyId}`))
+  log(`   • Contatos-proprietários: movíveis ${plan.movableOwners.length}, compartilhados/mantidos ${plan.sharedOwners.length}`)
 }
 
-// Reporta (sem mover) dados operacionais que referenciam os imóveis movidos.
 async function reportRelatedData(propertyIds: string[], sourceCompanyId: string | null) {
   if (propertyIds.length === 0) return
   log('\n🔎 Dados relacionados (REPORTE — não são movidos automaticamente):')
@@ -393,106 +295,226 @@ async function reportRelatedData(propertyIds: string[], sourceCompanyId: string 
   log('   → Migração relacional destes dados deve ser um passo revisado à parte (ver runbook).')
 }
 
-// ── Revogação de sessões (força novo login após mudança de role/empresa) ────
-async function revokeSessions(userIds: string[]) {
-  if (userIds.length === 0 || DRY_RUN) { if (DRY_RUN) log('\n• [dry] revogaria sessões/refresh tokens dos usuários provisionados'); return }
-  const s = await prisma.session.deleteMany({ where: { userId: { in: userIds } } }).catch(() => ({ count: 0 }))
-  const r = await prisma.refreshToken.deleteMany({ where: { userId: { in: userIds } } }).catch(() => ({ count: 0 }))
-  log(`\n🔒 Sessões revogadas: ${s.count} | refresh tokens: ${r.count}`)
+// ── Snapshot (pré-escrita, progresso, conclusão) ────────────────────────────
+type SnapStatus = 'started' | 'completed' | 'failed'
+interface Snapshot {
+  status: SnapStatus
+  error?: string
+  sourceMode: string; sourceCompanyId: string | null; sourceUserEmail: string | null
+  before: {
+    planExisted: boolean
+    company: { existed: boolean; id: string | null }
+    tenant: { existed: boolean; id: string | null; before: any | null }
+    users: { email: string; existed: boolean; id: string | null; oldCompanyId: string | null; oldRole: string | null }[]
+    properties: { id: string; oldCompanyId: string; oldUserId: string }[]
+    contacts: { id: string; oldCompanyId: string }[]
+    sharedOwnersKept: string[]
+  }
+  progress: { propertiesTotal: number; propertiesDone: number; lastBatchIndex: number; contactsMoved: number; sessionsRevoked: number }
+  targetCompanyId?: string | null
+}
+let SNAP_FILE = ''
+function initSnapshot(plan: Plan): Snapshot {
+  return {
+    status: 'started',
+    sourceMode: SOURCE_MODE, sourceCompanyId: SOURCE_COMPANY_ID || null, sourceUserEmail: SOURCE_USER_EMAIL || null,
+    before: {
+      planExisted: plan.planExisted,
+      company: plan.company,
+      tenant: plan.tenant,
+      users: plan.users.map(u => ({ email: u.email, existed: u.existed, id: u.id, oldCompanyId: u.oldCompanyId, oldRole: u.oldRole })),
+      properties: plan.properties.map(p => ({ id: p.id, oldCompanyId: p.oldCompanyId, oldUserId: p.oldUserId })),
+      contacts: plan.movableOwners.map(c => ({ id: c.id, oldCompanyId: c.oldCompanyId })),
+      sharedOwnersKept: plan.sharedOwners,
+    },
+    progress: { propertiesTotal: plan.properties.length, propertiesDone: 0, lastBatchIndex: -1, contactsMoved: 0, sessionsRevoked: 0 },
+  }
+}
+function writeSnapshot(snap: Snapshot) {
+  try {
+    if (!SNAP_FILE) {
+      const dir = join(process.cwd(), '.migration-runs')
+      mkdirSync(dir, { recursive: true })
+      const stamp = process.env.RUN_STAMP || String(process.hrtime.bigint())
+      SNAP_FILE = join(dir, `lemos-provision-${stamp}.json`)
+    }
+    writeFileSync(SNAP_FILE, JSON.stringify(snap, null, 2))
+  } catch (e) {
+    log('⚠️  Falha ao gravar snapshot:', (e as Error).message)
+  }
+}
+
+// ── Execução real (writes) — snapshot já gravado como "started" ──────────────
+async function ensureFundadorPlanUpsert() {
+  // Upsert idempotente com os dados CANÔNICOS (garante metadata/módulos/temas/
+  // limites/preços/isActive corretos mesmo que o plano já exista).
+  await prisma.planDefinition.upsert({
+    where: { slug: FUNDADOR_PLAN.slug },
+    update: {
+      name: FUNDADOR_PLAN.name, description: FUNDADOR_PLAN.description,
+      priceMonthly: FUNDADOR_PLAN.priceMonthly, priceYearly: FUNDADOR_PLAN.priceYearly,
+      maxProperties: FUNDADOR_PLAN.maxProperties, maxLeadViews: FUNDADOR_PLAN.maxLeadViews,
+      maxUsers: FUNDADOR_PLAN.maxUsers, maxAIRequests: FUNDADOR_PLAN.maxAIRequests,
+      themes: FUNDADOR_PLAN.themes, modules: FUNDADOR_PLAN.modules, features: FUNDADOR_PLAN.features,
+      isActive: FUNDADOR_PLAN.isActive, sortOrder: FUNDADOR_PLAN.sortOrder, metadata: FUNDADOR_PLAN.metadata,
+    },
+    create: { ...FUNDADOR_PLAN },
+  })
+}
+
+async function ensureCompany(plan: Plan): Promise<string> {
+  if (plan.company.existed && plan.company.id) {
+    const cur = await prisma.company.findUnique({ where: { id: plan.company.id }, select: { settings: true } })
+    await prisma.company.update({
+      where: { id: plan.company.id },
+      data: { plan: 'fundador', isActive: true, settings: mergeSettings(cur?.settings, { canonical: CANONICAL, billingExempt: true }) as any },
+    })
+    return plan.company.id
+  }
+  const created = await prisma.company.create({
+    data: {
+      name: 'Imobiliária Lemos', tradeName: 'Imobiliária Lemos', creci: '279051-F',
+      city: 'Franca', state: 'SP', email: 'contato@imobiliarialemos.com.br',
+      website: 'https://www.imobiliarialemos.com.br', plan: 'fundador', isActive: true,
+      settings: { canonical: CANONICAL, billingExempt: true } as any,
+    },
+  })
+  return created.id
+}
+
+async function upsertUser(u: UserPlan, companyId: string, creds: { email: string; password: string }[]): Promise<string> {
+  const settingsPatch: Record<string, unknown> = { mustChangePassword: true }
+  if (u.role === 'ADMIN') settingsPatch.accessLevel = 'full'
+  if (u.existed && u.id) {
+    const cur = await prisma.user.findUnique({ where: { id: u.id }, select: { settings: true, emailVerifiedAt: true, passwordHash: true } })
+    const data: any = {
+      companyId, role: u.role, status: 'ACTIVE',
+      emailVerifiedAt: cur?.emailVerifiedAt ?? new Date(),
+      settings: mergeSettings(cur?.settings, settingsPatch) as any,
+    }
+    // NÃO sobrescreve senha de existente (salvo RESET_EXISTING_PASSWORDS ou sem senha).
+    if (RESET_EXISTING_PASSWORDS || !cur?.passwordHash) {
+      const pw = FORCE_PASSWORD || genPassword()
+      data.passwordHash = await argon2.hash(pw, { type: argon2.argon2id })
+      creds.push({ email: u.email, password: pw })
+    }
+    await prisma.user.update({ where: { id: u.id }, data })
+    return u.id
+  }
+  const pw = FORCE_PASSWORD || genPassword()
+  const created = await prisma.user.create({
+    data: {
+      companyId, email: u.email, name: u.name, role: u.role, status: 'ACTIVE',
+      emailVerifiedAt: new Date(), passwordHash: await argon2.hash(pw, { type: argon2.argon2id }),
+      settings: settingsPatch as any,
+    },
+  })
+  creds.push({ email: u.email, password: pw })
+  return created.id
+}
+
+async function ensureTenant(plan: Plan, companyId: string, ownerId: string) {
+  if (plan.tenant.existed && plan.tenant.id) {
+    const cur = await prisma.tenant.findUnique({ where: { id: plan.tenant.id }, select: { settings: true } })
+    await prisma.tenant.update({
+      where: { id: plan.tenant.id },
+      data: {
+        plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
+        companyId, ownerId, settings: mergeSettings(cur?.settings, { canonical: CANONICAL, billingExempt: true }) as any,
+      },
+    })
+    return
+  }
+  await prisma.tenant.create({
+    data: {
+      name: 'Imobiliária Lemos', subdomain: SUBDOMAIN, companyId, ownerId,
+      plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
+      activatedAt: new Date(), settings: { canonical: CANONICAL, billingExempt: true } as any,
+    },
+  })
+}
+
+async function executePlan(plan: Plan, snap: Snapshot, creds: { email: string; password: string }[]) {
+  // 1) Plano (upsert canônico)
+  await ensureFundadorPlanUpsert()
+  // 2) Company
+  const companyId = await ensureCompany(plan)
+  snap.targetCompanyId = companyId; writeSnapshot(snap)
+  // 3) Proprietário principal PRIMEIRO (resolve dependência circular do tenant)
+  const mainPlan = plan.users.find(u => u.email === MAIN_ADMIN_EMAIL)!
+  const mainUserId = await upsertUser(mainPlan, companyId, creds)
+  // 4) Tenant (ownerId = proprietário principal)
+  await ensureTenant(plan, companyId, mainUserId)
+  // 5) Demais usuários
+  for (const u of plan.users) { if (u.email !== MAIN_ADMIN_EMAIL) await upsertUser(u, companyId, creds) }
+  log(`👥 Usuários provisionados: ${plan.users.length}`)
+
+  // 6) Imóveis em lotes, atualizando progresso no snapshot
+  const propIds = plan.properties.map(p => p.id)
+  for (let i = 0; i < propIds.length; i += BATCH_SIZE) {
+    const batch = propIds.slice(i, i + BATCH_SIZE)
+    await prisma.property.updateMany({ where: { id: { in: batch } }, data: { companyId, userId: mainUserId } })
+    snap.progress.propertiesDone += batch.length
+    snap.progress.lastBatchIndex = Math.floor(i / BATCH_SIZE)
+    writeSnapshot(snap)
+    log(`   ...imóveis movidos ${snap.progress.propertiesDone}/${propIds.length}`)
+  }
+  // 7) Contatos-proprietários movíveis (não compartilhados)
+  const movableIds = plan.movableOwners.map(c => c.id)
+  if (movableIds.length) {
+    await prisma.contact.updateMany({ where: { id: { in: movableIds } }, data: { companyId } })
+    snap.progress.contactsMoved = movableIds.length; writeSnapshot(snap)
+  }
+  // 8) Revogar sessões dos usuários provisionados (inclui o gmail que perde SUPER_ADMIN)
+  const provisionedIds = plan.users.map(u => u.id).filter(Boolean) as string[]
+  // (ids de usuários novos foram materializados acima; recoleta por email para garantir)
+  const allIds = (await prisma.user.findMany({ where: { email: { in: plan.users.map(u => u.email) } }, select: { id: true } })).map(x => x.id)
+  const ids = [...new Set([...provisionedIds, ...allIds])]
+  const s = await prisma.session.deleteMany({ where: { userId: { in: ids } } }).catch(() => ({ count: 0 }))
+  const r = await prisma.refreshToken.deleteMany({ where: { userId: { in: ids } } }).catch(() => ({ count: 0 }))
+  snap.progress.sessionsRevoked = s.count; writeSnapshot(snap)
+  log(`🔒 Sessões revogadas: ${s.count} | refresh tokens: ${r.count}`)
 }
 
 // ── Main ────────────────────────────────────────────────────────────────────
 async function main() {
   preflight()
 
-  // Confirma que o super-admin da plataforma existe (aviso, não bloqueia).
-  const superAdmin = await prisma.user.findUnique({ where: { email: PLATFORM_SUPERADMIN_EMAIL }, select: { id: true, role: true } })
+  const superAdmin = await prisma.user.findUnique({ where: { email: PLATFORM_SUPERADMIN_EMAIL }, select: { role: true } })
   if (!superAdmin) log(`⚠️  Aviso: super-admin da plataforma (${PLATFORM_SUPERADMIN_EMAIL}) não encontrado.`)
-  else if (superAdmin.role !== 'SUPER_ADMIN') log(`⚠️  Aviso: ${PLATFORM_SUPERADMIN_EMAIL} existe mas não é SUPER_ADMIN (será corrigido no boot da API).`)
+  else if (superAdmin.role !== 'SUPER_ADMIN') log(`⚠️  Aviso: ${PLATFORM_SUPERADMIN_EMAIL} existe mas não é SUPER_ADMIN (corrigido no boot da API).`)
 
-  // Detecta conflito: emails duplicados (idempotência por email).
-  for (const u of [...ADMINS, ...BROKERS]) {
-    const dupes = await prisma.user.count({ where: { email: norm(u.email) } })
-    if (dupes > 1) abort(`Mais de um usuário com email ${u.email} — resolva a duplicidade antes.`)
-  }
+  // PASS 1 — plano (somente leituras)
+  const plan = await buildPlan()
 
-  // 1) Plano fundador
-  const plan = await ensureFundadorPlan()
-  if (!DRY_RUN && !plan) abort('Falha ao garantir plano fundador.')
-
-  // 2) Company
-  const company = await ensureCompany()
-  const companyId = company?.id ?? null
-  if (!DRY_RUN && !companyId) abort('Falha ao garantir Company Lemos.')
-
-  // creds acumula as senhas geradas (individuais) — impressas UMA vez ao final.
-  const creds: { email: string; password: string }[] = []
-
-  // 3) Proprietário principal PRIMEIRO (resolve dependência circular do tenant)
-  const mainAdmin = ADMINS.find(a => norm(a.email) === MAIN_ADMIN_EMAIL)!
-  const mainRep = await upsertUser(mainAdmin, 'ADMIN', companyId, creds)
-  const mainUserId = mainRep.id
-
-  // 4) Tenant (ownerId = proprietário principal)
-  await ensureTenant(companyId, mainUserId)
-
-  // 5) Demais usuários
-  const userReports: any[] = [mainRep]
-  for (const a of ADMINS) {
-    if (norm(a.email) === MAIN_ADMIN_EMAIL) continue
-    userReports.push(await upsertUser(a, 'ADMIN', companyId, creds))
-  }
-  for (const b of BROKERS) userReports.push(await upsertUser(b, 'BROKER', companyId, creds))
-  log(`\n👥 Usuários provisionados: ${userReports.length} (${ADMINS.length} admins + ${BROKERS.length} corretores)`)
-
-  // 6/7) Imóveis + proprietários vinculados
-  let propReport: { moved: any[]; movedOwners: { id: string; companyId: string }[]; sharedOwners: string[] } = { moved: [], movedOwners: [], sharedOwners: [] }
-  const where = await buildPropertyWhere()
-  if (where) {
-    // Seleciona e reporta sempre (mesmo em dry-run, quando a company ainda não existe);
-    // só grava quando !DRY_RUN e os destinos estão materializados.
-    propReport = await migrateProperties(where, companyId, mainUserId)
-    await reportRelatedData(propReport.moved.map((p: any) => p.id), SOURCE_COMPANY_ID || null)
-  } else if (!SKIP_PROPERTIES && !SOURCE_MODE) {
-    log('\nℹ️  SOURCE_MODE não definido — imóveis NÃO foram tocados. Defina SOURCE_MODE para reatribuir.')
-  }
-
-  // 8) Revogar sessões dos usuários provisionados (inclui o gmail que perde SUPER_ADMIN)
-  const provisionedIds = userReports.map(r => r.id).filter(Boolean) as string[]
-  await revokeSessions(provisionedIds)
-
-  // 9) Rollback file (antes→depois) — NÃO contém senhas.
-  const rollback = {
-    dryRun: DRY_RUN,
-    sourceMode: SOURCE_MODE, sourceCompanyId: SOURCE_COMPANY_ID || null, sourceUserEmail: SOURCE_USER_EMAIL || null,
-    targetCompanyId: companyId,
-    // usuários movidos/criados: email, ação, empresa e papel ANTERIORES
-    users: userReports,
-    // imóveis: id + empresa/usuário ANTERIORES
-    properties: propReport.moved.map((p: any) => ({ id: p.id, oldCompanyId: p.companyId, oldUserId: p.userId })),
-    // contatos-proprietários alterados: id + empresa ANTERIOR
-    contactsMoved: propReport.movedOwners.map(c => ({ id: c.id, oldCompanyId: c.companyId })),
-    sharedOwnersKept: propReport.sharedOwners,
-  }
-  // DRY_RUN não grava NADA — nem o snapshot. Só a execução real gera o arquivo.
+  // DRY-RUN: reporta e SAI. Não grava NADA (nem snapshot).
   if (DRY_RUN) {
-    log('\n• [dry] snapshot/rollback NÃO gravado (dry-run não escreve nada em disco).')
-  } else {
-    try {
-      const dir = join(process.cwd(), '.migration-runs')
-      mkdirSync(dir, { recursive: true })
-      // timestamp injetado por env p/ evitar Date.now() não-determinístico em alguns runners
-      const stamp = process.env.RUN_STAMP || String(process.hrtime.bigint())
-      const file = join(dir, `lemos-provision-${stamp}.json`)
-      writeFileSync(file, JSON.stringify(rollback, null, 2))
-      log(`\n🗂️  Rollback/snapshot salvo em: ${file}`)
-    } catch (e) {
-      log('⚠️  Não foi possível gravar o arquivo de rollback:', (e as Error).message)
-    }
+    reportPlan(plan)
+    await reportRelatedData(plan.properties.map(p => p.id), SOURCE_COMPANY_ID || null)
+    log('\n🔍 DRY-RUN concluído (nada foi gravado — nem snapshot).')
+    log('   Revise os números e rode com DRY_RUN=false CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS.')
+    return
   }
 
-  // Credenciais individuais — impressas UMA ÚNICA VEZ aqui (nunca no snapshot).
-  if (!DRY_RUN && creds.length > 0) {
+  // PASS 2 — execução real. Snapshot "started" ANTES da primeira escrita.
+  const snap = initSnapshot(plan)
+  writeSnapshot(snap)
+  log(`\n🗂️  Snapshot pré-escrita gravado (status=started): ${SNAP_FILE}`)
+  const creds: { email: string; password: string }[] = []
+  try {
+    await executePlan(plan, snap, creds)
+    snap.status = 'completed'; writeSnapshot(snap)
+  } catch (e) {
+    snap.status = 'failed'; snap.error = (e as Error).message; writeSnapshot(snap)
+    log(`\n❌ Falha na execução — snapshot marcado como "failed" (último lote: ${snap.progress.lastBatchIndex}, imóveis movidos: ${snap.progress.propertiesDone}/${snap.progress.propertiesTotal}).`)
+    throw e
+  }
+
+  await reportRelatedData(plan.properties.map(p => p.id), SOURCE_COMPANY_ID || null)
+
+  if (plan.sharedOwners.length) log(`\n⚠️  ${plan.sharedOwners.length} proprietário(s) compartilhado(s) NÃO movidos (também possuem imóveis fora da seleção).`)
+
+  if (creds.length > 0) {
     log('\n' + '═'.repeat(70))
     log('🔑 SENHAS PROVISÓRIAS INDIVIDUAIS (copie AGORA — não serão exibidas de novo)')
     log('   Entregue cada uma ao respectivo usuário por canal seguro. Todos terão de')
@@ -502,8 +524,7 @@ async function main() {
     log('═'.repeat(70))
   }
 
-  log(`\n${DRY_RUN ? '🔍 DRY-RUN concluído (nada foi gravado).' : '✅ Provisionamento concluído.'}`)
-  if (DRY_RUN) log('   Revise os números acima e rode com DRY_RUN=false CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS para aplicar.')
+  log(`\n✅ Provisionamento concluído. Snapshot (status=completed): ${SNAP_FILE}`)
 }
 
 main()

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -63,7 +63,7 @@
 import { PrismaClient } from '@prisma/client'
 import * as argon2 from 'argon2'
 import { randomBytes } from 'node:crypto'
-import { writeFileSync, mkdirSync } from 'node:fs'
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 // ── Config / env (parsing estrito e seguro) ───────────────────────────────
@@ -330,7 +330,10 @@ function initSnapshot(plan: Plan): Snapshot {
     progress: { propertiesTotal: plan.properties.length, propertiesDone: 0, lastBatchIndex: -1, contactsMoved: 0, sessionsRevoked: 0 },
   }
 }
-function writeSnapshot(snap: Snapshot) {
+// `required=true` → falha ao gravar ABORTA (impede modificar o banco sem um
+// snapshot válido de rastreabilidade). `required=false` só loga (best-effort,
+// usado apenas na gravação de status "failed" dentro do catch).
+function writeSnapshot(snap: Snapshot, required = false) {
   try {
     if (!SNAP_FILE) {
       const dir = join(process.cwd(), '.migration-runs')
@@ -340,7 +343,23 @@ function writeSnapshot(snap: Snapshot) {
     }
     writeFileSync(SNAP_FILE, JSON.stringify(snap, null, 2))
   } catch (e) {
+    if (required) throw new Error(`Não foi possível gravar o snapshot obrigatório: ${(e as Error).message}`)
     log('⚠️  Falha ao gravar snapshot:', (e as Error).message)
+  }
+}
+
+// Confirma que o snapshot inicial existe e tem conteúdo JSON válido antes de
+// permitir QUALQUER escrita no banco. Aborta se não conseguir reler/parsear.
+function assertSnapshotPersisted() {
+  if (!SNAP_FILE) abort('Snapshot obrigatório não foi materializado (SNAP_FILE vazio).')
+  try {
+    const raw = readFileSync(SNAP_FILE, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (!parsed || parsed.status !== 'started' || !parsed.before) {
+      abort(`Snapshot inicial inválido em ${SNAP_FILE} (conteúdo inesperado).`)
+    }
+  } catch (e) {
+    abort(`Não foi possível reler/validar o snapshot obrigatório (${SNAP_FILE}): ${(e as Error).message}`)
   }
 }
 
@@ -439,7 +458,7 @@ async function executePlan(plan: Plan, snap: Snapshot, creds: { email: string; p
   await ensureFundadorPlanUpsert()
   // 2) Company
   const companyId = await ensureCompany(plan)
-  snap.targetCompanyId = companyId; writeSnapshot(snap)
+  snap.targetCompanyId = companyId; writeSnapshot(snap, true)
   // 3) Proprietário principal PRIMEIRO (resolve dependência circular do tenant)
   const mainPlan = plan.users.find(u => u.email === MAIN_ADMIN_EMAIL)!
   const mainUserId = await upsertUser(mainPlan, companyId, creds)
@@ -456,14 +475,14 @@ async function executePlan(plan: Plan, snap: Snapshot, creds: { email: string; p
     await prisma.property.updateMany({ where: { id: { in: batch } }, data: { companyId, userId: mainUserId } })
     snap.progress.propertiesDone += batch.length
     snap.progress.lastBatchIndex = Math.floor(i / BATCH_SIZE)
-    writeSnapshot(snap)
+    writeSnapshot(snap, true)
     log(`   ...imóveis movidos ${snap.progress.propertiesDone}/${propIds.length}`)
   }
   // 7) Contatos-proprietários movíveis (não compartilhados)
   const movableIds = plan.movableOwners.map(c => c.id)
   if (movableIds.length) {
     await prisma.contact.updateMany({ where: { id: { in: movableIds } }, data: { companyId } })
-    snap.progress.contactsMoved = movableIds.length; writeSnapshot(snap)
+    snap.progress.contactsMoved = movableIds.length; writeSnapshot(snap, true)
   }
   // 8) Revogar sessões dos usuários provisionados (inclui o gmail que perde SUPER_ADMIN)
   const provisionedIds = plan.users.map(u => u.id).filter(Boolean) as string[]
@@ -472,7 +491,7 @@ async function executePlan(plan: Plan, snap: Snapshot, creds: { email: string; p
   const ids = [...new Set([...provisionedIds, ...allIds])]
   const s = await prisma.session.deleteMany({ where: { userId: { in: ids } } }).catch(() => ({ count: 0 }))
   const r = await prisma.refreshToken.deleteMany({ where: { userId: { in: ids } } }).catch(() => ({ count: 0 }))
-  snap.progress.sessionsRevoked = s.count; writeSnapshot(snap)
+  snap.progress.sessionsRevoked = s.count; writeSnapshot(snap, true)
   log(`🔒 Sessões revogadas: ${s.count} | refresh tokens: ${r.count}`)
 }
 
@@ -497,14 +516,17 @@ async function main() {
   }
 
   // PASS 2 — execução real. Snapshot "started" ANTES da primeira escrita.
+  // OBRIGATÓRIO: se não conseguir gravar/validar o snapshot, aborta SEM tocar o banco.
   const snap = initSnapshot(plan)
-  writeSnapshot(snap)
-  log(`\n🗂️  Snapshot pré-escrita gravado (status=started): ${SNAP_FILE}`)
+  writeSnapshot(snap, true)
+  assertSnapshotPersisted()
+  log(`\n🗂️  Snapshot pré-escrita gravado e validado (status=started): ${SNAP_FILE}`)
   const creds: { email: string; password: string }[] = []
   try {
     await executePlan(plan, snap, creds)
-    snap.status = 'completed'; writeSnapshot(snap)
+    snap.status = 'completed'; writeSnapshot(snap, true)
   } catch (e) {
+    // best-effort: não mascara o erro original se a gravação de "failed" falhar.
     snap.status = 'failed'; snap.error = (e as Error).message; writeSnapshot(snap)
     log(`\n❌ Falha na execução — snapshot marcado como "failed" (último lote: ${snap.progress.lastBatchIndex}, imóveis movidos: ${snap.progress.propertiesDone}/${snap.progress.propertiesTotal}).`)
     throw e

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -1,0 +1,425 @@
+/**
+ * Provisionamento oficial da parceira fundadora — IMOBILIÁRIA LEMOS
+ * ==================================================================
+ *
+ * Cria/consolida, de forma IDEMPOTENTE e com DRY-RUN por padrão:
+ *
+ *   1. Plano interno "fundador" (R$0, ilimitado, todos os módulos, sem cobrança).
+ *   2. Company  "Imobiliária Lemos"  (marcador estável settings.canonical).
+ *   3. Usuário proprietário principal (imobiliarialemosfranca@gmail.com).
+ *   4. Tenant   (site do parceiro, plano fundador, ACTIVE, isento de cobrança).
+ *   5. Os 9 usuários da equipe (4 admins ADMIN + 5 corretores BROKER).
+ *   6. Reatribuição dos imóveis (companyId + userId) da empresa/usuário de ORIGEM
+ *      para a Company Lemos + o proprietário principal — EM LOTES, com guardas.
+ *   7. Move os CONTATOS-PROPRIETÁRIOS (via PropertyOwner) dos imóveis movidos,
+ *      para não deixar referência cross-tenant de dono.
+ *   8. Revoga sessões/refresh tokens dos usuários provisionados (força novo login).
+ *   9. Grava um arquivo de ROLLBACK (antes→depois) em ./.migration-runs/.
+ *
+ * O que este script NÃO faz automaticamente (por segurança — ver runbook):
+ *   • NÃO move em massa dados operacionais só por companyId (leads, deals,
+ *     contratos, locações, transações, contatos genéricos). Ele apenas REPORTA
+ *     no dry-run quantos registros da origem referenciam os imóveis movidos, para
+ *     você decidir uma migração relacional revisada em passo separado.
+ *   • NÃO cancela cobranças/assinaturas Asaas existentes (apenas reporta IDs).
+ *   • NÃO sobrescreve senha de usuário que já existe (a menos de RESET_EXISTING_PASSWORDS).
+ *
+ * ──────────────────────────────────────────────────────────────────
+ * COMO RODAR (numa máquina/CI que enxergue o banco de PRODUÇÃO):
+ *
+ *   # 1) Pré-visualizar (NÃO grava nada). DRY_RUN é o padrão seguro.
+ *   DATABASE_URL=... \
+ *   SOURCE_MODE=company \
+ *   SOURCE_COMPANY_ID=cmnhzieqf0000mx1cqcqgfv4n \
+ *   npx tsx scripts/provision-imobiliaria-lemos.ts
+ *
+ *   # 2) Executar de verdade (exige confirmação forte):
+ *   DATABASE_URL=... \
+ *   SOURCE_MODE=company \
+ *   SOURCE_COMPANY_ID=cmnhzieqf0000mx1cqcqgfv4n \
+ *   DRY_RUN=false \
+ *   CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
+ *   npx tsx scripts/provision-imobiliaria-lemos.ts
+ *
+ * VARIÁVEIS DE AMBIENTE:
+ *   DATABASE_URL                 (obrigatória) conexão Postgres
+ *   DRY_RUN                      default "true" — SÓ "false" (exato) executa
+ *   CONFIRM_PRODUCTION_MIGRATION exija = "IMOBILIARIA_LEMOS" quando DRY_RUN=false
+ *   SOURCE_MODE                  "company" | "user" | "company_and_user" (obrigatória p/ mover imóveis)
+ *   SOURCE_COMPANY_ID            id da company de origem dos imóveis
+ *   SOURCE_USER_EMAIL            e-mail do usuário dono atual dos imóveis
+ *   SKIP_PROPERTIES              "true" — só provisiona estrutura, não mexe em imóveis
+ *   MAX_MOVE                     limite de segurança (default 100000); aborta se exceder
+ *   BATCH_SIZE                   lote de update de imóveis (default 200)
+ *   RESET_EXISTING_PASSWORDS     "true" — redefine senha de usuários já existentes p/ a padrão
+ *   DEFAULT_PASSWORD             senha provisória (default "lemos2026")
+ *   SUBDOMAIN                    subdomínio do tenant (default "lemos")
+ */
+
+import { PrismaClient } from '@prisma/client'
+import * as argon2 from 'argon2'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// ── Config / env (parsing estrito e seguro) ───────────────────────────────
+const prisma = new PrismaClient()
+
+// DRY_RUN estrito: qualquer valor != "false" permanece seguro (dry-run).
+const DRY_RUN = process.env.DRY_RUN !== 'false'
+const CONFIRM = process.env.CONFIRM_PRODUCTION_MIGRATION || ''
+const SOURCE_MODE = (process.env.SOURCE_MODE || '').trim() // company | user | company_and_user
+const SOURCE_COMPANY_ID = (process.env.SOURCE_COMPANY_ID || '').trim()
+const SOURCE_USER_EMAIL = (process.env.SOURCE_USER_EMAIL || '').trim().toLowerCase()
+const SKIP_PROPERTIES = process.env.SKIP_PROPERTIES === 'true'
+const MAX_MOVE = Number(process.env.MAX_MOVE || 100000)
+const BATCH_SIZE = Math.max(1, Number(process.env.BATCH_SIZE || 200))
+const RESET_EXISTING_PASSWORDS = process.env.RESET_EXISTING_PASSWORDS === 'true'
+const DEFAULT_PASSWORD = process.env.DEFAULT_PASSWORD || 'lemos2026'
+const SUBDOMAIN = (process.env.SUBDOMAIN || 'lemos').toLowerCase().trim()
+
+const CANONICAL = 'imobiliaria-lemos'
+const MAIN_ADMIN_EMAIL = 'imobiliarialemosfranca@gmail.com'
+const PLATFORM_SUPERADMIN_EMAIL = 'tomas@agoraencontrei.com.br'
+
+const ADMINS = [
+  { email: 'imobiliarialemosfranca@gmail.com', name: 'Imobiliária Lemos (Admin)' },
+  { email: 'tomascesarlemossilva@gmail.com', name: 'Tomás César Lemos Silva' },
+  { email: 'blognairalemos@gmail.com', name: 'Naira Lemos' },
+  { email: 'noemialemos3@gmail.com', name: 'Noêmia Lemos' },
+]
+const BROKERS = [
+  { email: 'lorensesso@gmail.com', name: 'Loren Sesso' },
+  { email: 'lauraimobiliarialemos@gmail.com', name: 'Laura' },
+  { email: 'kairoimobiliarialemos@gmail.com', name: 'Kairo' },
+  { email: 'miriamimobiliarialemos@gmail.com', name: 'Miriam' },
+  { email: 'lucasimobiliarialemos@gmail.com', name: 'Lucas' },
+]
+
+// ── Utilitários ────────────────────────────────────────────────────────────
+const log = (...a: any[]) => console.log(...a)
+const norm = (e: string) => e.trim().toLowerCase()
+
+function mergeSettings(existing: unknown, patch: Record<string, unknown>): Record<string, unknown> {
+  const base = existing && typeof existing === 'object' && !Array.isArray(existing)
+    ? (existing as Record<string, unknown>)
+    : {}
+  return { ...base, ...patch }
+}
+
+function dbHost(url: string): string {
+  try { return new URL(url).host } catch { return '(não parseável)' }
+}
+
+function abort(msg: string): never {
+  console.error(`\n❌ ABORTADO: ${msg}\n`)
+  process.exit(1)
+}
+
+// ── Guardas de segurança ────────────────────────────────────────────────────
+function preflight() {
+  if (!process.env.DATABASE_URL) abort('DATABASE_URL não definida.')
+  log('─'.repeat(70))
+  log(`Banco de destino: ${dbHost(process.env.DATABASE_URL!)}`)
+  log(`Modo:             ${DRY_RUN ? '🔍 DRY-RUN (não grava)' : '🚨 EXECUÇÃO REAL (grava)'}`)
+  log(`SOURCE_MODE:      ${SOURCE_MODE || '(nenhum — não moverá imóveis)'}`)
+  log(`SOURCE_COMPANY:   ${SOURCE_COMPANY_ID || '—'}`)
+  log(`SOURCE_USER:      ${SOURCE_USER_EMAIL || '—'}`)
+  log(`Subdomínio:       ${SUBDOMAIN}`)
+  log('─'.repeat(70))
+
+  if (!DRY_RUN && CONFIRM !== 'IMOBILIARIA_LEMOS') {
+    abort('Execução real exige CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS.')
+  }
+  if (!SKIP_PROPERTIES && SOURCE_MODE) {
+    const validModes = ['company', 'user', 'company_and_user']
+    if (!validModes.includes(SOURCE_MODE)) abort(`SOURCE_MODE inválido: use ${validModes.join(' | ')}.`)
+    if ((SOURCE_MODE === 'company' || SOURCE_MODE === 'company_and_user') && !SOURCE_COMPANY_ID)
+      abort('SOURCE_MODE requer SOURCE_COMPANY_ID.')
+    if ((SOURCE_MODE === 'user' || SOURCE_MODE === 'company_and_user') && !SOURCE_USER_EMAIL)
+      abort('SOURCE_MODE requer SOURCE_USER_EMAIL.')
+  }
+}
+
+// Constrói o WHERE de seleção de imóveis a mover, com semântica explícita.
+async function buildPropertyWhere(): Promise<any | null> {
+  if (SKIP_PROPERTIES || !SOURCE_MODE) return null
+  const sourceUser = SOURCE_USER_EMAIL
+    ? await prisma.user.findUnique({ where: { email: SOURCE_USER_EMAIL }, select: { id: true, companyId: true } })
+    : null
+  if ((SOURCE_MODE === 'user' || SOURCE_MODE === 'company_and_user') && !sourceUser)
+    abort(`SOURCE_USER_EMAIL não encontrado: ${SOURCE_USER_EMAIL}`)
+
+  if (SOURCE_MODE === 'company') return { companyId: SOURCE_COMPANY_ID }
+  if (SOURCE_MODE === 'user') return { userId: sourceUser!.id }
+  // company_and_user → AND estrito (mais seguro)
+  return { AND: [{ companyId: SOURCE_COMPANY_ID }, { userId: sourceUser!.id }] }
+}
+
+// ── Provisionamento estrutural (idempotente) ────────────────────────────────
+async function ensureFundadorPlan() {
+  const existing = await prisma.planDefinition.findUnique({ where: { slug: 'fundador' } })
+  if (existing) return existing
+  if (DRY_RUN) { log('• [dry] criaria PlanDefinition "fundador"'); return null }
+  return prisma.planDefinition.create({
+    data: {
+      slug: 'fundador', name: 'Fundador',
+      description: 'Plano interno da parceira fundadora — acesso total, sem cobrança.',
+      priceMonthly: 0, priceYearly: 0,
+      maxProperties: -1, maxLeadViews: -1, maxUsers: -1, maxAIRequests: -1,
+      themes: ['all'], modules: ['site_basico', 'crm_basico', 'crm_avancado', 'ia_tomas', 'whatsapp', 'leiloes', 'dominio_proprio', 'split_pagamentos', 'video_editor'],
+      features: ['Acesso completo e ilimitado', 'Isento de cobrança (parceira fundadora)'],
+      isActive: true, sortOrder: 0,
+      metadata: { internal: true, billingExempt: true, allModules: true, allThemes: true } as any,
+    },
+  })
+}
+
+async function ensureCompany() {
+  const found = await prisma.company.findFirst({
+    where: { settings: { path: ['canonical'], equals: CANONICAL } },
+  }).catch(() => null)
+  if (found) {
+    if (!DRY_RUN) {
+      await prisma.company.update({
+        where: { id: found.id },
+        data: { plan: 'fundador', isActive: true, settings: mergeSettings(found.settings, { canonical: CANONICAL, billingExempt: true }) as any },
+      })
+    }
+    return found
+  }
+  if (DRY_RUN) { log('• [dry] criaria Company "Imobiliária Lemos"'); return null }
+  return prisma.company.create({
+    data: {
+      name: 'Imobiliária Lemos', tradeName: 'Imobiliária Lemos',
+      creci: '279051-F', city: 'Franca', state: 'SP',
+      email: 'contato@imobiliarialemos.com.br', website: 'https://www.imobiliarialemos.com.br',
+      plan: 'fundador', isActive: true,
+      settings: { canonical: CANONICAL, billingExempt: true } as any,
+    },
+  })
+}
+
+// Cria/atualiza um usuário de forma idempotente por email (normalizado).
+async function upsertUser(u: { email: string; name: string }, role: 'ADMIN' | 'BROKER', companyId: string | null) {
+  const email = norm(u.email)
+  const existing = await prisma.user.findUnique({ where: { email } })
+  const settingsPatch: Record<string, unknown> = { mustChangePassword: true }
+  if (role === 'ADMIN') { settingsPatch.accessLevel = 'full' }
+
+  if (existing) {
+    const report = {
+      email, action: 'update', wasCompanyId: existing.companyId, wasRole: existing.role,
+    }
+    if (!DRY_RUN && companyId) {
+      const data: any = {
+        companyId, role, status: 'ACTIVE',
+        emailVerifiedAt: existing.emailVerifiedAt ?? new Date(),
+        settings: mergeSettings(existing.settings, settingsPatch) as any,
+      }
+      if (RESET_EXISTING_PASSWORDS || !existing.passwordHash) {
+        data.passwordHash = await argon2.hash(DEFAULT_PASSWORD, { type: argon2.argon2id })
+      }
+      await prisma.user.update({ where: { id: existing.id }, data })
+    }
+    return { ...report, id: existing.id }
+  }
+
+  if (DRY_RUN || !companyId) { log(`• [dry] criaria user ${email} (${role})`); return { email, action: 'create', id: null } }
+  const created = await prisma.user.create({
+    data: {
+      companyId, email, name: u.name, role, status: 'ACTIVE',
+      emailVerifiedAt: new Date(),
+      passwordHash: await argon2.hash(DEFAULT_PASSWORD, { type: argon2.argon2id }),
+      settings: settingsPatch as any,
+    },
+  })
+  return { email, action: 'create', id: created.id, wasCompanyId: null, wasRole: null }
+}
+
+async function ensureTenant(companyId: string | null, ownerId: string | null) {
+  // Guarda contra colisão de subdomínio com outro tenant.
+  const bySub = await prisma.tenant.findUnique({ where: { subdomain: SUBDOMAIN } }).catch(() => null)
+  if (bySub) {
+    const isOurs = (bySub.settings as any)?.canonical === CANONICAL || (companyId && bySub.companyId === companyId)
+    if (!isOurs) abort(`Subdomínio "${SUBDOMAIN}" já pertence a outro tenant (${bySub.id}). Escolha outro SUBDOMAIN.`)
+    if (!DRY_RUN) {
+      await prisma.tenant.update({
+        where: { id: bySub.id },
+        data: {
+          plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
+          companyId: companyId ?? bySub.companyId, ownerId: ownerId ?? bySub.ownerId,
+          settings: mergeSettings(bySub.settings, { canonical: CANONICAL, billingExempt: true }) as any,
+        },
+      })
+    }
+    return bySub
+  }
+  if (DRY_RUN || !companyId) { log(`• [dry] criaria Tenant "${SUBDOMAIN}"`); return null }
+  return prisma.tenant.create({
+    data: {
+      name: 'Imobiliária Lemos', subdomain: SUBDOMAIN, companyId, ownerId,
+      plan: 'fundador', planStatus: 'ACTIVE', planPrice: 0, splitPercent: 0, isActive: true,
+      activatedAt: new Date(),
+      settings: { canonical: CANONICAL, billingExempt: true } as any,
+    },
+  })
+}
+
+// ── Migração de imóveis (em lotes, com rollback) ────────────────────────────
+async function migrateProperties(where: any, targetCompanyId: string | null, targetUserId: string | null) {
+  const ids = await prisma.property.findMany({ where, select: { id: true, companyId: true, userId: true, reference: true, title: true } })
+  log(`\n📦 Imóveis selecionados para mover: ${ids.length}`)
+  if (ids.length === 0) { log('   (nenhum imóvel corresponde ao filtro — nada a mover)'); return { moved: [], ownersMoved: 0 } }
+  if (ids.length > MAX_MOVE) abort(`Seleção (${ids.length}) excede MAX_MOVE (${MAX_MOVE}). Confira o filtro antes de prosseguir.`)
+
+  // Amostra para conferência
+  log('   Amostra (até 5):')
+  ids.slice(0, 5).forEach(p => log(`     - ${p.id} | ${p.reference ?? '—'} | ${p.title?.slice(0, 50) ?? ''} | company=${p.companyId} user=${p.userId}`))
+  const fromCompanies = [...new Set(ids.map(p => p.companyId))]
+  log(`   Empresas de origem distintas: ${fromCompanies.length} → ${fromCompanies.join(', ')}`)
+
+  // Contatos-proprietários vinculados (via PropertyOwner) — movem junto.
+  const owners = await prisma.propertyOwner.findMany({
+    where: { propertyId: { in: ids.map(p => p.id) } },
+    select: { contactId: true },
+  })
+  const ownerContactIds = [...new Set(owners.map(o => o.contactId))]
+  log(`   Contatos-proprietários vinculados: ${ownerContactIds.length}`)
+
+  if (DRY_RUN || !targetCompanyId || !targetUserId) {
+    log('   [dry] NÃO gravou (dry-run ou destino ainda não materializado). Rode com DRY_RUN=false para aplicar.')
+    return { moved: ids, ownersMoved: ownerContactIds.length }
+  }
+
+  // Aplica em lotes (evita transação gigante/locks longos).
+  let done = 0
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const batch = ids.slice(i, i + BATCH_SIZE).map(p => p.id)
+    await prisma.property.updateMany({
+      where: { id: { in: batch } },
+      data: { companyId: targetCompanyId, userId: targetUserId },
+    })
+    done += batch.length
+    log(`   ...movidos ${done}/${ids.length}`)
+  }
+  // Move os contatos-proprietários para a company Lemos (evita ref cross-tenant).
+  if (ownerContactIds.length > 0) {
+    await prisma.contact.updateMany({
+      where: { id: { in: ownerContactIds } },
+      data: { companyId: targetCompanyId },
+    })
+  }
+  return { moved: ids, ownersMoved: ownerContactIds.length }
+}
+
+// Reporta (sem mover) dados operacionais que referenciam os imóveis movidos.
+async function reportRelatedData(propertyIds: string[], sourceCompanyId: string | null) {
+  if (propertyIds.length === 0) return
+  log('\n🔎 Dados relacionados (REPORTE — não são movidos automaticamente):')
+  const idSet = { in: propertyIds }
+  const safeCount = async (label: string, fn: () => Promise<number>) => {
+    try { log(`   • ${label}: ${await fn()}`) } catch { log(`   • ${label}: (modelo indisponível)`) }
+  }
+  await safeCount('LeadProperty (leads↔imóvel)', () => (prisma as any).leadProperty.count({ where: { propertyId: idSet } }))
+  await safeCount('DealProperty (deals↔imóvel)', () => (prisma as any).dealProperty.count({ where: { propertyId: idSet } }))
+  await safeCount('PortalPublication', () => (prisma as any).portalPublication.count({ where: { propertyId: idSet } }))
+  if (sourceCompanyId) {
+    await safeCount('Contacts na company de origem (total)', () => prisma.contact.count({ where: { companyId: sourceCompanyId } }))
+    await safeCount('Leads na company de origem (total)', () => prisma.lead.count({ where: { companyId: sourceCompanyId } }))
+  }
+  log('   → Migração relacional destes dados deve ser um passo revisado à parte (ver runbook).')
+}
+
+// ── Revogação de sessões (força novo login após mudança de role/empresa) ────
+async function revokeSessions(userIds: string[]) {
+  if (userIds.length === 0 || DRY_RUN) { if (DRY_RUN) log('\n• [dry] revogaria sessões/refresh tokens dos usuários provisionados'); return }
+  const s = await prisma.session.deleteMany({ where: { userId: { in: userIds } } }).catch(() => ({ count: 0 }))
+  const r = await prisma.refreshToken.deleteMany({ where: { userId: { in: userIds } } }).catch(() => ({ count: 0 }))
+  log(`\n🔒 Sessões revogadas: ${s.count} | refresh tokens: ${r.count}`)
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+async function main() {
+  preflight()
+
+  // Confirma que o super-admin da plataforma existe (aviso, não bloqueia).
+  const superAdmin = await prisma.user.findUnique({ where: { email: PLATFORM_SUPERADMIN_EMAIL }, select: { id: true, role: true } })
+  if (!superAdmin) log(`⚠️  Aviso: super-admin da plataforma (${PLATFORM_SUPERADMIN_EMAIL}) não encontrado.`)
+  else if (superAdmin.role !== 'SUPER_ADMIN') log(`⚠️  Aviso: ${PLATFORM_SUPERADMIN_EMAIL} existe mas não é SUPER_ADMIN (será corrigido no boot da API).`)
+
+  // Detecta conflito: emails duplicados (idempotência por email).
+  for (const u of [...ADMINS, ...BROKERS]) {
+    const dupes = await prisma.user.count({ where: { email: norm(u.email) } })
+    if (dupes > 1) abort(`Mais de um usuário com email ${u.email} — resolva a duplicidade antes.`)
+  }
+
+  // 1) Plano fundador
+  const plan = await ensureFundadorPlan()
+  if (!DRY_RUN && !plan) abort('Falha ao garantir plano fundador.')
+
+  // 2) Company
+  const company = await ensureCompany()
+  const companyId = company?.id ?? null
+  if (!DRY_RUN && !companyId) abort('Falha ao garantir Company Lemos.')
+
+  // 3) Proprietário principal PRIMEIRO (resolve dependência circular do tenant)
+  const mainAdmin = ADMINS.find(a => norm(a.email) === MAIN_ADMIN_EMAIL)!
+  const mainRep = await upsertUser(mainAdmin, 'ADMIN', companyId)
+  const mainUserId = mainRep.id
+
+  // 4) Tenant (ownerId = proprietário principal)
+  await ensureTenant(companyId, mainUserId)
+
+  // 5) Demais usuários
+  const userReports: any[] = [mainRep]
+  for (const a of ADMINS) {
+    if (norm(a.email) === MAIN_ADMIN_EMAIL) continue
+    userReports.push(await upsertUser(a, 'ADMIN', companyId))
+  }
+  for (const b of BROKERS) userReports.push(await upsertUser(b, 'BROKER', companyId))
+  log(`\n👥 Usuários provisionados: ${userReports.length} (${ADMINS.length} admins + ${BROKERS.length} corretores)`)
+
+  // 6/7) Imóveis + proprietários vinculados
+  let propReport: { moved: any[]; ownersMoved: number } = { moved: [], ownersMoved: 0 }
+  const where = await buildPropertyWhere()
+  if (where) {
+    // Seleciona e reporta sempre (mesmo em dry-run, quando a company ainda não existe);
+    // só grava quando !DRY_RUN e os destinos estão materializados.
+    propReport = await migrateProperties(where, companyId, mainUserId)
+    await reportRelatedData(propReport.moved.map((p: any) => p.id), SOURCE_COMPANY_ID || null)
+  } else if (!SKIP_PROPERTIES && !SOURCE_MODE) {
+    log('\nℹ️  SOURCE_MODE não definido — imóveis NÃO foram tocados. Defina SOURCE_MODE para reatribuir.')
+  }
+
+  // 8) Revogar sessões dos usuários provisionados
+  const provisionedIds = userReports.map(r => r.id).filter(Boolean) as string[]
+  await revokeSessions(provisionedIds)
+
+  // 9) Rollback file (antes→depois)
+  const rollback = {
+    dryRun: DRY_RUN,
+    sourceMode: SOURCE_MODE, sourceCompanyId: SOURCE_COMPANY_ID || null, sourceUserEmail: SOURCE_USER_EMAIL || null,
+    targetCompanyId: companyId,
+    users: userReports,
+    properties: propReport.moved.map((p: any) => ({ id: p.id, oldCompanyId: p.companyId, oldUserId: p.userId })),
+    ownersMoved: propReport.ownersMoved,
+  }
+  try {
+    const dir = join(process.cwd(), '.migration-runs')
+    mkdirSync(dir, { recursive: true })
+    // timestamp injetado por env p/ evitar Date.now() não-determinístico em alguns runners
+    const stamp = process.env.RUN_STAMP || String(process.hrtime.bigint())
+    const file = join(dir, `lemos-provision-${DRY_RUN ? 'dryrun-' : ''}${stamp}.json`)
+    writeFileSync(file, JSON.stringify(rollback, null, 2))
+    log(`\n🗂️  Rollback/snapshot salvo em: ${file}`)
+  } catch (e) {
+    log('⚠️  Não foi possível gravar o arquivo de rollback:', (e as Error).message)
+  }
+
+  log(`\n${DRY_RUN ? '🔍 DRY-RUN concluído (nada foi gravado).' : '✅ Provisionamento concluído.'}`)
+  if (DRY_RUN) log('   Revise os números acima e rode com DRY_RUN=false CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS para aplicar.')
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1) })
+  .finally(() => prisma.$disconnect())

--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -58,6 +58,7 @@
 
 import { PrismaClient } from '@prisma/client'
 import * as argon2 from 'argon2'
+import { randomBytes } from 'node:crypto'
 import { writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -74,8 +75,20 @@ const SKIP_PROPERTIES = process.env.SKIP_PROPERTIES === 'true'
 const MAX_MOVE = Number(process.env.MAX_MOVE || 100000)
 const BATCH_SIZE = Math.max(1, Number(process.env.BATCH_SIZE || 200))
 const RESET_EXISTING_PASSWORDS = process.env.RESET_EXISTING_PASSWORDS === 'true'
-const DEFAULT_PASSWORD = process.env.DEFAULT_PASSWORD || 'lemos2026'
+// Contagem esperada de imóveis: se definida, o script ABORTA caso a seleção
+// divirja (guarda anti-erro de filtro). Deixe vazio p/ não checar.
+const EXPECTED_PROPERTY_COUNT = process.env.EXPECTED_PROPERTY_COUNT
+  ? Number(process.env.EXPECTED_PROPERTY_COUNT) : null
+// Senha: por padrão, cada usuário NOVO recebe uma senha ALEATÓRIA INDIVIDUAL
+// (impressa uma única vez ao final). NÃO há mais senha coletiva. Um valor
+// explícito em FORCE_PASSWORD só é usado se você quiser forçar uma senha comum.
+const FORCE_PASSWORD = process.env.FORCE_PASSWORD || process.env.DEFAULT_PASSWORD || ''
 const SUBDOMAIN = (process.env.SUBDOMAIN || 'lemos').toLowerCase().trim()
+
+// Gera uma senha forte, aleatória e individual (impressa uma vez; nunca no snapshot).
+function genPassword(): string {
+  return 'Lm-' + randomBytes(12).toString('base64url')
+}
 
 const CANONICAL = 'imobiliaria-lemos'
 const MAIN_ADMIN_EMAIL = 'imobiliarialemosfranca@gmail.com'
@@ -200,39 +213,50 @@ async function ensureCompany() {
 }
 
 // Cria/atualiza um usuário de forma idempotente por email (normalizado).
-async function upsertUser(u: { email: string; name: string }, role: 'ADMIN' | 'BROKER', companyId: string | null) {
+// `creds` acumula {email, password} das senhas geradas, p/ impressão única.
+async function upsertUser(
+  u: { email: string; name: string },
+  role: 'ADMIN' | 'BROKER',
+  companyId: string | null,
+  creds: { email: string; password: string }[],
+) {
   const email = norm(u.email)
   const existing = await prisma.user.findUnique({ where: { email } })
   const settingsPatch: Record<string, unknown> = { mustChangePassword: true }
   if (role === 'ADMIN') { settingsPatch.accessLevel = 'full' }
 
   if (existing) {
-    const report = {
-      email, action: 'update', wasCompanyId: existing.companyId, wasRole: existing.role,
-    }
+    const report = { email, action: 'update', wasCompanyId: existing.companyId, wasRole: existing.role }
     if (!DRY_RUN && companyId) {
       const data: any = {
         companyId, role, status: 'ACTIVE',
         emailVerifiedAt: existing.emailVerifiedAt ?? new Date(),
         settings: mergeSettings(existing.settings, settingsPatch) as any,
       }
+      // Usuário EXISTENTE: NÃO sobrescreve a senha (a menos de RESET_EXISTING_PASSWORDS
+      // ou se ele não tem senha alguma — ex.: só login social).
       if (RESET_EXISTING_PASSWORDS || !existing.passwordHash) {
-        data.passwordHash = await argon2.hash(DEFAULT_PASSWORD, { type: argon2.argon2id })
+        const pw = FORCE_PASSWORD || genPassword()
+        data.passwordHash = await argon2.hash(pw, { type: argon2.argon2id })
+        creds.push({ email, password: pw })
       }
       await prisma.user.update({ where: { id: existing.id }, data })
     }
     return { ...report, id: existing.id }
   }
 
-  if (DRY_RUN || !companyId) { log(`• [dry] criaria user ${email} (${role})`); return { email, action: 'create', id: null } }
+  // Usuário NOVO: senha ALEATÓRIA INDIVIDUAL (ou FORCE_PASSWORD se explicitado).
+  const pw = FORCE_PASSWORD || genPassword()
+  if (DRY_RUN || !companyId) { log(`• [dry] criaria user ${email} (${role})`); return { email, action: 'create', id: null, wasCompanyId: null, wasRole: null } }
   const created = await prisma.user.create({
     data: {
       companyId, email, name: u.name, role, status: 'ACTIVE',
       emailVerifiedAt: new Date(),
-      passwordHash: await argon2.hash(DEFAULT_PASSWORD, { type: argon2.argon2id }),
+      passwordHash: await argon2.hash(pw, { type: argon2.argon2id }),
       settings: settingsPatch as any,
     },
   })
+  creds.push({ email, password: pw })
   return { email, action: 'create', id: created.id, wasCompanyId: null, wasRole: null }
 }
 
@@ -267,10 +291,14 @@ async function ensureTenant(companyId: string | null, ownerId: string | null) {
 
 // ── Migração de imóveis (em lotes, com rollback) ────────────────────────────
 async function migrateProperties(where: any, targetCompanyId: string | null, targetUserId: string | null) {
-  const ids = await prisma.property.findMany({ where, select: { id: true, companyId: true, userId: true, reference: true, title: true } })
+  const ids = await prisma.property.findMany({ where, select: { id: true, companyId: true, userId: true, reference: true, slug: true, title: true } })
   log(`\n📦 Imóveis selecionados para mover: ${ids.length}`)
-  if (ids.length === 0) { log('   (nenhum imóvel corresponde ao filtro — nada a mover)'); return { moved: [], ownersMoved: 0 } }
+  if (ids.length === 0) { log('   (nenhum imóvel corresponde ao filtro — nada a mover)'); return { moved: [], movedOwners: [], sharedOwners: [] } }
   if (ids.length > MAX_MOVE) abort(`Seleção (${ids.length}) excede MAX_MOVE (${MAX_MOVE}). Confira o filtro antes de prosseguir.`)
+  // Guarda anti-erro: se a contagem esperada foi informada e diverge, aborta.
+  if (EXPECTED_PROPERTY_COUNT != null && ids.length !== EXPECTED_PROPERTY_COUNT) {
+    abort(`Contagem (${ids.length}) diverge de EXPECTED_PROPERTY_COUNT (${EXPECTED_PROPERTY_COUNT}). Revise o filtro.`)
+  }
 
   // Amostra para conferência
   log('   Amostra (até 5):')
@@ -278,17 +306,48 @@ async function migrateProperties(where: any, targetCompanyId: string | null, tar
   const fromCompanies = [...new Set(ids.map(p => p.companyId))]
   log(`   Empresas de origem distintas: ${fromCompanies.length} → ${fromCompanies.join(', ')}`)
 
-  // Contatos-proprietários vinculados (via PropertyOwner) — movem junto.
+  // ── Detecção de colisão de slug/reference no destino ─────────────────────
+  // Property tem @@unique([companyId, slug]) e @@unique([companyId, reference]).
+  // (a) duplicados dentro da própria seleção (só ocorre se a origem for multi-empresa)
+  const dupSlugs = firstDuplicates(ids.map(p => p.slug))
+  const dupRefs = firstDuplicates(ids.map(p => p.reference).filter(Boolean) as string[])
+  if (dupSlugs.length) abort(`Colisão de slug dentro da seleção: ${dupSlugs.slice(0, 10).join(', ')}. Origem multi-empresa? Restrinja o filtro.`)
+  if (dupRefs.length) abort(`Colisão de reference dentro da seleção: ${dupRefs.slice(0, 10).join(', ')}.`)
+  // (b) colisão com imóveis já existentes na company de destino
+  if (targetCompanyId) {
+    const clashSlug = await prisma.property.count({ where: { companyId: targetCompanyId, slug: { in: ids.map(p => p.slug) }, id: { notIn: ids.map(p => p.id) } } })
+    const refs = ids.map(p => p.reference).filter(Boolean) as string[]
+    const clashRef = refs.length ? await prisma.property.count({ where: { companyId: targetCompanyId, reference: { in: refs }, id: { notIn: ids.map(p => p.id) } } }) : 0
+    if (clashSlug > 0 || clashRef > 0) abort(`Destino já possui imóveis com slug/reference em conflito (slug=${clashSlug}, ref=${clashRef}).`)
+  }
+
+  // ── Contatos-proprietários (via PropertyOwner) ───────────────────────────
+  const movedSet = new Set(ids.map(p => p.id))
   const owners = await prisma.propertyOwner.findMany({
     where: { propertyId: { in: ids.map(p => p.id) } },
     select: { contactId: true },
   })
   const ownerContactIds = [...new Set(owners.map(o => o.contactId))]
-  log(`   Contatos-proprietários vinculados: ${ownerContactIds.length}`)
+  // Proprietário COMPARTILHADO: possui também imóvel FORA da seleção → NÃO mover
+  // (senão o imóvel não-migrado passaria a referenciar contato de outra empresa).
+  const sharedOwners: string[] = []
+  const movableOwnerIds: string[] = []
+  for (const cid of ownerContactIds) {
+    const otherLinks = await prisma.propertyOwner.findMany({ where: { contactId: cid }, select: { propertyId: true } })
+    const ownsOutside = otherLinks.some(l => !movedSet.has(l.propertyId))
+    if (ownsOutside) sharedOwners.push(cid); else movableOwnerIds.push(cid)
+  }
+  log(`   Contatos-proprietários vinculados: ${ownerContactIds.length} (movíveis: ${movableOwnerIds.length}, compartilhados/mantidos: ${sharedOwners.length})`)
+  if (sharedOwners.length) log(`   ⚠️  ${sharedOwners.length} proprietário(s) também possuem imóveis fora da seleção — NÃO serão movidos (evita ref cross-tenant).`)
+
+  // Snapshot dos contatos movíveis (para rollback) ANTES de alterar.
+  const movableOwners = movableOwnerIds.length
+    ? await prisma.contact.findMany({ where: { id: { in: movableOwnerIds } }, select: { id: true, companyId: true } })
+    : []
 
   if (DRY_RUN || !targetCompanyId || !targetUserId) {
     log('   [dry] NÃO gravou (dry-run ou destino ainda não materializado). Rode com DRY_RUN=false para aplicar.')
-    return { moved: ids, ownersMoved: ownerContactIds.length }
+    return { moved: ids, movedOwners: movableOwners, sharedOwners }
   }
 
   // Aplica em lotes (evita transação gigante/locks longos).
@@ -302,14 +361,18 @@ async function migrateProperties(where: any, targetCompanyId: string | null, tar
     done += batch.length
     log(`   ...movidos ${done}/${ids.length}`)
   }
-  // Move os contatos-proprietários para a company Lemos (evita ref cross-tenant).
-  if (ownerContactIds.length > 0) {
-    await prisma.contact.updateMany({
-      where: { id: { in: ownerContactIds } },
-      data: { companyId: targetCompanyId },
-    })
+  // Move os contatos-proprietários (só os NÃO compartilhados) para a company Lemos.
+  if (movableOwnerIds.length > 0) {
+    await prisma.contact.updateMany({ where: { id: { in: movableOwnerIds } }, data: { companyId: targetCompanyId } })
   }
-  return { moved: ids, ownersMoved: ownerContactIds.length }
+  return { moved: ids, movedOwners: movableOwners, sharedOwners }
+}
+
+// Retorna os valores que aparecem mais de uma vez em `arr`.
+function firstDuplicates(arr: string[]): string[] {
+  const seen = new Set<string>(); const dup = new Set<string>()
+  for (const v of arr) { if (seen.has(v)) dup.add(v); else seen.add(v) }
+  return [...dup]
 }
 
 // Reporta (sem mover) dados operacionais que referenciam os imóveis movidos.
@@ -362,9 +425,12 @@ async function main() {
   const companyId = company?.id ?? null
   if (!DRY_RUN && !companyId) abort('Falha ao garantir Company Lemos.')
 
+  // creds acumula as senhas geradas (individuais) — impressas UMA vez ao final.
+  const creds: { email: string; password: string }[] = []
+
   // 3) Proprietário principal PRIMEIRO (resolve dependência circular do tenant)
   const mainAdmin = ADMINS.find(a => norm(a.email) === MAIN_ADMIN_EMAIL)!
-  const mainRep = await upsertUser(mainAdmin, 'ADMIN', companyId)
+  const mainRep = await upsertUser(mainAdmin, 'ADMIN', companyId, creds)
   const mainUserId = mainRep.id
 
   // 4) Tenant (ownerId = proprietário principal)
@@ -374,13 +440,13 @@ async function main() {
   const userReports: any[] = [mainRep]
   for (const a of ADMINS) {
     if (norm(a.email) === MAIN_ADMIN_EMAIL) continue
-    userReports.push(await upsertUser(a, 'ADMIN', companyId))
+    userReports.push(await upsertUser(a, 'ADMIN', companyId, creds))
   }
-  for (const b of BROKERS) userReports.push(await upsertUser(b, 'BROKER', companyId))
+  for (const b of BROKERS) userReports.push(await upsertUser(b, 'BROKER', companyId, creds))
   log(`\n👥 Usuários provisionados: ${userReports.length} (${ADMINS.length} admins + ${BROKERS.length} corretores)`)
 
   // 6/7) Imóveis + proprietários vinculados
-  let propReport: { moved: any[]; ownersMoved: number } = { moved: [], ownersMoved: 0 }
+  let propReport: { moved: any[]; movedOwners: { id: string; companyId: string }[]; sharedOwners: string[] } = { moved: [], movedOwners: [], sharedOwners: [] }
   const where = await buildPropertyWhere()
   if (where) {
     // Seleciona e reporta sempre (mesmo em dry-run, quando a company ainda não existe);
@@ -391,29 +457,49 @@ async function main() {
     log('\nℹ️  SOURCE_MODE não definido — imóveis NÃO foram tocados. Defina SOURCE_MODE para reatribuir.')
   }
 
-  // 8) Revogar sessões dos usuários provisionados
+  // 8) Revogar sessões dos usuários provisionados (inclui o gmail que perde SUPER_ADMIN)
   const provisionedIds = userReports.map(r => r.id).filter(Boolean) as string[]
   await revokeSessions(provisionedIds)
 
-  // 9) Rollback file (antes→depois)
+  // 9) Rollback file (antes→depois) — NÃO contém senhas.
   const rollback = {
     dryRun: DRY_RUN,
     sourceMode: SOURCE_MODE, sourceCompanyId: SOURCE_COMPANY_ID || null, sourceUserEmail: SOURCE_USER_EMAIL || null,
     targetCompanyId: companyId,
+    // usuários movidos/criados: email, ação, empresa e papel ANTERIORES
     users: userReports,
+    // imóveis: id + empresa/usuário ANTERIORES
     properties: propReport.moved.map((p: any) => ({ id: p.id, oldCompanyId: p.companyId, oldUserId: p.userId })),
-    ownersMoved: propReport.ownersMoved,
+    // contatos-proprietários alterados: id + empresa ANTERIOR
+    contactsMoved: propReport.movedOwners.map(c => ({ id: c.id, oldCompanyId: c.companyId })),
+    sharedOwnersKept: propReport.sharedOwners,
   }
-  try {
-    const dir = join(process.cwd(), '.migration-runs')
-    mkdirSync(dir, { recursive: true })
-    // timestamp injetado por env p/ evitar Date.now() não-determinístico em alguns runners
-    const stamp = process.env.RUN_STAMP || String(process.hrtime.bigint())
-    const file = join(dir, `lemos-provision-${DRY_RUN ? 'dryrun-' : ''}${stamp}.json`)
-    writeFileSync(file, JSON.stringify(rollback, null, 2))
-    log(`\n🗂️  Rollback/snapshot salvo em: ${file}`)
-  } catch (e) {
-    log('⚠️  Não foi possível gravar o arquivo de rollback:', (e as Error).message)
+  // DRY_RUN não grava NADA — nem o snapshot. Só a execução real gera o arquivo.
+  if (DRY_RUN) {
+    log('\n• [dry] snapshot/rollback NÃO gravado (dry-run não escreve nada em disco).')
+  } else {
+    try {
+      const dir = join(process.cwd(), '.migration-runs')
+      mkdirSync(dir, { recursive: true })
+      // timestamp injetado por env p/ evitar Date.now() não-determinístico em alguns runners
+      const stamp = process.env.RUN_STAMP || String(process.hrtime.bigint())
+      const file = join(dir, `lemos-provision-${stamp}.json`)
+      writeFileSync(file, JSON.stringify(rollback, null, 2))
+      log(`\n🗂️  Rollback/snapshot salvo em: ${file}`)
+    } catch (e) {
+      log('⚠️  Não foi possível gravar o arquivo de rollback:', (e as Error).message)
+    }
+  }
+
+  // Credenciais individuais — impressas UMA ÚNICA VEZ aqui (nunca no snapshot).
+  if (!DRY_RUN && creds.length > 0) {
+    log('\n' + '═'.repeat(70))
+    log('🔑 SENHAS PROVISÓRIAS INDIVIDUAIS (copie AGORA — não serão exibidas de novo)')
+    log('   Entregue cada uma ao respectivo usuário por canal seguro. Todos terão de')
+    log('   trocar a senha no primeiro acesso (mustChangePassword).')
+    log('─'.repeat(70))
+    for (const c of creds) log(`   ${c.email.padEnd(38)} ${c.password}`)
+    log('═'.repeat(70))
   }
 
   log(`\n${DRY_RUN ? '🔍 DRY-RUN concluído (nada foi gravado).' : '✅ Provisionamento concluído.'}`)


### PR DESCRIPTION
> ⚠️ **Não fazer merge automático.** Aguardando revisão final.
> O maior risco não é a UI — é a **migração relacional de dados**, feita por um script fora deste diff, com DRY-RUN por padrão. Ver seções 7/8/9/10.

## 1. Resumo completo

Separa dois papéis que hoje estão acoplados no AgoraEncontrei:

- **Plataforma (AgoraEncontrei)** — administra parceiros, planos, afiliados, tenants, eventos, saúde de integrações, filas de repasse, inteligência de mercado. Papel do super-admin `tomas@agoraencontrei.com.br`.
- **Parceiro (Imobiliária Lemos)** — a primeira parceira oficial (fundadora), que usa o sistema para gerir carteira de locação, imóveis, clientes e site próprio, **sem cobrança**.

O que o PR entrega:

1. **Esconde/bloqueia** as ferramentas de plataforma para quem não é `SUPER_ADMIN` (sidebar + guard de rota no front; guards no back).
2. **Plano interno “fundador”** (R$0, ilimitado, todos os módulos/temas), excluído do catálogo público, do checkout e das métricas comerciais.
3. **`tomascesarlemossilva@gmail.com`** deixa de ser super-admin da plataforma no boot e passa a ser **ADMIN da Lemos** (feito pelo script; boot não o re-promove mais).
4. **Script de provisionamento/migração** idempotente (DRY-RUN por padrão) que cria plano/empresa/tenant/9 usuários e reatribui os imóveis à Lemos, com guardas fortes de produção.

Contas resultantes:

| Conta | Papel | Empresa |
|---|---|---|
| `tomas@agoraencontrei.com.br` | `SUPER_ADMIN` | AgoraEncontrei (plataforma) |
| `imobiliarialemosfranca@gmail.com` (dono principal) + `tomascesarlemossilva@`, `blognairalemos@`, `noemialemos3@` | `ADMIN` | Imobiliária Lemos |
| `lorensesso@` + Laura/Kairo/Miriam/Lucas | `BROKER` | Imobiliária Lemos |

## 2. Arquivos criados e modificados

**Criados**
- `apps/web/src/lib/platform-routes.ts` — fonte única (`PLATFORM_ONLY_HREFS`, `isPlatformOnly`, `isPlatformAdmin`).
- `apps/api/src/services/billing-exempt.ts` — `isBillingExempt` central.
- `scripts/provision-imobiliaria-lemos.ts` — provisionamento/migração idempotente (DRY-RUN por padrão).
- `scripts/RUNBOOK-imobiliaria-lemos.md` — runbook de deploy/rollback.

**Modificados**
- `apps/web/src/components/dashboard/sidebar.tsx` — esconde itens platform-only.
- `apps/web/src/components/dashboard/guard.tsx` — redireciona rota platform-only; não renderiza conteúdo antes do redirect.
- `apps/api/src/utils/permissions.ts` — `requireSuperAdmin` (preHandler + auditLog).
- `apps/api/src/routes/market/index.ts` — `/api/v1/market` exige SUPER_ADMIN.
- `apps/api/src/routes/tenants/index.ts` — `POST /` exige SUPER_ADMIN; `GET/PATCH /:id` e `/mine` permitem ADMIN/MANAGER da mesma empresa; campos financeiros só SUPER_ADMIN.
- `apps/api/src/server.ts` — remove o gmail da auto-promoção a SUPER_ADMIN no boot.
- `apps/api/src/services/bootstrap-plans.ts` — plano `fundador` (internal + billingExempt).
- `apps/api/src/routes/master/admin-config.ts` — catálogo público exclui planos `internal`.
- `apps/api/src/routes/billing/saas-checkout.ts` — bloqueia contratar plano `internal`.
- `apps/api/src/routes/billing/saas-webhook.ts` — tenant isento nunca é rebaixado (PAST_DUE/SUSPENDED).
- `apps/api/src/services/tenant.service.ts` — `calculateMRR` exclui internos/isentos + constante `EXCLUDE_INTERNAL_TENANT`.
- `apps/api/src/services/master/{intelligence,retention,forecast}.service.ts` — métricas excluem internos/isentos.
- `packages/database/prisma/seed.ts` — admin da plataforma como `SUPER_ADMIN`.
- `.gitignore` — ignora `.migration-runs/` (snapshots com IDs de produção).

## 3. Decisões de segurança

- **Plataforma = `SUPER_ADMIN`, nunca `ADMIN`/`accessLevel:full`/plano ilimitado.** São conceitos distintos: *plano Fundador* = acesso comercial aos módulos; *SUPER_ADMIN* = autoridade global. O gate platform-only checa o role, não o full-access.
- **Defesa em camadas:** front esconde (sidebar) e redireciona (guard), mas a barreira real é o back (403 por SUPER_ADMIN). O guard retorna um loader e **não renderiza** a página protegida antes do redirect (nenhuma query da página dispara).
- **`isPlatformOnly` por prefixo normalizado** (remove query/hash/trailing slash) — cobre subrotas dinâmicas (`/admin/tenants/:id`) e query (`/admin/repasses?status=`). Testado, incluindo o caso-armadilha `/dashboard/marketing/campanhas` ≠ `/dashboard/market`.
- **`POST /api/v1/tenants` agora exige SUPER_ADMIN** (antes qualquer autenticado auto-criava tenant sem regra de plano). Criação legítima de parceiro é via checkout.
- **Campos financeiros do tenant** (`splitPercent`, `repasse*`) só editáveis por SUPER_ADMIN — um parceiro não reduz o próprio split.
- **Senhas individuais e aleatórias** por usuário (sem senha coletiva), impressas 1x, `mustChangePassword`. Usuário existente **não** tem senha sobrescrita.
- **`isBillingExempt` não usa `planPrice=0`** — usa flags explícitas (`plan.metadata.billingExempt`/`internal`, `tenant.settings.billingExempt`, `company.settings.billingExempt`), gravadas de forma coerente pelo provisionamento.
- **`settings` sempre por merge** (nunca sobrescreve JSON), com validação de objeto.

## 4. Resultado dos testes

Ambiente sem banco (não é possível rodar a migração aqui), então validei o testável:

- `pnpm db:generate` ✅ e `prisma validate` ✅ (schema íntegro).
- **API typecheck** ✅ nos arquivos alterados (0 erros novos).
- **Web typecheck** ✅ nos arquivos alterados (0 erros novos).
- **Script** — `tsc` isolado ✅ (nomes de modelo/campo Prisma resolvem), parseia e o preflight aborta sem `DATABASE_URL` ✅.
- **Testes de runtime dos helpers puros** (`isPlatformOnly`/`isPlatformAdmin`/`isBillingExempt`): 12 casos de rota + role + isenção, **todos passaram** (inclui `/dashboard/marketing/campanhas` corretamente = false).

## 5. Erros de typecheck pré-existentes que permaneceram (exatos)

Nenhum introduzido por este PR. Continuam (ambientais/pré-existentes):

**API**
```
src/plugins/automation.ts(53,56) TS2322   src/plugins/automation.ts(54,56) TS2322
src/plugins/automation.ts(55,56) TS2322   src/plugins/automation.ts(56,56) TS2322
src/plugins/automation.ts(57,56) TS2322   src/plugins/automation.ts(83,7)  TS2322
src/plugins/automation.ts(89,7)  TS2322   src/plugins/automation.ts(95,7)  TS2322
src/plugins/automation.ts(102,7) TS2322   src/plugins/automation.ts(109,7) TS2322
src/services/tomas.service.ts(14,40) TS2307
```
(automation.ts = skew de versão do ioredis no install; tomas.service.ts = pacote `@agoraencontrei/tomas-knowledge` não buildado.)

**Web**
```
src/app/(dashboard)/dashboard/contacts/page.tsx(75,5) TS2322
src/app/(dashboard)/dashboard/contacts/page.tsx(245,69) TS2345
src/app/(dashboard)/dashboard/financiamentos/page.tsx(175,5) TS2322
src/app/(dashboard)/dashboard/financiamentos/page.tsx(418,40) TS2345
src/app/(dashboard)/dashboard/properties/new/page.tsx(244,5) TS2322
src/app/(dashboard)/dashboard/properties/new/page.tsx(306,59) TS2345
src/app/(public)/SmartQuiz.tsx(253,7) TS2322
src/app/(public)/loteamentos/[slug]/page.tsx(3,47) TS2305
src/app/api/chat/stream/route.ts(2,40) TS2307
src/app/layout.tsx(9,8) TS2882
```

## 6. Instruções de deploy (ordem NÃO inverter)

1. **Backup** do banco (Neon snapshot/branch).
2. **Deploy do código** (API + Web). Confirme que **todas** as instâncias da API subiram — o boot agora só promove `tomas@agoraencontrei.com.br`.
3. Confirme o plano: `SELECT slug FROM plan_definitions WHERE slug='fundador';`
4. **Dry-run** (seção 7) e revise as contagens.
5. **Migração real** (seção 7).
6. **Reinicie a API**; confirme o gmail permanece `ADMIN`.
7. Peça à equipe **logout + login** (o script já revoga sessões/refresh tokens dos 9).

## 7. Instruções de dry-run

```bash
DATABASE_URL="<prod>" \
SOURCE_MODE=company \
SOURCE_COMPANY_ID="<id-da-empresa-de-origem>" \
npx tsx scripts/provision-imobiliaria-lemos.ts
```
`DRY_RUN` é o padrão (só `DRY_RUN=false` executa). Opcional: `EXPECTED_PROPERTY_COUNT=<n>` aborta se a seleção divergir. Execução real:
```bash
DATABASE_URL="<prod>" SOURCE_MODE=company SOURCE_COMPANY_ID="<id>" \
DRY_RUN=false CONFIRM_PRODUCTION_MIGRATION=IMOBILIARIA_LEMOS \
npx tsx scripts/provision-imobiliaria-lemos.ts
```
**Confirmei que `DRY_RUN=true` não grava absolutamente nada** — plano, empresa, tenant, usuários e revogação de sessões ficam atrás de `!DRY_RUN`; e o **snapshot também só é escrito na execução real** (dry-run não toca o disco).

## 8. Instruções de rollback

- Preferencial: **restaurar o backup** do banco.
- Alternativa: cada execução real grava `.migration-runs/lemos-provision-<stamp>.json` com o mapa **antes→depois**: usuários (`wasCompanyId`/`wasRole`), imóveis (`oldCompanyId`/`oldUserId`), contatos movidos (`oldCompanyId`) e owners mantidos.
- **Existe snapshot JSON, não um rollback executável automático.** A reversão é manual a partir do snapshot (ou via restore do backup). Posso adicionar um `--rollback <arquivo>` se desejarem.

## 9. Riscos conhecidos

- **Migração relacional é o maior risco.** Rode dry-run e, idealmente, teste antes numa **cópia do banco de produção**.
- **JWT antigo do gmail** pode conter `role: SUPER_ADMIN` até expirar (access 15 min / refresh 30 dias) — por isso o script revoga sessões e o runbook pede logout/login.
- Isolamento multi-tenant é **manual** por `companyId` em todo o código (fora do escopo deste PR auditar os 407 pontos).
- `POST /api/v1/tenants` restrito a SUPER_ADMIN: se algum fluxo legado dependia dele para self-service, precisará usar o checkout.
- `CriticalToast` tem um alvo `/dashboard/parceiros` para `plan_sale` (evento só de plataforma); coberto pelo guard.

## 10. O que foi deliberadamente NÃO migrado

O script move **apenas**: `Property` (companyId + userId) e os **contatos-proprietários** ligados a esses imóveis (via `PropertyOwner`), e **somente** os que não são compartilhados com imóveis fora da seleção.

**NÃO** move em massa (apenas **reporta** contagens no dry-run), para não arrastar dados alheios da empresa de origem (ex.: Univen/Noêmia):
- **Leads** e `LeadProperty`
- **Deals** e `DealProperty`
- **Contratos** (`Contract`), **Locações** (`Rental`) e **Transações** financeiras
- **Contatos/Clientes genéricos** sem imóvel associado
- `PortalConfig`, credenciais/integrações, webhooks, auditoria, configurações do site

Migrar a carteira operacional completa deve ser um **passo separado e revisado**, por relação com os imóveis migrados (nunca por `companyId` cego), em lotes, validado em cópia do banco. Posso implementar esse passo se aprovado.

---

### Verificações finais solicitadas (checklist)
- ✅ `DRY_RUN=true` não grava nada (nem plano/empresa/tenant/usuários/sessões/snapshot).
- ✅ Script revoga `Session` + `RefreshToken` dos usuários provisionados (inclui o gmail).
- ✅ Usuário existente não tem senha sobrescrita (salvo `RESET_EXISTING_PASSWORDS`).
- ✅ Senha coletiva removida — senhas aleatórias individuais + `mustChangePassword`.
- ✅ `SOURCE_COMPANY_ID` + `SOURCE_USER_EMAIL` usam **AND** (`SOURCE_MODE=company_and_user`), nunca OR.
- ✅ `EXPECTED_PROPERTY_COUNT` + `MAX_MOVE` abortam se a quantidade divergir/exceder.
- ✅ Detecção de colisão: subdomínio, canonical, e-mail (dup), slug e reference (seleção e destino) antes de gravar. CPF: não é escrito pelo script (N/A).
- ✅ Proprietários compartilhados entre imóveis migrados e não migrados **não** são movidos.
- ✅ Rollback guarda `oldCompanyId`/`oldUserId` (imóveis), empresa anterior (contatos), papéis/empresas anteriores (usuários) e owners mantidos.
- ℹ️ Rollback = **snapshot JSON** (reversão manual/por backup), não executável automático.
- ✅ Plano Fundador excluído de: catálogo público, checkout, MRR, churn, retenção, forecast. Inadimplência/comissões/afiliados: não aplicável à Lemos (sem assinatura Asaas, `splitPercent=0`, não é afiliado).
- ✅ `billingExempt` não considera `planPrice=0` — usa flags explícitas.
- ✅ Guard front não renderiza conteúdo protegido antes de redirecionar.
- ✅ Sidebar (desktop+mobile compartilham `NavContent`); nenhum link solto de plataforma fora dela (varredura feita).
- ✅ `POST /api/v1/tenants` agora exige SUPER_ADMIN.
- ✅ Regra escolhida do `meu-site`: **qualquer ADMIN/MANAGER da mesma empresa** edita o próprio tenant (os 4 admins da Lemos), com campos financeiros restritos a SUPER_ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_