### PR TITLE
Hardening de autenticação: staff/portal, OAuth, portal-login, tokens

### DIFF
--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -5,10 +5,12 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { env } from '../utils/env.js'
 
 export interface JwtPayload {
-  sub: string      // userId
+  sub: string      // userId (staff) — clientId no token de portal
   cid: string      // companyId
   role: string
   jti?: string
+  tv?: number      // tokenVersion — invalidação imediata (staff)
+  type?: string    // 'portal' quando é token de portal (proprietário/inquilino)
 }
 
 declare module '@fastify/jwt' {
@@ -21,6 +23,7 @@ declare module '@fastify/jwt' {
 declare module 'fastify' {
   interface FastifyInstance {
     authenticate: (req: FastifyRequest, reply: any) => Promise<void>
+    authenticatePortal: (req: FastifyRequest, reply: any) => Promise<void>
     optionalAuth: (req: FastifyRequest, reply: any) => Promise<void>
   }
 }
@@ -34,17 +37,67 @@ export default fp(async (app: FastifyInstance) => {
     sign: { expiresIn: env.JWT_ACCESS_EXPIRES },
   })
 
+  // ── Staff auth ─────────────────────────────────────────────────────────────
+  // Além de validar assinatura/expiração, agora:
+  //  (1) REJEITA tokens de portal (type:'portal') — eles NÃO podem acessar rotas
+  //      de staff (fechava confusão staff↔portal, já que ambos usam o mesmo
+  //      JWT_SECRET; um token de cliente tinha `cid` undefined e vazava queries).
+  //  (2) confirma que o usuário existe e está ACTIVE (suspenso/inativo perde acesso
+  //      imediatamente, não só no próximo login).
+  //  (3) confere `tv` (tokenVersion) contra o banco — troca de senha/role/suspensão
+  //      incrementam tokenVersion e invalidam os access tokens antigos na hora.
   app.decorate('authenticate', async (req: FastifyRequest, reply: any) => {
     try {
       await req.jwtVerify()
+      const u = req.user as JwtPayload
+      if (u?.type === 'portal') {
+        return reply.status(401).send({ error: 'UNAUTHORIZED', message: 'Portal token not allowed on staff routes' })
+      }
+      const prisma = (req.server as any).prisma
+      const dbUser = await prisma.user.findUnique({
+        where: { id: u.sub },
+        select: { status: true, tokenVersion: true },
+      })
+      if (!dbUser || dbUser.status !== 'ACTIVE') {
+        return reply.status(401).send({ error: 'UNAUTHORIZED', message: 'Account inactive or not found' })
+      }
+      if ((u.tv ?? 0) !== (dbUser.tokenVersion ?? 0)) {
+        return reply.status(401).send({ error: 'TOKEN_STALE', message: 'Session invalidated, please log in again' })
+      }
     } catch (err) {
       reply.status(401).send({ error: 'UNAUTHORIZED', message: 'Invalid or expired token' })
+    }
+  })
+
+  // ── Portal auth (proprietário/inquilino) ────────────────────────────────────
+  // Centraliza o guard antes duplicado em routes/portal. Exige type:'portal' e
+  // confirma que o Client ainda existe (token de 24h não vale para cliente
+  // removido). Anexa req.portalClient { id, companyId } para escopo por empresa.
+  app.decorate('authenticatePortal', async (req: FastifyRequest, reply: any) => {
+    try {
+      await req.jwtVerify()
+      const u = req.user as JwtPayload
+      if (u?.type !== 'portal') {
+        return reply.status(401).send({ error: 'UNAUTHORIZED', message: 'Portal token required' })
+      }
+      const prisma = (req.server as any).prisma
+      const client = await prisma.client.findUnique({ where: { id: u.sub }, select: { id: true, companyId: true } })
+      if (!client) {
+        return reply.status(401).send({ error: 'UNAUTHORIZED', message: 'Client not found' })
+      }
+      ;(req as any).portalClient = client
+    } catch {
+      return reply.status(401).send({ error: 'UNAUTHORIZED' })
     }
   })
 
   app.decorate('optionalAuth', async (req: FastifyRequest, _reply: any) => {
     try {
       await req.jwtVerify()
+      // Token de portal não deve virar "usuário staff" em rotas públicas.
+      if ((req.user as JwtPayload)?.type === 'portal') {
+        ;(req as any).user = undefined
+      }
     } catch {
       // silently ignore — user is unauthenticated
     }

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import { AuthService } from '../../services/auth.service.js'
+import { findActivePortalContract } from '../../services/portal-auth.service.js'
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
 
@@ -301,11 +302,10 @@ export default async function authRoutes(app: FastifyInstance) {
 
     const cl = matches[0]
 
-    // Contrato ativo do cliente (para o resumo do portal).
-    const contract = await app.prisma.contract.findFirst({
-      where: { isActive: true, OR: [{ tenantId: cl.id }, { landlordId: cl.id }] },
-      select: { id: true, status: true, rentValue: true, propertyAddress: true, startDate: true },
-    }).catch(() => null)
+    // Contrato ativo do cliente (para o resumo do portal). SEMPRE escopado à
+    // empresa do cliente (companyId do tenant/cliente resolvido, nunca do body):
+    // um cliente da empresa A jamais recebe contrato da empresa B.
+    const contract = await findActivePortalContract(app.prisma, { id: cl.id, companyId: cl.companyId }).catch(() => null)
 
     // Token de portal — agora carrega `cid` (companyId) para escopo tenant a jusante.
     const token = app.jwt.sign(

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -242,7 +242,7 @@ export default async function authRoutes(app: FastifyInstance) {
   app.post('/portal-login', {
     config: { rateLimit: { max: 10, timeWindow: '15 minutes' } },
   }, async (req, reply) => {
-    const { cpf, birthDate } = req.body as { cpf?: string; birthDate?: string }
+    const { cpf, birthDate, subdomain } = req.body as { cpf?: string; birthDate?: string; subdomain?: string }
 
     if (!cpf || !birthDate) {
       return reply.status(400).send({ error: 'MISSING_FIELDS', message: 'CPF e data de nascimento são obrigatórios' })
@@ -256,41 +256,71 @@ export default async function authRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: 'INVALID_CPF', message: 'CPF deve ter 11 dígitos' })
     }
 
-    // Look up client by CPF (document field) — using parameterized query
-    const client = await app.prisma.$queryRaw<any[]>`
-      SELECT c.id, c.name, c.document, c."birthDate", c.email, c.phone, c.roles,
-              co."landlordName", co."tenantName", co.id as "contractId", co.status as "contractStatus",
-              co."rentValue", co."propertyAddress", co."startDate"
-       FROM clients c
-       LEFT JOIN contracts co ON (co."tenantId" = c.id OR co."landlordId" = c.id) AND co."isActive" = true
-       WHERE c.document = ${cpfNorm}
-       LIMIT 1`
+    // Normaliza a data informada (aceita YYYY-MM-DD ou DD/MM/YYYY).
+    const inputDate = birthDate.trim()
+    const normalizedInput = inputDate.includes('/') ? inputDate.split('/').reverse().join('-') : inputDate
 
-    if (!client.length) {
-      // Generic error message to prevent CPF enumeration
+    // Escopo por empresa: o portal é servido no subdomínio do parceiro. Quando o
+    // front envia `subdomain`, resolvemos a company e filtramos por ela — isto
+    // FECHA a colisão de CPF cross-tenant (Client.document é único só por empresa,
+    // então o mesmo CPF pode existir em várias imobiliárias).
+    let scopedCompanyId: string | null = null
+    if (subdomain && /^[a-z0-9-]{2,}$/i.test(subdomain)) {
+      const tenant = await app.prisma.tenant.findUnique({
+        where: { subdomain: subdomain.toLowerCase() }, select: { companyId: true },
+      }).catch(() => null)
+      scopedCompanyId = tenant?.companyId ?? null
+    }
+
+    // Candidatos por CPF (+ empresa, se conhecida). NUNCA LIMIT 1 sem escopo.
+    const candidates = await app.prisma.client.findMany({
+      where: { document: cpfNorm, ...(scopedCompanyId ? { companyId: scopedCompanyId } : {}) },
+      select: { id: true, name: true, companyId: true, birthDate: true, email: true, phone: true, roles: true },
+    })
+
+    // Exige birthDate cadastrada E igual à informada — registros sem data de
+    // nascimento NÃO logam (antes o check era pulado se birthDate fosse null).
+    const matches = candidates.filter(c =>
+      c.birthDate && new Date(c.birthDate).toISOString().split('T')[0] === normalizedInput,
+    )
+
+    if (matches.length === 0) {
+      // Mensagem genérica p/ não permitir enumeração de CPF.
       return reply.status(401).send({ error: 'INVALID_CREDENTIALS', message: 'CPF ou data de nascimento incorretos' })
     }
-
-    const cl = client[0]
-
-    // Verify birthdate
-    if (cl.birthDate) {
-      const dbDate = new Date(cl.birthDate).toISOString().split('T')[0]
-      const inputDate = birthDate.trim()
-      // Accept YYYY-MM-DD or DD/MM/YYYY
-      const normalizedInput = inputDate.includes('/')
-        ? inputDate.split('/').reverse().join('-')
-        : inputDate
-      if (dbDate !== normalizedInput) {
-        return reply.status(401).send({ error: 'INVALID_CREDENTIALS', message: 'CPF ou data de nascimento incorretos' })
-      }
+    // Ambiguidade cross-tenant: o mesmo CPF+nascimento existe em >1 empresa e o
+    // front não informou o subdomínio. NÃO escolhemos arbitrariamente — pedimos
+    // para acessar pelo site da imobiliária (que envia o subdomínio).
+    const distinctCompanies = [...new Set(matches.map(m => m.companyId))]
+    if (distinctCompanies.length > 1) {
+      return reply.status(409).send({
+        error: 'AMBIGUOUS_CLIENT',
+        message: 'Encontramos seu cadastro em mais de uma imobiliária. Acesse pelo site da sua imobiliária.',
+      })
     }
 
-    // Return portal token (simple JWT)
+    const cl = matches[0]
+
+    // Contrato ativo do cliente (para o resumo do portal).
+    const contract = await app.prisma.contract.findFirst({
+      where: { isActive: true, OR: [{ tenantId: cl.id }, { landlordId: cl.id }] },
+      select: { id: true, status: true, rentValue: true, propertyAddress: true, startDate: true },
+    }).catch(() => null)
+
+    // Token de portal — agora carrega `cid` (companyId) para escopo tenant a jusante.
     const token = app.jwt.sign(
-      { sub: cl.id, name: cl.name, type: 'portal', roles: cl.roles || [] } as any,
+      { sub: cl.id, cid: cl.companyId, name: cl.name, type: 'portal', roles: cl.roles || [] } as any,
       { expiresIn: '24h' }
     )
+
+    // Auditoria (antes o portal-login não deixava rastro de acesso).
+    await app.prisma.auditLog.create({
+      data: {
+        companyId: cl.companyId, userId: cl.id, action: 'portal.login',
+        resource: 'client', resourceId: cl.id,
+        ipAddress: req.ip, payload: { cpf: cpfNorm, scoped: !!scopedCompanyId } as any,
+      },
+    }).catch(() => {})
 
     return reply.send({
       accessToken: token,
@@ -302,12 +332,12 @@ export default async function authRoutes(app: FastifyInstance) {
         email: cl.email,
         phone: cl.phone,
         roles: cl.roles,
-        contract: cl.contractId ? {
-          id: cl.contractId,
-          status: cl.contractStatus,
-          rentValue: cl.rentValue,
-          propertyAddress: cl.propertyAddress,
-          startDate: cl.startDate,
+        contract: contract ? {
+          id: contract.id,
+          status: contract.status,
+          rentValue: contract.rentValue,
+          propertyAddress: contract.propertyAddress,
+          startDate: contract.startDate,
         } : null,
       },
     })

--- a/apps/api/src/routes/portal/index.ts
+++ b/apps/api/src/routes/portal/index.ts
@@ -5,17 +5,9 @@ import type { FastifyInstance } from 'fastify'
  * Token has type='portal' and sub=clientId
  */
 export default async function portalRoutes(app: FastifyInstance) {
-  // Auth guard for portal tokens
-  const portalAuth = async (req: any, reply: any) => {
-    try {
-      await req.jwtVerify()
-      if (req.user?.type !== 'portal') {
-        return reply.status(401).send({ error: 'INVALID_TOKEN' })
-      }
-    } catch {
-      return reply.status(401).send({ error: 'UNAUTHORIZED' })
-    }
-  }
+  // Guard centralizado (plugins/jwt.ts): exige type:'portal' e confirma que o
+  // Client ainda existe; anexa req.portalClient { id, companyId }.
+  const portalAuth = app.authenticatePortal
 
   // GET /api/v1/portal/dashboard — summary for the logged-in client
   app.get('/dashboard', { preHandler: [portalAuth] }, async (req: any, reply) => {

--- a/apps/api/src/routes/users/index.ts
+++ b/apps/api/src/routes/users/index.ts
@@ -434,6 +434,13 @@ export default async function usersRoutes(app: FastifyInstance) {
       updateData.settings = newSettings
     }
 
+    // Mudança de role/status/empresa invalida IMEDIATAMENTE os access tokens
+    // antigos do usuário (bump de tokenVersion): um usuário rebaixado/suspenso/
+    // movido não continua com o token elevado por até 15 min.
+    if (updateData.role !== undefined || updateData.status !== undefined || updateData.companyId !== undefined) {
+      updateData.tokenVersion = { increment: 1 }
+    }
+
     const user = await app.prisma.user.update({
       where: { id },
       data: updateData,
@@ -486,8 +493,11 @@ export default async function usersRoutes(app: FastifyInstance) {
 
     await app.prisma.user.update({
       where: { id },
-      data: { passwordHash },
+      // Bump tokenVersion → derruba sessões/access tokens antigos do alvo na hora.
+      data: { passwordHash, tokenVersion: { increment: 1 } },
     })
+    // Revoga refresh tokens do alvo também.
+    await app.prisma.refreshToken.deleteMany({ where: { userId: id } }).catch(() => {})
 
     await createAuditLog({
       prisma: app.prisma, req,
@@ -514,8 +524,10 @@ export default async function usersRoutes(app: FastifyInstance) {
 
     await app.prisma.user.update({
       where: { id, companyId: req.user.cid },
-      data: { status: 'INACTIVE' },
+      // Desativa e invalida imediatamente os tokens (tokenVersion + refresh).
+      data: { status: 'INACTIVE', tokenVersion: { increment: 1 } },
     })
+    await app.prisma.refreshToken.deleteMany({ where: { userId: id } }).catch(() => {})
 
     await createAuditLog({
       prisma: app.prisma, req,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1256,6 +1256,12 @@ async function runMigrations(prisma: any) {
     // Postgres). Índice único idempotente.
     `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "cpf" TEXT`,
     `CREATE UNIQUE INDEX IF NOT EXISTS "users_cpf_key" ON "users"("cpf")`,
+
+    // ── Auth hardening ────────────────────────────────────────────────────────
+    // tokenVersion: invalidação imediata de access tokens (suspend/role/senha).
+    // Índice de family: reuse-detection/logout fazem deleteMany por family.
+    `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "tokenVersion" INTEGER NOT NULL DEFAULT 0`,
+    `CREATE INDEX IF NOT EXISTS "refresh_tokens_family_idx" ON "refresh_tokens"("family")`,
   ]
   for (const sql of recentMigrations) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -281,6 +281,13 @@ export class AuthService {
       throw Object.assign(new Error('Refresh token expirado'), { statusCode: 401, code: 'REFRESH_TOKEN_EXPIRED' })
     }
 
+    // Recheca o estado do usuário: suspenso/inativo não renova (antes um usuário
+    // suspenso mantinha acesso renovando o refresh por até 30 dias).
+    if (stored.user.status !== 'ACTIVE') {
+      await this.prisma.refreshToken.deleteMany({ where: { family: stored.family } })
+      throw Object.assign(new Error('Conta inativa'), { statusCode: 403, code: 'ACCOUNT_INACTIVE' })
+    }
+
     // Mark as used
     await this.prisma.refreshToken.update({ where: { id: stored.id }, data: { usedAt: new Date() } })
 
@@ -333,6 +340,11 @@ export class AuthService {
     if (!payload?.sub || !payload?.email) {
       throw Object.assign(new Error('Token Google inválido'), { statusCode: 401, code: 'INVALID_GOOGLE_TOKEN' })
     }
+    // Exige e-mail verificado pelo Google — o vínculo por e-mail (abaixo) a uma
+    // conta existente seria account-takeover se o e-mail não fosse verificado.
+    if (payload.email_verified === false) {
+      throw Object.assign(new Error('E-mail Google não verificado'), { statusCode: 401, code: 'GOOGLE_EMAIL_NOT_VERIFIED' })
+    }
 
     const { sub: googleId, email, name, picture } = payload
 
@@ -353,9 +365,14 @@ export class AuthService {
           update: {},
         })
       } else {
-        // Create new user + company
-        const company = await this.prisma.company.findFirst({ where: { isActive: true } })
-          ?? await this.prisma.company.create({ data: { name: (name ?? email) + ' Imobiliária' } })
+        // SEGURANÇA (multi-tenant): usuário novo via Google SEMPRE ganha uma
+        // empresa NOVA — mesma invariante do register(). Antes usava
+        // `company.findFirst({ isActive:true })` (sem orderBy), que prendia o
+        // novo usuário na PRIMEIRA empresa ativa do banco e o criava como ADMIN
+        // dela (escalonamento de privilégio cross-tenant).
+        const company = await this.prisma.company.create({
+          data: { name: (name ?? email) + ' Imobiliária' },
+        })
 
         user = await this.prisma.user.create({
           data: {
@@ -417,7 +434,12 @@ export class AuthService {
     }
 
     const newHash = await argon2.hash(newPassword, { type: argon2.argon2id })
-    await this.prisma.user.update({ where: { id: userId }, data: { passwordHash: newHash } })
+    // Incrementa tokenVersion → invalida IMEDIATAMENTE todos os access tokens
+    // antigos (não só os refresh). Sem isso, um token roubado seguia válido 15min.
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { passwordHash: newHash, tokenVersion: { increment: 1 } },
+    })
 
     // Revoke all refresh tokens
     await this.prisma.refreshToken.deleteMany({ where: { userId } })
@@ -430,6 +452,7 @@ export class AuthService {
       sub: user.id,
       cid: companyId,
       role: user.role,
+      tv: (user as any).tokenVersion ?? 0,
     }
 
     const accessToken = this.app.jwt.sign(payload, { expiresIn: env.JWT_ACCESS_EXPIRES })

--- a/apps/api/src/services/portal-auth.service.ts
+++ b/apps/api/src/services/portal-auth.service.ts
@@ -1,0 +1,35 @@
+import type { PrismaClient } from '@prisma/client'
+
+export interface PortalClientRef {
+  id: string
+  companyId: string
+}
+
+export interface PortalContract {
+  id: string
+  status: string
+  rentValue: unknown
+  propertyAddress: string | null
+  startDate: Date | null
+}
+
+/**
+ * Busca o contrato ATIVO do cliente do portal, SEMPRE escopado à empresa do
+ * cliente. O `companyId` vem exclusivamente do cliente/tenant resolvido no
+ * login (subdomínio) — NUNCA de dados do body. Assim um cliente da empresa A
+ * jamais recebe um contrato da empresa B, mesmo que exista um contrato de outra
+ * empresa cujo `tenantId`/`landlordId` coincida com o id do cliente.
+ */
+export async function findActivePortalContract(
+  prisma: Pick<PrismaClient, 'contract'>,
+  client: PortalClientRef,
+): Promise<PortalContract | null> {
+  return (prisma as any).contract.findFirst({
+    where: {
+      companyId: client.companyId,
+      isActive: true,
+      OR: [{ tenantId: client.id }, { landlordId: client.id }],
+    },
+    select: { id: true, status: true, rentValue: true, propertyAddress: true, startDate: true },
+  })
+}

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -123,7 +123,31 @@ const envSchema = z.object({
   ADMIN_RESET_TOKEN: z.string().min(32).optional(),
 })
 
+// Placeholders de dev — NUNCA podem ser aceitos como segredo real em produção.
+const PLACEHOLDER_SECRETS = new Set([
+  'development-jwt-secret-placeholder-min-32-chars!!',
+  'development-cookie-secret-placeholder-32-chars!',
+])
+
+function assertNoPlaceholderSecretInProd() {
+  if (process.env.NODE_ENV !== 'production') return
+  const offenders = ['JWT_SECRET', 'COOKIE_SECRET'].filter(
+    (k) => process.env[k] && PLACEHOLDER_SECRETS.has(process.env[k] as string),
+  )
+  if (offenders.length) {
+    console.error('❌ FATAL: production boot refused — placeholder secret detected:')
+    offenders.forEach((k) => console.error(`  ${k} está usando o valor placeholder de desenvolvimento.`))
+    console.error('Defina segredos reais (>=32 chars) para JWT_SECRET e COOKIE_SECRET.')
+    process.exit(1)
+  }
+}
+
 function parseEnv() {
+  // Mesmo quando o schema valida (segredo com >=32 chars), recusa boot em produção
+  // se o valor for o placeholder de dev — senão qualquer um que conheça o
+  // placeholder forjaria tokens.
+  assertNoPlaceholderSecretInProd()
+
   const result = envSchema.safeParse(process.env)
   if (result.success) return result.data
 

--- a/apps/api/test/portal-contract-scope.test.ts
+++ b/apps/api/test/portal-contract-scope.test.ts
@@ -1,0 +1,85 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { findActivePortalContract } from '../src/services/portal-auth.service.js'
+
+/**
+ * Mock mínimo do Prisma cujo `contract.findFirst` aplica a semântica do `where`
+ * de forma genérica (igualdade para chaves escalares; `OR` = qualquer condição).
+ * Se o código deixar de escopar por `companyId`, um contrato de outra empresa
+ * "vazaria" aqui e os testes de isolamento falham — exatamente o que queremos.
+ */
+function mockPrisma(contracts: any[]) {
+  const matchesWhere = (row: any, where: any): boolean => {
+    for (const [k, v] of Object.entries(where)) {
+      if (k === 'OR') {
+        const ok = (v as any[]).some((cond) =>
+          Object.entries(cond).every(([kk, vv]) => row[kk] === vv),
+        )
+        if (!ok) return false
+      } else if (row[k] !== v) {
+        return false
+      }
+    }
+    return true
+  }
+  return {
+    contract: {
+      findFirst: async ({ where }: any) => contracts.find((c) => matchesWhere(c, where)) ?? null,
+    },
+  } as any
+}
+
+const clientA = { id: 'cli-1', companyId: 'empresa-A' }
+
+test('portal: cliente da empresa A NÃO recebe contrato da empresa B', async () => {
+  const prisma = mockPrisma([
+    // Contrato da empresa B cujo tenantId coincide com o id do cliente A.
+    { id: 'k-B', companyId: 'empresa-B', isActive: true, tenantId: 'cli-1', landlordId: null },
+    // Contrato correto, da empresa A.
+    { id: 'k-A', companyId: 'empresa-A', isActive: true, tenantId: 'cli-1', landlordId: null },
+  ])
+  const contract = await findActivePortalContract(prisma, clientA)
+  assert.ok(contract, 'deveria retornar um contrato')
+  assert.equal(contract!.id, 'k-A')
+})
+
+test('portal: contrato com tenantId/landlordId correspondente mas companyId diferente é ignorado', async () => {
+  const prisma = mockPrisma([
+    { id: 'k-B', companyId: 'empresa-B', isActive: true, tenantId: 'cli-1', landlordId: 'cli-1' },
+  ])
+  const contract = await findActivePortalContract(prisma, clientA)
+  assert.equal(contract, null)
+})
+
+test('portal: o contrato retornado sempre pertence à mesma company do cliente/tenant', async () => {
+  const prisma = mockPrisma([
+    { id: 'k-A', companyId: 'empresa-A', isActive: true, tenantId: null, landlordId: 'cli-1' },
+    { id: 'k-B', companyId: 'empresa-B', isActive: true, tenantId: null, landlordId: 'cli-1' },
+  ])
+  const contract = await findActivePortalContract(prisma, clientA)
+  assert.ok(contract)
+  // A empresa do contrato precisa bater com a do cliente (validado pelo where).
+  const chosen = [
+    { id: 'k-A', companyId: 'empresa-A' },
+    { id: 'k-B', companyId: 'empresa-B' },
+  ].find((c) => c.id === contract!.id)!
+  assert.equal(chosen.companyId, clientA.companyId)
+})
+
+test('portal: cliente sem contrato ATIVO continua autenticando, mas contract = null', async () => {
+  const prisma = mockPrisma([
+    // Existe contrato da empresa certa, mas inativo → não conta.
+    { id: 'k-A', companyId: 'empresa-A', isActive: false, tenantId: 'cli-1', landlordId: null },
+  ])
+  const contract = await findActivePortalContract(prisma, clientA)
+  assert.equal(contract, null)
+})
+
+test('portal: encontra por landlordId quando o cliente é o proprietário', async () => {
+  const prisma = mockPrisma([
+    { id: 'k-A', companyId: 'empresa-A', isActive: true, tenantId: 'outro', landlordId: 'cli-1' },
+  ])
+  const contract = await findActivePortalContract(prisma, clientA)
+  assert.ok(contract)
+  assert.equal(contract!.id, 'k-A')
+})

--- a/apps/web/src/app/(portal)/portal/login/page.tsx
+++ b/apps/web/src/app/(portal)/portal/login/page.tsx
@@ -32,11 +32,24 @@ export default function PortalLoginPage() {
 
     const rawCpf = cpf.replace(/\D/g, '')
 
+    // O portal é servido no subdomínio da imobiliária (ex.: lemos.agoraencontrei.com.br).
+    // Enviamos o subdomínio para o backend escopar o login por empresa e evitar
+    // colisão de CPF entre imobiliárias. Custom domains / localhost → sem escopo.
+    let subdomain: string | undefined
+    if (typeof window !== 'undefined') {
+      const host = window.location.hostname
+      const reserved = new Set(['www', 'app', 'api', 'admin', 'localhost'])
+      if (host.endsWith('.agoraencontrei.com.br')) {
+        const label = host.split('.')[0]
+        if (label && !reserved.has(label)) subdomain = label
+      }
+    }
+
     try {
       const res = await fetch(`${API_URL}/api/v1/auth/portal-login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cpf: rawCpf, birthDate }),
+        body: JSON.stringify({ cpf: rawCpf, birthDate, ...(subdomain ? { subdomain } : {}) }),
       })
 
       if (res.status === 404) {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -188,6 +188,10 @@ model User {
   settings          Json        @default("{}")
   emailVerifiedAt   DateTime?
   lastLoginAt       DateTime?
+  // Invalidação imediata de access tokens: incrementado ao suspender/inativar,
+  // mudar role ou trocar senha. O JWT carrega o valor no claim `tv`; o
+  // authenticate rejeita tokens cujo `tv` diverge do valor atual no banco.
+  tokenVersion      Int         @default(0)
   createdAt         DateTime    @default(now())
   updatedAt         DateTime    @updatedAt
 
@@ -238,6 +242,7 @@ model RefreshToken {
 
   @@index([userId])
   @@index([token])
+  @@index([family])
   @@map("refresh_tokens")
 }
 


### PR DESCRIPTION
> ⚠️ **Não fazer merge automático.** PR de segurança, separado do PR #265 (Lemos) — não há sobreposição de arquivos.

## Contexto

Endurecimento dos fluxos de autenticação após auditoria. Corrige fraquezas exploráveis (algumas críticas de multi-tenant) sem quebrar os fluxos existentes (mudanças backward-compatible).

## Fraquezas corrigidas

**1. Confusão de token staff × portal (CRÍTICO)** — `plugins/jwt.ts`
Staff e portal usam o mesmo `JWT_SECRET`; o `authenticate` não rejeitava tokens de portal, então um token de cliente (com `cid` undefined) era aceito em ~147 rotas de staff. Agora `authenticate` **rejeita `type:'portal'`**. Novo `authenticatePortal` centralizado (exige `type:'portal'` + confirma que o `Client` existe; anexa `req.portalClient`). `optionalAuth` descarta token portal.

**2. Cross-tenant no portal-login (CRÍTICO)** — `routes/auth/index.ts`
A busca era `$queryRaw ... WHERE document = cpf LIMIT 1` **sem `companyId`**. Como `Client.document` é único só por empresa, o mesmo CPF podia casar cliente de **outra imobiliária** (acesso a PII/financeiro de terceiros). Agora:
- consulta Prisma **escopada por empresa** (subdomínio → tenant → `companyId`);
- exige `birthDate` cadastrada e igual (antes pulava o 2º fator se fosse null);
- bloqueia ambiguidade cross-tenant (`409`);
- embute `cid` no token portal e grava `auditLog`;
- **contrato do resumo escopado por `companyId` do cliente** (fix desta última revisão) — extraído para `services/portal-auth.service.ts` e coberto por testes.
- front do portal envia o subdomínio (lido do hostname).

**3. Google OAuth novo usuário vira ADMIN de empresa alheia (CRÍTICO)** — `auth.service.ts`
Usuário novo era vinculado a `company.findFirst({isActive:true})` (sem `orderBy`) como `ADMIN` — escalonamento cross-tenant. Agora **cria empresa nova** (invariante do `register`) e exige `email_verified`.

**4. Access token sem invalidação imediata (ALTO)** — `schema.prisma` + `server.ts` + `auth.service.ts` + `users`
`authenticate` só validava assinatura/expiração; suspenso/rebaixado/senha-trocada mantinha acesso até 15 min (e renovava por 30 dias). Adicionado `User.tokenVersion` + claim `tv`; `authenticate` valida **status ACTIVE + tokenVersion** contra o banco. Bump de `tokenVersion` em: troca de senha (self e reset admin), mudança de role/status/empresa, desativação. Refresh **recheca status** (suspenso não renova).

**5. Perf/hygiene** — `@@index([family])` em RefreshToken (reuse-detection/logout fazem `deleteMany` por family); `env.ts` recusa boot em produção com segredo placeholder.

## Arquivos alterados
- Novo: `apps/api/src/services/portal-auth.service.ts`, `apps/api/test/portal-contract-scope.test.ts`
- Editado: `apps/api/src/plugins/jwt.ts`, `apps/api/src/routes/auth/index.ts`, `apps/api/src/routes/portal/index.ts`, `apps/api/src/routes/users/index.ts`, `apps/api/src/services/auth.service.ts`, `apps/api/src/server.ts`, `apps/api/src/utils/env.ts`, `packages/database/prisma/schema.prisma`, `apps/web/src/app/(portal)/portal/login/page.tsx`

## Testes executados
- ✅ `prisma generate` + `prisma validate` (schema válido).
- ✅ API typecheck: 0 erros novos (permanecem só os 10 pré-existentes de `plugins/automation.ts`, skew do ioredis).
- ✅ `verify:boot`: **98 módulos de rota linkam**.
- ✅ Unit tests: **33 pass / 0 fail** (28 existentes + 5 novos de escopo de contrato do portal).
- ✅ Web typecheck: portal sem erros.

## Nota de deploy
Migração aditiva idempotente no boot (`users.tokenVersion` via `ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS refresh_tokens_family_idx`), no mesmo padrão do `runMigrations`. O claim `tv` é backward-compatible (token sem `tv` = 0; usuários novos default 0), então tokens atuais seguem válidos até o primeiro bump. Após deploy, mudanças de role/senha/suspensão passam a invalidar na hora.

## Riscos conhecidos
- `authenticate` agora faz +1 consulta indexada por PK por request (status/tokenVersion) — barato em rotas de dashboard; pode-se cachear em Redis depois.
- Refresh token ainda retorna no body (o front depende dele) — migração cookie-only fica como passo faseado.
- portal-login sem subdomínio (custom domain/legado) cai no tratamento de ambiguidade; recomenda-se o portal sempre enviar o subdomínio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_