### PR TITLE
ci(seo-tests): buildar tomas-knowledge antes dos testes da API (conserta o job `test`)

### DIFF
--- a/.github/workflows/seo-tests.yml
+++ b/.github/workflows/seo-tests.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      # Os testes da API importam @agoraencontrei/tomas-knowledge pelo dist/
+      # (gitignored), então o pacote precisa ser BUILDADO antes — senão os testes
+      # do Tomás quebram com ERR_MODULE_NOT_FOUND.
+      - name: Build workspace packages (tomas-knowledge)
+        run: pnpm --filter @agoraencontrei/tomas-knowledge build
+
       - name: Database — transform + dataset sweep
         run: pnpm --filter @agoraencontrei/database test
 


### PR DESCRIPTION
O job **`test`** (`.github/workflows/seo-tests.yml`) está **vermelho na main**: ele roda os testes da API sem **buildar** o pacote `@agoraencontrei/tomas-knowledge`, cujo `dist/` é gitignored.

Desde que os testes do Tomás (`tomas-brains.test.ts`, `tomas-brain-label.test.ts`) passaram a importar esse pacote, o job quebra com:
```
ERR_MODULE_NOT_FOUND: Cannot find module '.../@agoraencontrei/tomas-knowledge/dist/index.js'
```

## Fix
Adiciona um passo de **build do pacote antes dos testes** — exatamente o que o `build-desktop.yml` já faz:
```yaml
- name: Build workspace packages (tomas-knowledge)
  run: pnpm --filter @agoraencontrei/tomas-knowledge build
```

## Verificação
Reproduzido e validado localmente a sequência do CI:
```
rm -rf packages/tomas-knowledge/dist && pnpm --filter @agoraencontrei/tomas-knowledge build && pnpm --filter @agoraencontrei/api test
→ 47/47 testes verdes
```

Sem mudança de código de produção — só o workflow de CI. Sem auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_