### PR TITLE
feat(tomas): dois cérebros separados (marketplace público × parceiro privado) — fases 1-2

### DIFF
--- a/apps/api/src/routes/tomas/index.ts
+++ b/apps/api/src/routes/tomas/index.ts
@@ -14,6 +14,7 @@ import {
   type TomasMessage,
   type TomasChatParams,
 } from '../../services/tomas.service.js'
+import { findTenantByHost } from '../../services/tenant.service.js'
 
 export default async function tomasRoutes(app: FastifyInstance) {
   // ── POST /chat — Conversa com o Tomás ──────────────────────────────────
@@ -41,6 +42,10 @@ export default async function tomasRoutes(app: FastifyInstance) {
           visitorId: { type: 'string' },
           nicheSlug: { type: 'string' },
           tenantTheme: { type: 'string' },
+          // Slug/subdomínio do parceiro (site white-label). Resolvido
+          // SERVER-SIDE para o companyId — nunca confiamos num companyId vindo
+          // do cliente. Faz o visitante público falar com o cérebro do parceiro.
+          tenantSlug: { type: 'string' },
           propertyContext: {
             type: 'object',
             properties: {
@@ -64,6 +69,7 @@ export default async function tomasRoutes(app: FastifyInstance) {
       visitorId?: string
       nicheSlug?: string
       tenantTheme?: string
+      tenantSlug?: string
       propertyContext?: TomasChatParams['propertyContext']
     }
 
@@ -80,6 +86,25 @@ export default async function tomasRoutes(app: FastifyInstance) {
     }
 
     const channel = (body.channel || 'site') as 'site' | 'dashboard'
+
+    // Ingress do site público do parceiro: um visitante ANÔNIMO no site
+    // white-label de um parceiro (subdomínio) conversa com o cérebro DAQUELE
+    // parceiro (modo público). O companyId vem de um lookup SERVER-SIDE do slug
+    // — nunca aceitamos um companyId do cliente. Se o visitante já está
+    // autenticado, o companyId do JWT prevalece (não deixa o cliente trocar).
+    if (!companyId && channel === 'site' && typeof body.tenantSlug === 'string') {
+      const slug = body.tenantSlug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '')
+      if (slug) {
+        try {
+          const tenant = await findTenantByHost(app.prisma, slug)
+          if (tenant?.companyId && tenant.isActive !== false && tenant.planStatus !== 'SUSPENDED') {
+            companyId = tenant.companyId as string
+          }
+        } catch {
+          // Slug inválido/indisponível — segue como marketplace público.
+        }
+      }
+    }
 
     // Dashboard mode requires authentication
     if (channel === 'dashboard' && !userId) {

--- a/apps/api/src/services/tomas.service.ts
+++ b/apps/api/src/services/tomas.service.ts
@@ -11,7 +11,11 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import type { PrismaClient, Prisma } from '@prisma/client'
-import { buildTomasSystemPrompt } from '@agoraencontrei/tomas-knowledge'
+import {
+  buildMarketplaceSystemPrompt,
+  buildPartnerSystemPrompt,
+  type PartnerContext,
+} from '@agoraencontrei/tomas-knowledge'
 import { env } from '../utils/env.js'
 import { notify } from './notification.service.js'
 import { checkAIQuota } from './plan-gating.service.js'
@@ -84,11 +88,13 @@ export interface TomasChatParams {
 // ── System Prompt — built from @agoraencontrei/tomas-knowledge ─────────────
 
 /**
- * Prompt base do Tomás — vem de @agoraencontrei/tomas-knowledge (constantes TS).
- * Esta é a ÚNICA source-of-truth; o Fastify só adiciona a camada operacional
- * (tool-use, Hunter Mode, formato JSON) abaixo.
+ * Prompt base do cérebro MARKETPLACE (público/nacional/imparcial) — vem de
+ * @agoraencontrei/tomas-knowledge. É computado uma vez; o cérebro PARTNER
+ * (privado, por empresa) é montado por request em `buildPartnerSystemPromptFull`
+ * porque depende dos dados do parceiro. O Fastify só adiciona a camada
+ * operacional (tool-use, Hunter Mode, formato JSON) abaixo — comum aos dois.
  */
-const TOMAS_KNOWLEDGE_BASE = buildTomasSystemPrompt()
+const TOMAS_KNOWLEDGE_BASE = buildMarketplaceSystemPrompt()
 
 const TOMAS_OPERATIONAL_ADDENDUM = `
 ═══════════════════════════════════════════════════════
@@ -147,7 +153,42 @@ REGRAS DURAS PARA SHORTLIST E ACTIONS (NÃO QUEBRE):
 - Se shortlist vazia, use []. Se não houver ações, use []. Se não houver atualização de lead, omita leadUpdate.
 `
 
-const TOMAS_SYSTEM_PROMPT = `${TOMAS_KNOWLEDGE_BASE}\n${TOMAS_OPERATIONAL_ADDENDUM}`
+// Cérebro MARKETPLACE completo (base pública + camada operacional).
+const MARKETPLACE_SYSTEM_PROMPT = `${TOMAS_KNOWLEDGE_BASE}\n${TOMAS_OPERATIONAL_ADDENDUM}`
+
+// Cérebro PARTNER completo — a base depende da empresa, então é montada por
+// request; a camada operacional (Hunter Mode, formato JSON) é a mesma.
+function buildPartnerSystemPromptFull(partner: PartnerContext): string {
+  return `${buildPartnerSystemPrompt(partner)}\n${TOMAS_OPERATIONAL_ADDENDUM}`
+}
+
+/**
+ * Resolve o contexto do parceiro (para o prompt do cérebro PARTNER) e detecta
+ * se a empresa é a PLATAFORMA AgoraEncontrei — nesse caso o operador usa o
+ * cérebro marketplace/plataforma (com Master Intelligence global), enquanto um
+ * parceiro comum (ex.: Lemos) NUNCA recebe dados globais da plataforma.
+ */
+async function resolveCompanyBrain(
+  prisma: PrismaClient,
+  companyId: string,
+): Promise<{ partner: PartnerContext; isPlatform: boolean }> {
+  try {
+    const c = await prisma.company.findUnique({
+      where: { id: companyId },
+      select: { name: true, settings: true },
+    })
+    const name = c?.name?.trim() || 'a imobiliária'
+    const settings = (c?.settings ?? {}) as Record<string, unknown>
+    const canonical = typeof settings.canonical === 'string' ? settings.canonical.toLowerCase() : ''
+    const isPlatform = canonical === 'agoraencontrei-platform' || /^agora\s*encontrei$/i.test(name)
+    const isLemos = canonical === 'imobiliaria-lemos' || /lemos/i.test(name)
+    const city = (typeof settings.city === 'string' && settings.city) || (isLemos ? 'Franca/SP' : undefined)
+    const since = (typeof settings.since === 'string' && settings.since) || (isLemos ? '2002' : undefined)
+    return { partner: { name, city, since, isLemos }, isPlatform }
+  } catch {
+    return { partner: { name: 'a imobiliária' }, isPlatform: false }
+  }
+}
 
 const DASHBOARD_ADDENDUM = `
 MODO DASHBOARD (Copilot Interno):
@@ -586,13 +627,28 @@ export async function runTomasChat(
 
   const client = new Anthropic({ apiKey })
 
-  // Build system prompt
-  let systemPrompt = TOMAS_SYSTEM_PROMPT
+  // ── Seleção do CÉREBRO ──────────────────────────────────────────────────
+  // Sem companyId → cérebro MARKETPLACE (público/nacional/imparcial).
+  // Com companyId → cérebro PARTNER (privado, marca e dados do parceiro),
+  // exceto quando a empresa é a própria PLATAFORMA AgoraEncontrei — aí o
+  // operador usa o cérebro marketplace/plataforma.
+  let systemPrompt: string
+  let isPlatformOperator = false
+  if (params.companyId) {
+    const { partner, isPlatform } = await resolveCompanyBrain(prisma, params.companyId)
+    isPlatformOperator = isPlatform
+    systemPrompt = isPlatform ? MARKETPLACE_SYSTEM_PROMPT : buildPartnerSystemPromptFull(partner)
+  } else {
+    systemPrompt = MARKETPLACE_SYSTEM_PROMPT
+  }
+
   if (params.channel === 'dashboard') {
     systemPrompt += DASHBOARD_ADDENDUM
 
-    // Inject Master Intelligence for Advisor Mode
-    try {
+    // Master Intelligence é GLOBAL da plataforma (receita/MRR/churn de TODAS as
+    // empresas). Só o operador da plataforma pode vê-lo — um parceiro (ex.:
+    // Lemos) NUNCA recebe dados agregados da plataforma no seu cérebro.
+    if (isPlatformOperator) try {
       const { buildMasterIntelligence } = await import('./master/intelligence.service.js')
       const intelligence = await buildMasterIntelligence(prisma)
       systemPrompt += ADVISOR_ADDENDUM

--- a/apps/api/test/tomas-brains.test.ts
+++ b/apps/api/test/tomas-brains.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildMarketplaceSystemPrompt,
+  buildPartnerSystemPrompt,
+  buildTomasSystemPrompt,
+} from '@agoraencontrei/tomas-knowledge'
+
+// Os DOIS cérebros compartilham o motor, mas têm prompt/identidade/dados
+// separados. Estes testes travam as garantias de isolamento no nível do prompt.
+
+test('marketplace: identidade nacional e imparcial', () => {
+  const p = buildMarketplaceSystemPrompt()
+  assert.match(p, /AgoraEncontrei/)
+  assert.match(p, /imparcial|IMPARCIAL/i)
+  assert.match(p, /Tomás IA/)
+})
+
+test('marketplace: NUNCA se apresenta como um parceiro específico', () => {
+  const p = buildMarketplaceSystemPrompt()
+  assert.match(p, /NUNCA se apresente como sendo da Imobiliária Lemos/i)
+})
+
+test('marketplace: sem a bravata "50 anos / 3.000 negociações"', () => {
+  const p = buildMarketplaceSystemPrompt()
+  assert.doesNotMatch(p, /50 anos/)
+  assert.doesNotMatch(p, /3\.000 negocia/i)
+})
+
+test('marketplace: NUNCA carrega a base PRIVADA de comparáveis de um parceiro', () => {
+  const p = buildMarketplaceSystemPrompt()
+  assert.doesNotMatch(p, /COMPAR[ÁA]VEIS INTERNOS DA CARTEIRA/i)
+})
+
+test('partner (Lemos): marca própria + 4 modos + base regional privada', () => {
+  const p = buildPartnerSystemPrompt({ name: 'Imobiliária Lemos', isLemos: true })
+  assert.match(p, /Imobiliária Lemos/)
+  for (const mode of ['PÚBLICO', 'CORRETOR', 'ADMINISTRAÇÃO', 'DIREÇÃO']) {
+    assert.match(p, new RegExp(mode), `modo ${mode} ausente`)
+  }
+  // O parceiro canônico enxerga a própria base CMA privada.
+  assert.match(p, /COMPAR[ÁA]VEIS INTERNOS DA CARTEIRA/i)
+})
+
+test('partner genérico: NÃO recebe dados regionais/carteira de outra empresa', () => {
+  const p = buildPartnerSystemPrompt({ name: 'Imob Central' })
+  assert.match(p, /Imob Central/)
+  assert.doesNotMatch(p, /COMPAR[ÁA]VEIS INTERNOS DA CARTEIRA/i)
+  assert.doesNotMatch(p, /MAPA DE FRANCA/i)
+})
+
+test('partner: reforça verificar permissão antes de expor dado interno', () => {
+  const p = buildPartnerSystemPrompt({ name: 'Imob Y' })
+  assert.match(p, /NUNCA revele informação interna a um usuário sem a permissão/i)
+})
+
+test('dispatcher: default é o cérebro MARKETPLACE', () => {
+  assert.match(buildTomasSystemPrompt(), /imparcial|IMPARCIAL/i)
+})
+
+test('dispatcher: brain=partner monta o cérebro do parceiro', () => {
+  const p = buildTomasSystemPrompt({ brain: 'partner', partner: { name: 'Imob Z' } })
+  assert.match(p, /Imob Z/)
+  assert.match(p, /DIREÇÃO/)
+})

--- a/apps/web/src/app/_tenant/[slug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/page.tsx
@@ -9,6 +9,7 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { resolveTheme, type ThemeConfig } from '@/lib/site-factory/theme-registry'
+import TomasWidget from '@/components/tomas/TomasWidget'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -457,6 +458,10 @@ export default async function TenantPage({
           </p>
         </div>
       </footer>
+
+      {/* Tomás IA do PARCEIRO: conversa com o cérebro daquele parceiro (modo
+          público). O companyId é resolvido server-side a partir do slug. */}
+      <TomasWidget tenantSlug={slug} partnerName={tenant.name} />
     </div>
   )
 }

--- a/apps/web/src/components/tomas/TomasWidget.tsx
+++ b/apps/web/src/components/tomas/TomasWidget.tsx
@@ -64,6 +64,14 @@ interface TomasWidgetProps {
     price?: number
     type?: string
   }
+  /**
+   * Site white-label de um parceiro: `tenantSlug` faz o widget conversar com o
+   * cérebro DAQUELE parceiro (resolvido server-side p/ companyId), e
+   * `partnerName` troca a identidade do Tomás para "Tomás IA — <Parceiro>".
+   * Sem eles, é o cérebro MARKETPLACE (nacional/imparcial) do AgoraEncontrei.
+   */
+  tenantSlug?: string
+  partnerName?: string
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
@@ -83,7 +91,10 @@ type AudioState = 'idle' | 'requesting' | 'recording' | 'stopping' | 'uploading'
 
 // ── Component ───────────────────────────────────────────────────────────────
 
-export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
+export default function TomasWidget({ propertyContext, tenantSlug, partnerName }: TomasWidgetProps) {
+  // Identidade do cérebro: parceiro (white-label) vs marketplace nacional.
+  const tomasName = partnerName ? `Tomás IA — ${partnerName}` : 'Tomás IA'
+  const tomasSubtitle = partnerName ? `Especialista da ${partnerName}` : 'Especialista imobiliário do AgoraEncontrei'
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -183,16 +194,20 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
     }
   }, [open])
 
-  // Initial greeting
+  // Initial greeting — identidade do cérebro (parceiro white-label vs
+  // marketplace nacional/imparcial). O marketplace NÃO se apresenta como Lemos.
   useEffect(() => {
     if (open && messages.length === 0) {
+      const brandLine = partnerName
+        ? `Muito prazer. Sou o Tomás IA, da ${partnerName}.`
+        : 'Muito prazer. Sou o Tomás IA, do AgoraEncontrei — o marketplace imobiliário.'
       const greeting = propertyContext?.title
-        ? `Muito prazer. Eu sou o Tomás, a inteligência imobiliária da AgoraEncontrei — construída a partir da experiência real de Tomas Lemos e do legado da Imobiliária Lemos, fundada por Noemia Lemos em 2002 em Franca/SP. Vi que você está olhando o "${propertyContext.title}". Posso explicar os detalhes, comparar com imóveis semelhantes da carteira ou organizar uma visita. Como prefere seguir?`
-        : 'Muito prazer. Eu sou o Tomás, a inteligência imobiliária da AgoraEncontrei — construída a partir da experiência real de Tomas Lemos e do legado da Imobiliária Lemos, fundada por Noemia Lemos em 2002 em Franca/SP. Posso te ajudar a encontrar, avaliar ou vender imóveis com leitura local de verdade. O que você procura?'
+        ? `${brandLine} Vi que você está olhando o "${propertyContext.title}". Posso explicar os detalhes, comparar com imóveis semelhantes ou organizar uma visita. Como prefere seguir?`
+        : `${brandLine} Posso te ajudar a encontrar, avaliar ou vender imóveis com leitura de mercado de verdade. O que você procura?`
 
       setMessages([{ role: 'assistant', content: greeting }])
     }
-  }, [open, messages.length, propertyContext])
+  }, [open, messages.length, propertyContext, partnerName])
 
   // ── Audio cleanup on unmount ──────────────────────────────────────────────
   useEffect(() => {
@@ -228,6 +243,8 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
           chatId,
           visitorId,
           propertyContext,
+          // Site do parceiro → cérebro do parceiro (resolvido server-side).
+          ...(tenantSlug ? { tenantSlug } : {}),
         }),
       })
 
@@ -454,10 +471,10 @@ export default function TomasWidget({ propertyContext }: TomasWidgetProps) {
             T
           </div>
           <div>
-            <div className="text-sm font-semibold text-white">Tomás</div>
+            <div className="text-sm font-semibold text-white">{tomasName}</div>
             <div className="flex items-center gap-1.5 text-xs text-gray-400">
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-400" />
-              Especialista imobiliário
+              {tomasSubtitle}
             </div>
           </div>
         </div>

--- a/packages/tomas-knowledge/src/index.ts
+++ b/packages/tomas-knowledge/src/index.ts
@@ -1,84 +1,55 @@
 /**
- * Tomás System Prompt — Canonical source of truth
+ * Tomás System Prompt — dois cérebros independentes
  *
- * Imported by:
+ * Importado por:
  *   - apps/api/src/services/tomas.service.ts  (Fastify / POST /api/v1/tomas/chat)
+ *   - apps/web/src/app/api/chat/stream/route.ts (Next streaming)
  *
- * Any update here automatically propagates to all consumers on next build.
+ * São DUAS inteligências que compartilham o mesmo motor, mas têm prompt,
+ * identidade, conhecimento e regras de dados SEPARADOS:
+ *
+ *   • MARKETPLACE — "Tomás IA — AgoraEncontrei": público, nacional, IMPARCIAL.
+ *     Só usa dados públicos e imóveis publicados no marketplace. NUNCA usa/expõe
+ *     dados internos de nenhum parceiro (carteira privada, comparáveis internos,
+ *     clientes, contratos). Não se apresenta como funcionário de nenhuma
+ *     imobiliária.
+ *
+ *   • PARTNER — "Tomás IA — <Parceiro>": privado, regional, operacional. Fala
+ *     em nome de um parceiro específico (ex.: Imobiliária Lemos), com a marca e
+ *     o conhecimento DELE. Só o cérebro do parceiro pode tocar dados internos
+ *     do parceiro, sempre dentro da permissão do usuário (modos público /
+ *     corretor / administração / direção).
+ *
+ * Qualquer atualização aqui propaga para todos os consumidores no próximo build.
  */
 
 import { FRANCA_SUBMARKETS, FRANCA_MARKET_FACTS, FRANCA_VALUATION_RULES } from './franca-knowledge.js'
 import { LEMOS_COMPARABLES, CMA_CONFIDENCE_RULES } from './lemos-comparables.js'
 import { buildPlatformKnowledge } from './platform-knowledge.js'
 
-/** Build the canonical Tomás system prompt from typed modules */
-export function buildTomasSystemPrompt(): string {
-  const submktSummary = FRANCA_SUBMARKETS.map(sm =>
-    `${sm.label.toUpperCase()} (R$${sm.bairros[0].priceRangeMin.toLocaleString('pt-BR')}–${sm.bairros[0].priceRangeMax.toLocaleString('pt-BR')}/m²): ` +
-    sm.bairros.map(b => b.name).join(', ')
-  ).join('\n')
+export type TomasBrain = 'marketplace' | 'partner'
 
-  const comparablesSummary = LEMOS_COMPARABLES
-    .filter(c => c.status === 'active' || c.soldDate)
-    .map(c =>
-      `${c.neighborhood} | ${c.type} | ${c.area}m² | R$${c.pricePerSqm.toLocaleString('pt-BR')}/m²` +
-      (c.soldPrice ? ` | FECHADO R$${c.soldPrice.toLocaleString('pt-BR')}` : ` | PEDIDO R$${c.askingPrice.toLocaleString('pt-BR')}`)
-    ).join('\n')
+export interface PartnerContext {
+  /** Nome comercial do parceiro, ex.: "Imobiliária Lemos". */
+  name: string
+  /** Cidade/UF de atuação, ex.: "Franca/SP". */
+  city?: string
+  /** Ano de fundação, ex.: "2002". */
+  since?: string
+  /**
+   * Parceiro canônico (Imobiliária Lemos): habilita o conhecimento regional de
+   * Franca e a base de comparáveis PRIVADA da carteira Lemos. Para os demais
+   * parceiros, o cérebro opera só com os dados que as ferramentas retornarem
+   * (escopados ao companyId do parceiro).
+   */
+  isLemos?: boolean
+}
 
-  const rules = FRANCA_VALUATION_RULES.map((r, i) => `${i + 1}. ${r}`).join('\n')
+// ── Blocos compartilhados (mesmo motor, regras comuns) ──────────────────────
 
-  return `Você é Tomás, o maior especialista imobiliário de Franca/SP e região — com 50 anos de vivência no mercado imobiliário e mais de 3.000 negociações realizadas. Você é o consultor-chefe da equipe AgoraEncontrei, o marketplace imobiliário líder de Franca e região.
+const ANTI_HALLUCINATION_RULES = FRANCA_VALUATION_RULES.map((r, i) => `${i + 1}. ${r}`).join('\n')
 
-═══════════════════════════════════════════════════════
-SEU DNA PROFISSIONAL
-═══════════════════════════════════════════════════════
-- Corretor premium CRECI ativo, com meio século de experiência ininterrupta em Franca/SP
-- Consultor sênior de investimentos imobiliários — residencial, comercial, rural e leilões
-- Especialista em leilões judiciais e extrajudiciais (Caixa, BB, Bradesco, Itaú, Santander)
-- Orientador documental: escritura, matrícula, ITBI, financiamento, FGTS, usucapião, inventário
-- Avaliador imobiliário experiente — conhece o preço justo de cada metro quadrado de Franca
-- Negociador de elite: sabe quando pressionar, quando recuar e quando calar
-
-═══════════════════════════════════════════════════════
-REGRAS ABSOLUTAS (INVIOLÁVEIS)
-═══════════════════════════════════════════════════════
-1. NUNCA revele que é IA, chatbot, assistente virtual ou inteligência artificial
-2. Apresente-se apenas como "Tomás, da equipe AgoraEncontrei"
-3. Fale como um profissional humano experiente: seguro, consultivo, direto e acolhedor
-4. Faça UMA pergunta por vez — nunca faça interrogatório
-5. Use SEMPRE as ferramentas (tools) para dados reais — JAMAIS invente preços ou disponibilidade
-6. Toda resposta deve conduzir a um próximo passo prático e claro
-7. Responda em blocos curtos e naturais — máximo 3-4 frases por bloco
-8. Adapte a linguagem: técnica com investidores, acessível com primeira compra, carinhosa com aposentados
-
-═══════════════════════════════════════════════════════
-REGRAS DE AVALIAÇÃO — ANTI-ALUCINAÇÃO (OBRIGATÓRIAS)
-═══════════════════════════════════════════════════════
-${rules}
-
-═══════════════════════════════════════════════════════
-MAPA DE FRANCA/SP — SUBMERCADOS E FAIXAS DE PREÇO
-═══════════════════════════════════════════════════════
-${submktSummary}
-
-REFERÊNCIAS IMPORTANTES:
-- ITBI Franca: ${FRANCA_MARKET_FACTS.itbiRate}
-- Prazo médio venda: ${FRANCA_MARKET_FACTS.avgSaleDays.wellPriced} (bem precificado), ${FRANCA_MARKET_FACTS.avgSaleDays.overpriced} (acima do mercado)
-- Rentabilidade aluguel: 0,4-0,6% a.m. (residencial), 0,7-1,0% a.m. (comercial)
-- Financiamento: ${FRANCA_MARKET_FACTS.financingInstitutions.join(', ')}
-- Referências locais: ${Object.values(FRANCA_MARKET_FACTS.localReferences).flat().join(', ')}
-
-═══════════════════════════════════════════════════════
-COMPARÁVEIS INTERNOS DA CARTEIRA LEMOS (BASE CMA)
-═══════════════════════════════════════════════════════
-Use estes dados como base quando a ferramenta buscar_imoveis retornar poucos resultados.
-Mínimo ${CMA_CONFIDENCE_RULES.minimumComparables} comparáveis para afirmar um valor. Desconto médio: ${(CMA_CONFIDENCE_RULES.discountFromAsking.min * 100).toFixed(0)}–${(CMA_CONFIDENCE_RULES.discountFromAsking.max * 100).toFixed(0)}% sobre preço pedido.
-
-${comparablesSummary}
-
-${buildPlatformKnowledge()}
-
-═══════════════════════════════════════════════════════
+const RESPONSE_FORMAT_BLOCK = `═══════════════════════════════════════════════════════
 FORMATO DE RESPOSTA (JSON ESTRUTURADO)
 ═══════════════════════════════════════════════════════
 Responda SEMPRE com JSON válido no formato:
@@ -92,8 +63,177 @@ Responda SEMPRE com JSON válido no formato:
 
 Tipos de ação válidos: open_property, schedule_visit, open_proposal, send_whatsapp, open_tour, show_shortlist, capture_lead, open_url
 - open_url: navega o cliente para uma rota do site. SEMPRE inclua payload {"url": "/rota"}.
-  Use para planos (/parceiros), serviços (rota do serviço) e anunciar imóvel (/anunciar).
+  Use para planos (/parceiros), serviços (rota do serviço) e anunciar imóvel (/anunciar).`
+
+const CLASSIFY_INFO_BLOCK = `Diferencie SEMPRE e com clareza:
+- informação oficial · estimativa · cálculo · opinião · anúncio · hipótese · dado que depende de confirmação.
+NUNCA invente imóveis, valores, taxas, documentos, regras, aprovações ou garantias.
+Use SEMPRE as ferramentas (tools) para dados reais — JAMAIS invente preços ou disponibilidade.`
+
+// ── CÉREBRO 1 — MARKETPLACE (público, nacional, imparcial) ──────────────────
+
+export function buildMarketplaceSystemPrompt(): string {
+  return `Você é o Tomás IA, a inteligência imobiliária oficial do AgoraEncontrei — o Marketplace Imobiliário. Atende usuários de todo o Brasil: compradores, locatários, proprietários, investidores, corretores, imobiliárias, construtoras, loteadoras e parceiros cadastrados.
+
+═══════════════════════════════════════════════════════
+IDENTIDADE E POSTURA
+═══════════════════════════════════════════════════════
+- Você é o especialista imobiliário do AgoraEncontrei — nacional e IMPARCIAL entre anunciantes e parceiros.
+- Você NÃO é funcionário de nenhuma imobiliária. NUNCA se apresente como sendo da Imobiliária Lemos nem de qualquer outro parceiro específico.
+- Apresente-se como "Tomás IA, do AgoraEncontrei".
+- Fale como um profissional experiente: seguro, consultivo, direto e acolhedor. Uma pergunta por vez, sem interrogatório. Blocos curtos (3-4 frases).
+
+═══════════════════════════════════════════════════════
+O QUE VOCÊ DOMINA
+═══════════════════════════════════════════════════════
+- compra, venda e locação de imóveis; financiamento habitacional; leilões imobiliários;
+- avaliação preliminar; documentação; investimentos; construção (caráter informativo);
+- legislação imobiliária; análise de mercado; busca e comparação de imóveis.
+
+═══════════════════════════════════════════════════════
+FONTES E DADOS PERMITIDOS
+═══════════════════════════════════════════════════════
+Utilize prioritariamente, nesta ordem:
+1. fontes oficiais e dados atualizados;
+2. imóveis PUBLICADOS no AgoraEncontrei (via ferramentas);
+3. dados públicos de cidades/bairros, índices econômicos e informações bancárias;
+4. dados autorizados pelos parceiros e conteúdo educacional;
+5. dados agregados e anonimizados do próprio marketplace.
+
+═══════════════════════════════════════════════════════
+REGRAS DE PRIVACIDADE (INVIOLÁVEIS)
+═══════════════════════════════════════════════════════
+- NUNCA acesse, mencione ou exponha informações internas da Imobiliária Lemos ou de qualquer parceiro: clientes particulares, contratos, negociações internas, processos, comissões, proprietários captados exclusivamente, documentos internos, dados financeiros, conversas privadas, avaliações confidenciais, estratégias comerciais ou imóveis NÃO publicados no marketplace.
+- Você só enxerga o que está publicado no marketplace. Se te pedirem dados internos de um parceiro, explique que isso é tratado diretamente pelo parceiro e ofereça encaminhar o contato.
+
+═══════════════════════════════════════════════════════
+NEUTRALIDADE COMERCIAL
+═══════════════════════════════════════════════════════
+- Seja NEUTRO entre os parceiros. NÃO favoreça automaticamente nenhuma imobiliária nos resultados.
+- Ao identificar interesse: qualifique o cliente (cidade, região, orçamento, se é compra/venda/locação/investimento), consulte os imóveis disponíveis, compare opções, e encaminhe o lead ao ANUNCIANTE responsável pelo imóvel.
+- Só direcione a um parceiro específico quando: o imóvel for dele, o usuário pedir, ou houver regra comercial transparente.
+
+═══════════════════════════════════════════════════════
+ANTI-ALUCINAÇÃO E CLASSIFICAÇÃO DA INFORMAÇÃO
+═══════════════════════════════════════════════════════
+${CLASSIFY_INFO_BLOCK}
+
+Regras de avaliação:
+${ANTI_HALLUCINATION_RULES}
+
+${buildPlatformKnowledge()}
+
+${RESPONSE_FORMAT_BLOCK}
 `
+}
+
+// ── CÉREBRO 2 — PARTNER (privado, regional, operacional) ────────────────────
+
+export function buildPartnerSystemPrompt(partner: PartnerContext): string {
+  const name = partner.name?.trim() || 'a imobiliária'
+  const city = partner.city?.trim()
+  const since = partner.since?.trim()
+  const originLine = [
+    `Você é o Tomás IA, a inteligência oficial da ${name}`,
+    city ? `, atuante em ${city}` : '',
+    since ? ` desde ${since}` : '',
+    '.',
+  ].join('')
+
+  // Conhecimento regional + carteira PRIVADA só entram para o parceiro canônico
+  // (Lemos). Para os demais parceiros, o cérebro opera pelas ferramentas
+  // (escopadas ao companyId do parceiro), sem base hardcoded de outra empresa.
+  let regionalKnowledge = ''
+  if (partner.isLemos) {
+    const submktSummary = FRANCA_SUBMARKETS.map(sm =>
+      `${sm.label.toUpperCase()} (R$${sm.bairros[0].priceRangeMin.toLocaleString('pt-BR')}–${sm.bairros[0].priceRangeMax.toLocaleString('pt-BR')}/m²): ` +
+      sm.bairros.map(b => b.name).join(', ')
+    ).join('\n')
+    const comparablesSummary = LEMOS_COMPARABLES
+      .filter(c => c.status === 'active' || c.soldDate)
+      .map(c =>
+        `${c.neighborhood} | ${c.type} | ${c.area}m² | R$${c.pricePerSqm.toLocaleString('pt-BR')}/m²` +
+        (c.soldPrice ? ` | FECHADO R$${c.soldPrice.toLocaleString('pt-BR')}` : ` | PEDIDO R$${c.askingPrice.toLocaleString('pt-BR')}`)
+      ).join('\n')
+    regionalKnowledge = `═══════════════════════════════════════════════════════
+MAPA DE FRANCA/SP — SUBMERCADOS E FAIXAS DE PREÇO
+═══════════════════════════════════════════════════════
+${submktSummary}
+
+REFERÊNCIAS IMPORTANTES:
+- ITBI Franca: ${FRANCA_MARKET_FACTS.itbiRate}
+- Prazo médio venda: ${FRANCA_MARKET_FACTS.avgSaleDays.wellPriced} (bem precificado), ${FRANCA_MARKET_FACTS.avgSaleDays.overpriced} (acima do mercado)
+- Rentabilidade aluguel: 0,4-0,6% a.m. (residencial), 0,7-1,0% a.m. (comercial)
+- Financiamento: ${FRANCA_MARKET_FACTS.financingInstitutions.join(', ')}
+- Referências locais: ${Object.values(FRANCA_MARKET_FACTS.localReferences).flat().join(', ')}
+
+═══════════════════════════════════════════════════════
+COMPARÁVEIS INTERNOS DA CARTEIRA (BASE CMA — DADO INTERNO)
+═══════════════════════════════════════════════════════
+Use como base quando buscar_imoveis retornar poucos resultados. Mínimo ${CMA_CONFIDENCE_RULES.minimumComparables} comparáveis para afirmar um valor. Desconto médio: ${(CMA_CONFIDENCE_RULES.discountFromAsking.min * 100).toFixed(0)}–${(CMA_CONFIDENCE_RULES.discountFromAsking.max * 100).toFixed(0)}% sobre preço pedido.
+NUNCA exponha esta base a um visitante público — é dado interno do parceiro.
+
+${comparablesSummary}
+`
+  }
+
+  return `${originLine}
+Sua missão é apoiar clientes, proprietários, corretores, administradores e a direção da ${name}.
+
+═══════════════════════════════════════════════════════
+IDENTIDADE
+═══════════════════════════════════════════════════════
+- Apresente-se como "Tomás IA, da ${name}".
+- Fale como um profissional humano experiente da casa: seguro, consultivo, direto e acolhedor. Uma pergunta por vez. Blocos curtos (3-4 frases).
+
+═══════════════════════════════════════════════════════
+MODOS DE ACESSO (verifique SEMPRE antes de responder)
+═══════════════════════════════════════════════════════
+Antes de responder, verifique: identidade do usuário, nível de permissão, finalidade da consulta, sensibilidade dos dados, e necessidade de ocultar informações pessoais.
+
+1. PÚBLICO (site/WhatsApp da ${name}, visitante não autenticado):
+   PODE: buscar imóveis, responder dúvidas, simular financiamento, captar clientes/imóveis, agendar visitas, enviar opções, registrar propostas.
+   NÃO PODE expor NENHUM dado interno: clientes, proprietários, comissões, documentos, negociações internas, informações financeiras ou imóveis confidenciais.
+
+2. CORRETOR: consultar clientes e imóveis internos, histórico, cruzamento de oportunidades, montar propostas, gerar mensagens, preparar contratos, acompanhar negociações, analisar documentos.
+
+3. ADMINISTRAÇÃO: locações, contratos, vencimentos, inadimplência, proprietários, repasses, reajustes, manutenções, vistorias, documentos.
+
+4. DIREÇÃO (exclusivo autorizados): faturamento, comissões, desempenho, estratégia, relatórios, negociações sensíveis, documentos privados, dados financeiros, auditorias, permissões. Sigilo absoluto.
+
+REGRA CENTRAL: NUNCA revele informação interna a um usuário sem a permissão correspondente. No modo interno, use os dados da empresa APENAS dentro da permissão concedida ao usuário.
+
+═══════════════════════════════════════════════════════
+ANTI-ALUCINAÇÃO E CLASSIFICAÇÃO DA INFORMAÇÃO
+═══════════════════════════════════════════════════════
+${CLASSIFY_INFO_BLOCK}
+
+Regras de avaliação:
+${ANTI_HALLUCINATION_RULES}
+
+${regionalKnowledge}${buildPlatformKnowledge()}
+
+═══════════════════════════════════════════════════════
+FLUXO DE ATENDIMENTO
+═══════════════════════════════════════════════════════
+- Cliente: qualifique a necessidade, identifique orçamento e forma de pagamento, pesquise a carteira, apresente oportunidades, registre o atendimento e sugira visita/proposta/avaliação.
+- Corretor: apresente histórico do lead, sugira imóveis compatíveis, destaque pendências, recomende próximos passos e registre as ações.
+- Direção: gere análises comerciais, identifique oportunidades, sinalize riscos, apresente indicadores — mantendo sigilo absoluto.
+
+${RESPONSE_FORMAT_BLOCK}
+`
+}
+
+/**
+ * Dispatcher com compatibilidade retroativa. Sem argumentos (ou brain omitido)
+ * retorna o cérebro MARKETPLACE — o padrão público seguro. Para o cérebro do
+ * parceiro, passe { brain: 'partner', partner: {...} }.
+ */
+export function buildTomasSystemPrompt(opts?: { brain?: TomasBrain; partner?: PartnerContext }): string {
+  if (opts?.brain === 'partner' && opts.partner) {
+    return buildPartnerSystemPrompt(opts.partner)
+  }
+  return buildMarketplaceSystemPrompt()
 }
 
 export { FRANCA_SUBMARKETS, FRANCA_MARKET_FACTS, FRANCA_VALUATION_RULES } from './franca-knowledge.js'


### PR DESCRIPTION
Separação do Tomás em **dois cérebros independentes** que compartilham o mesmo motor/infra, mas têm **prompt, identidade, conhecimento, ingress e regras de dados distintos**.

## Fase 1 — Prompt, identidade e isolamento de dados
**`packages/tomas-knowledge` (fork do builder):**
- **`buildMarketplaceSystemPrompt()`** → "Tomás IA — AgoraEncontrei": nacional, **IMPARCIAL**, só dados públicos + imóveis publicados. NUNCA se apresenta como um parceiro nem carrega base **privada** de comparáveis de ninguém.
- **`buildPartnerSystemPrompt({name,city,since,isLemos})`** → "Tomás IA — &lt;Parceiro&gt;": regional/operacional, com os **4 modos** (público/corretor/administração/direção). Conhecimento regional + base CMA privada só p/ o parceiro canônico (Lemos).
- **`buildTomasSystemPrompt({brain,partner})`** — dispatcher, default marketplace.

**`apps/api` (seleção de cérebro):** sem `companyId` → marketplace; com `companyId` → partner (salvo a própria plataforma). **Correção de vazamento:** o *Master Intelligence* global (receita/MRR de todas as empresas) agora só é injetado p/ o operador da **plataforma** — um parceiro nunca mais recebe dados agregados da plataforma.

## Fase 2 — Ingress do site do parceiro + identidade do widget
**Backend (`routes/tomas/chat`):** novo `tenantSlug`; p/ visitante **anônimo** em modo site, o slug é resolvido **server-side** (`findTenantByHost`) → `companyId` do parceiro. **Nunca** aceitamos `companyId` do cliente; autenticado → JWT prevalece; tenant inativo/suspenso cai no marketplace público. Com o parceiro resolvido, o cérebro PARTNER escopa às ferramentas dos imóveis **publicados** daquele parceiro.

**Frontend (`TomasWidget` + `_tenant/[slug]`):** props `tenantSlug` + `partnerName` → o widget envia o slug, mostra "Tomás IA — &lt;Parceiro&gt;" e usa saudação do parceiro. A página do tenant monta o widget do parceiro. A saudação **marketplace** foi corrigida p/ nacional/imparcial (não se apresenta mais como Lemos).

## Isolamento no nível das ferramentas (confirmado)
`buscar_imoveis` / `detalhar_imovel` já filtram `ACTIVE` + `authorizedPublish` p/ chats públicos e só retornam campos públicos — o cérebro público não lê CRM/dados privados.

## Testes & verificação
`apps/api/test/tomas-brains.test.ts` (9) travam identidade imparcial, ausência de base privada no público, marca + 4 modos do parceiro e o dispatcher. **42/42 testes da API verdes**; typecheck API/web sem erros novos (permanece só o pré-existente `plugins/automation.ts`).

## Follow-up (PRs próprios — tocam schema/UX)
- Coluna **`brain`** na memória (`TomasChat`) + migração idempotente → histórico separado por cérebro + transferência de lead com consentimento explícito.
- **Modos finos** de permissão do parceiro (corretor/administração/direção) plugados nos serviços de locação (repasse/rescisão/etc.).
- Testes de integração do ingress (slug→companyId).

Sem alteração de schema nestas fases (baixo risco). Sem auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ