### PR TITLE
feat(tomas): dois cérebros — fase 3 (memória separada por cérebro)

### DIFF
--- a/apps/api/src/routes/tomas/index.ts
+++ b/apps/api/src/routes/tomas/index.ts
@@ -11,6 +11,7 @@ import {
   runTomasChat,
   getOrCreateChat,
   persistMessages,
+  resolveBrainLabel,
   type TomasMessage,
   type TomasChatParams,
 } from '../../services/tomas.service.js'
@@ -111,6 +112,10 @@ export default async function tomasRoutes(app: FastifyInstance) {
       return reply.status(401).send({ error: 'Autenticação necessária para o modo dashboard.' })
     }
 
+    // Qual cérebro atende (para separar a memória). Resolvido do companyId já
+    // confiável (JWT ou lookup server-side do slug) — não do cliente.
+    const brain = await resolveBrainLabel(app.prisma, companyId)
+
     // Create or resume conversation
     const chatId = await getOrCreateChat(app.prisma, {
       chatId: body.chatId,
@@ -119,6 +124,7 @@ export default async function tomasRoutes(app: FastifyInstance) {
       companyId,
       userId,
       propertyId: body.propertyContext?.propertyId,
+      brain,
     })
 
     // Run the agent

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -338,6 +338,16 @@ async function runMigrations(prisma: any) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }
   }
 
+  // ── Tomás: coluna do cérebro na memória (separa marketplace × parceiro) ──
+  // Aditiva e idempotente — segura em produção (não reescreve dados).
+  const tomasMigrations = [
+    `ALTER TABLE tomas_chats ADD COLUMN IF NOT EXISTS "brain" TEXT`,
+    `CREATE INDEX IF NOT EXISTS tomas_chats_brain_idx ON tomas_chats(brain)`,
+  ]
+  for (const sql of tomasMigrations) {
+    try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }
+  }
+
   for (const sql of auctionMigrations) {
     try {
       await prisma.$executeRawUnsafe(sql)

--- a/apps/api/src/services/tomas.service.ts
+++ b/apps/api/src/services/tomas.service.ts
@@ -190,6 +190,23 @@ async function resolveCompanyBrain(
   }
 }
 
+/** Rótulo do cérebro que atende o chat — usado para separar a memória. */
+export type TomasBrainLabel = 'marketplace' | 'partner'
+
+/**
+ * Decide qual cérebro atende, para gravar na memória (TomasChat.brain). Sem
+ * companyId → marketplace. Com companyId → partner, exceto a própria plataforma
+ * AgoraEncontrei (que opera o cérebro marketplace/plataforma).
+ */
+export async function resolveBrainLabel(
+  prisma: PrismaClient,
+  companyId?: string,
+): Promise<TomasBrainLabel> {
+  if (!companyId) return 'marketplace'
+  const { isPlatform } = await resolveCompanyBrain(prisma, companyId)
+  return isPlatform ? 'marketplace' : 'partner'
+}
+
 const DASHBOARD_ADDENDUM = `
 MODO DASHBOARD (Copilot Interno):
 - Priorize produtividade, execução e objetividade
@@ -864,14 +881,22 @@ export async function getOrCreateChat(
     companyId?: string
     userId?: string
     propertyId?: string
+    /** Cérebro que atende este chat — separa a memória (marketplace × parceiro). */
+    brain?: TomasBrainLabel
   },
 ): Promise<string> {
   if (params.chatId) {
     // SEGURANÇA (multi-tenant): só retoma um chat do MESMO contexto de empresa
     // (antes: retomava qualquer chatId → anexava mensagens / handoff no chat de
-    // outra empresa). Chats anônimos têm companyId null.
+    // outra empresa). Chats anônimos têm companyId null. Além disso, um chat só
+    // é retomado dentro do MESMO cérebro — memória do marketplace nunca se
+    // mistura com a de um parceiro.
     const existing = await prisma.tomasChat.findFirst({
-      where: { id: params.chatId, companyId: params.companyId ?? null },
+      where: {
+        id: params.chatId,
+        companyId: params.companyId ?? null,
+        ...(params.brain ? { brain: params.brain } : {}),
+      },
     })
     if (existing) return existing.id
   }
@@ -883,7 +908,8 @@ export async function getOrCreateChat(
       companyId: params.companyId,
       userId: params.userId,
       propertyId: params.propertyId,
-    },
+      ...(params.brain ? { brain: params.brain } : {}),
+    } as Prisma.TomasChatUncheckedCreateInput,
   })
 
   return chat.id

--- a/apps/api/test/tomas-brain-label.test.ts
+++ b/apps/api/test/tomas-brain-label.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveBrainLabel } from '../src/services/tomas.service.js'
+
+// Prisma falso: só precisa de company.findUnique para o resolveBrainLabel.
+function fakePrisma(company: { name?: string; settings?: unknown } | null): any {
+  return { company: { findUnique: async () => company } }
+}
+
+test('sem companyId → cérebro marketplace (nem consulta o banco)', async () => {
+  const label = await resolveBrainLabel(fakePrisma(null), undefined)
+  assert.equal(label, 'marketplace')
+})
+
+test('empresa parceira (Lemos) → cérebro partner', async () => {
+  const p = fakePrisma({ name: 'Imobiliária Lemos', settings: {} })
+  assert.equal(await resolveBrainLabel(p, 'company_lemos'), 'partner')
+})
+
+test('parceiro genérico → cérebro partner', async () => {
+  const p = fakePrisma({ name: 'Imob Central', settings: {} })
+  assert.equal(await resolveBrainLabel(p, 'company_x'), 'partner')
+})
+
+test('empresa PLATAFORMA (canonical) → cérebro marketplace', async () => {
+  const p = fakePrisma({ name: 'AgoraEncontrei', settings: { canonical: 'agoraencontrei-platform' } })
+  assert.equal(await resolveBrainLabel(p, 'company_platform'), 'marketplace')
+})
+
+test('lookup falha → não quebra, cai em partner (companyId presente)', async () => {
+  const p: any = { company: { findUnique: async () => { throw new Error('db down') } } }
+  assert.equal(await resolveBrainLabel(p, 'company_x'), 'partner')
+})

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2910,6 +2910,7 @@ model TomasChat {
   contactId     String?
   userId        String?   // corretor/admin no modo interno
   channel       String    @default("site")  // "site" | "dashboard"
+  brain         String?   // "marketplace" | "partner" — separa a memória por cérebro
   visitorId     String?   // fingerprint anônimo para visitantes
   propertyId    String?   // contexto do imóvel (quando aberto na página)
   summary       String?   @db.Text
@@ -2925,6 +2926,7 @@ model TomasChat {
   @@index([leadId])
   @@index([visitorId])
   @@index([channel])
+  @@index([brain])
   @@map("tomas_chats")
 }
 


### PR DESCRIPTION
Continuação da separação do Tomás em dois cérebros (Fases 1-2 já mergeadas no #270). Esta fase separa a **memória/histórico** por cérebro — uma conversa do **marketplace** nunca se mistura com a de um **parceiro**.

## Schema (`TomasChat`)
- Nova coluna **`brain`** (`"marketplace" | "partner"`) + índice. **Nullable e aditiva.**
- **Migração idempotente no boot** do server (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`) — mesmo padrão já usado no projeto, **segura em produção** (não reescreve dados, não bloqueia).

## Serviço (`tomas.service`)
- **`resolveBrainLabel(prisma, companyId)`** — decide o cérebro para gravar na memória: sem `companyId` → `marketplace`; parceiro → `partner`; plataforma AgoraEncontrei → `marketplace`. Exportado e reutilizável.
- **`getOrCreateChat`** grava `brain` e só **retoma** um chat do **mesmo cérebro** (além do mesmo `companyId`) — reforça o isolamento de memória.

## Rota (`/tomas/chat`)
- Resolve o `brain` a partir do `companyId` **já confiável** (JWT ou lookup server-side do slug do parceiro, da Fase 2) e passa para o `getOrCreateChat`.

## Testes & verificação
- `apps/api/test/tomas-brain-label.test.ts` (5): marketplace sem `companyId`, parceiro (Lemos/genérico), plataforma canônica, e resiliência a falha de lookup.
- **47/47 testes da API verdes** · `prisma validate` ok · `verify:boot` ok (98 rotas) · `typecheck` sem erros novos (permanece só o pré-existente `plugins/automation.ts`).

## Migração — nota de produção
A coluna é adicionada automaticamente no **boot da API** (deploy da main), de forma **idempotente e aditiva**. Não há passo manual e nenhum dado é reescrito. Nenhum `DRY_RUN`/`CONFIRM_PRODUCTION_MIGRATION` envolvido — é o mesmo mecanismo de boot-migration que o projeto já usa para outras colunas.

## Follow-up
- Transferência de lead **marketplace → parceiro** apenas com **consentimento explícito** do usuário.
- **Modos finos** de permissão do parceiro (corretor/administração/direção) plugados nos serviços de locação.

Sem auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_