### PR TITLE
feat(tomas): dois cérebros — fase 4 (consentimento de transferência + permissões finas)

### DIFF
--- a/apps/api/src/routes/tomas/index.ts
+++ b/apps/api/src/routes/tomas/index.ts
@@ -47,6 +47,8 @@ export default async function tomasRoutes(app: FastifyInstance) {
           // SERVER-SIDE para o companyId — nunca confiamos num companyId vindo
           // do cliente. Faz o visitante público falar com o cérebro do parceiro.
           tenantSlug: { type: 'string' },
+          // Confirmação explícita do usuário para ações de escrita (Fase 4).
+          confirm: { type: 'boolean' },
           propertyContext: {
             type: 'object',
             properties: {
@@ -71,17 +73,20 @@ export default async function tomasRoutes(app: FastifyInstance) {
       nicheSlug?: string
       tenantTheme?: string
       tenantSlug?: string
+      confirm?: boolean
       propertyContext?: TomasChatParams['propertyContext']
     }
 
     // Try to authenticate, but don't require it
     let userId: string | undefined
     let companyId: string | undefined
+    let role: string | undefined
     try {
       await request.jwtVerify()
-      const user = request.user as { sub?: string; cid?: string }
+      const user = request.user as { sub?: string; cid?: string; role?: string }
       userId = user.sub
       companyId = user.cid
+      role = user.role
     } catch {
       // Anonymous visitor — that's fine for site mode
     }
@@ -135,6 +140,8 @@ export default async function tomasRoutes(app: FastifyInstance) {
       visitorId: body.visitorId,
       companyId,
       userId,
+      role,
+      confirmed: body.confirm === true,
       nicheSlug: body.nicheSlug,
       tenantTheme: body.tenantTheme,
       propertyContext: body.propertyContext,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -343,6 +343,30 @@ async function runMigrations(prisma: any) {
   const tomasMigrations = [
     `ALTER TABLE tomas_chats ADD COLUMN IF NOT EXISTS "brain" TEXT`,
     `CREATE INDEX IF NOT EXISTS tomas_chats_brain_idx ON tomas_chats(brain)`,
+    // Consentimento de transferência de lead marketplace → parceiro (Fase 4).
+    `CREATE TABLE IF NOT EXISTS lead_transfer_consents (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "chatId" TEXT,
+      "visitorId" TEXT,
+      "leadId" TEXT,
+      "fromBrain" TEXT NOT NULL DEFAULT 'marketplace',
+      "toCompanyId" TEXT NOT NULL,
+      "toCompanyName" TEXT,
+      purpose TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      "dataShared" JSONB NOT NULL DEFAULT '{}',
+      "consentText" TEXT NOT NULL,
+      "consentVersion" TEXT NOT NULL,
+      source TEXT,
+      granted BOOLEAN NOT NULL DEFAULT true,
+      "grantedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+      "revokedAt" TIMESTAMP,
+      "createdAt" TIMESTAMP NOT NULL DEFAULT NOW()
+    )`,
+    `CREATE INDEX IF NOT EXISTS lead_transfer_consents_company_idx ON lead_transfer_consents("toCompanyId")`,
+    `CREATE INDEX IF NOT EXISTS lead_transfer_consents_visitor_idx ON lead_transfer_consents("visitorId")`,
+    `CREATE INDEX IF NOT EXISTS lead_transfer_consents_chat_idx ON lead_transfer_consents("chatId")`,
+    `CREATE INDEX IF NOT EXISTS lead_transfer_consents_lead_idx ON lead_transfer_consents("leadId")`,
   ]
   for (const sql of tomasMigrations) {
     try { await prisma.$executeRawUnsafe(sql) } catch { /* already exists */ }

--- a/apps/api/src/services/lead-transfer-consent.service.ts
+++ b/apps/api/src/services/lead-transfer-consent.service.ts
@@ -1,0 +1,165 @@
+/**
+ * Consentimento de transferência de lead (MARKETPLACE → parceiro) — Fase 4.
+ *
+ * Regra: nenhum dado de um usuário do marketplace vai para uma imobiliária sem
+ * consentimento EXPLÍCITO, informado e versionado. Guardamos o texto exato
+ * mostrado, os dados mínimos enviados, a finalidade, o canal, a origem, o
+ * carimbo de tempo e uma eventual revogação. Toda ação gera trilha de auditoria.
+ */
+import type { PrismaClient, Prisma } from '@prisma/client'
+
+/** Versão do texto de consentimento. Suba ao mudar o texto/campos. */
+export const CONSENT_TEXT_VERSION = '2026-07-04.v1'
+
+/** Campos que PODEM ser transferidos — o mínimo necessário, nunca o chat todo. */
+export const TRANSFERABLE_LEAD_FIELDS = [
+  'name', 'phone', 'email', 'interest', 'city', 'priceRange', 'paymentForm', 'bestTime',
+] as const
+export type TransferableField = typeof TRANSFERABLE_LEAD_FIELDS[number]
+
+export interface LeadDataInput {
+  name?: string
+  phone?: string
+  email?: string
+  interest?: string
+  city?: string
+  priceRange?: string
+  paymentForm?: string
+  bestTime?: string
+  /** Qualquer outro campo é DESCARTADO (minimização de dados). */
+  [k: string]: unknown
+}
+
+/** Reduz um objeto de lead ao mínimo transferível (descarta o resto). */
+export function minimalLeadData(input: LeadDataInput): Partial<Record<TransferableField, string>> {
+  const out: Partial<Record<TransferableField, string>> = {}
+  for (const f of TRANSFERABLE_LEAD_FIELDS) {
+    const v = input[f]
+    if (typeof v === 'string' && v.trim()) out[f] = v.trim()
+  }
+  return out
+}
+
+/** Texto informado exibido ao usuário ANTES de pedir o consentimento. */
+export function buildConsentText(params: {
+  partnerName: string
+  data: Partial<Record<TransferableField, string>>
+  purpose: string
+  channel: string
+}): string {
+  const fields = Object.keys(params.data)
+  const fieldLabels: Record<string, string> = {
+    name: 'nome', phone: 'telefone', email: 'e-mail', interest: 'interesse',
+    city: 'cidade', priceRange: 'faixa de preço', paymentForm: 'forma de pagamento', bestTime: 'melhor horário',
+  }
+  const shared = fields.map(f => fieldLabels[f] || f).join(', ') || 'nenhum dado'
+  return (
+    `Autorizo o AgoraEncontrei a enviar meus dados (${shared}) para ${params.partnerName} ` +
+    `com a finalidade de ${params.purpose}, para contato via ${params.channel}. ` +
+    `Posso revogar esta autorização a qualquer momento.`
+  )
+}
+
+async function writeAudit(
+  prisma: PrismaClient,
+  action: string,
+  toCompanyId: string,
+  payload: Prisma.InputJsonValue,
+) {
+  try {
+    await prisma.auditLog.create({
+      data: { companyId: toCompanyId, action, resource: 'lead_transfer_consent', payload },
+    })
+  } catch {
+    // auditoria nunca deve quebrar o fluxo principal
+  }
+}
+
+export interface RecordConsentInput {
+  chatId?: string
+  visitorId?: string
+  leadId?: string
+  toCompanyId: string
+  toCompanyName?: string
+  purpose: string
+  channel: string
+  data: LeadDataInput
+  source?: string
+}
+
+/** Registra o consentimento (minimiza dados, guarda texto+versão) + auditoria. */
+export async function recordLeadTransferConsent(prisma: PrismaClient, input: RecordConsentInput) {
+  const data = minimalLeadData(input.data)
+  const consentText = buildConsentText({
+    partnerName: input.toCompanyName || 'o parceiro',
+    data, purpose: input.purpose, channel: input.channel,
+  })
+  const rec = await prisma.leadTransferConsent.create({
+    data: {
+      chatId: input.chatId,
+      visitorId: input.visitorId,
+      leadId: input.leadId,
+      fromBrain: 'marketplace',
+      toCompanyId: input.toCompanyId,
+      toCompanyName: input.toCompanyName,
+      purpose: input.purpose,
+      channel: input.channel,
+      dataShared: data as Prisma.InputJsonValue,
+      consentText,
+      consentVersion: CONSENT_TEXT_VERSION,
+      source: input.source,
+      granted: true,
+    },
+  })
+  await writeAudit(prisma, 'lead_transfer.consent_granted', input.toCompanyId, {
+    consentId: rec.id, version: CONSENT_TEXT_VERSION, fields: Object.keys(data),
+    visitorId: input.visitorId ?? null, chatId: input.chatId ?? null,
+  })
+  return rec
+}
+
+/** True se existe consentimento vigente (concedido e não revogado) para o par. */
+export async function hasValidConsent(
+  prisma: PrismaClient,
+  params: { toCompanyId: string; visitorId?: string; chatId?: string },
+): Promise<boolean> {
+  if (!params.visitorId && !params.chatId) return false
+  const rec = await prisma.leadTransferConsent.findFirst({
+    where: {
+      toCompanyId: params.toCompanyId,
+      granted: true,
+      revokedAt: null,
+      OR: [
+        ...(params.visitorId ? [{ visitorId: params.visitorId }] : []),
+        ...(params.chatId ? [{ chatId: params.chatId }] : []),
+      ],
+    },
+    orderBy: { grantedAt: 'desc' },
+  })
+  return !!rec
+}
+
+/** Revoga o consentimento (respeitado por hasValidConsent) + auditoria. */
+export async function revokeLeadTransferConsent(
+  prisma: PrismaClient,
+  params: { toCompanyId: string; visitorId?: string; chatId?: string },
+): Promise<number> {
+  const res = await prisma.leadTransferConsent.updateMany({
+    where: {
+      toCompanyId: params.toCompanyId,
+      granted: true,
+      revokedAt: null,
+      OR: [
+        ...(params.visitorId ? [{ visitorId: params.visitorId }] : []),
+        ...(params.chatId ? [{ chatId: params.chatId }] : []),
+      ],
+    },
+    data: { granted: false, revokedAt: new Date() },
+  })
+  if (res.count > 0) {
+    await writeAudit(prisma, 'lead_transfer.consent_revoked', params.toCompanyId, {
+      count: res.count, visitorId: params.visitorId ?? null, chatId: params.chatId ?? null,
+    })
+  }
+  return res.count
+}

--- a/apps/api/src/services/tomas-policy.ts
+++ b/apps/api/src/services/tomas-policy.ts
@@ -1,0 +1,195 @@
+/**
+ * Tomás — Matriz de Política por Ferramenta (Fase 4)
+ *
+ * Fonte única de verdade das permissões dos DOIS cérebros. Para cada ferramenta
+ * define: em qual cérebro pode rodar, se exige companyId, se é leitura/escrita,
+ * se exige confirmação explícita, o papel mínimo do usuário, e se audita.
+ *
+ * Princípios (inegociáveis):
+ *  - Cérebro MARKETPLACE (público/plataforma): só dados públicos + operação da
+ *    plataforma para o operador autorizado. NUNCA expõe dado privado de parceiro.
+ *  - Cérebro PARTNER: só dados do PRÓPRIO companyId; nunca dados globais da
+ *    plataforma; nunca dados de outro parceiro; respeita o papel do usuário.
+ *  - Ação de ESCRITA nunca é executada silenciosamente — exige confirmação.
+ *  - Ferramenta desconhecida = NEGADA por padrão (fail-closed).
+ */
+
+export type TomasBrain = 'marketplace' | 'partner'
+export type ToolAccess = 'read' | 'write'
+
+/**
+ * Ranque de papel (crescente). O cérebro PARTNER mapeia modos:
+ *   0 anônimo (site público do parceiro) · 1 corretor (BROKER) ·
+ *   2 administração (ADMIN) · 3 direção/plataforma (SUPER_ADMIN).
+ * O cérebro MARKETPLACE/plataforma reserva os dados globais ao rank 3.
+ */
+export const ROLE_RANK = {
+  anonymous: 0,
+  BROKER: 1,
+  MANAGER: 2,
+  ADMIN: 2,
+  SUPER_ADMIN: 3,
+} as const
+
+export type RoleName = keyof typeof ROLE_RANK
+
+export function roleRank(role?: string | null): number {
+  if (!role) return 0
+  const r = (ROLE_RANK as Record<string, number>)[role]
+  return typeof r === 'number' ? r : 0
+}
+
+export interface ToolPolicy {
+  /** Cérebros onde a ferramenta pode rodar. */
+  brains: TomasBrain[]
+  /** Exige um companyId resolvido (escopo obrigatório do parceiro). */
+  requiresCompanyId: boolean
+  access: ToolAccess
+  /** Ação de escrita exige confirmação explícita antes de executar. */
+  requiresConfirmation: boolean
+  /** Papel mínimo do usuário (rank). 0 = permite anônimo. */
+  minRoleRank: number
+  /** Grava trilha de auditoria ao executar. */
+  audit: boolean
+  description: string
+}
+
+const R = ROLE_RANK
+
+/**
+ * MATRIZ COMPLETA. Ferramentas já implementadas + domínios previstos (declarados
+ * para governar futuras tools sem regressão de segurança). Tudo que não está
+ * aqui é NEGADO por padrão.
+ */
+export const TOOL_POLICIES: Record<string, ToolPolicy> = {
+  // ── Imóveis ──────────────────────────────────────────────────────────────
+  buscar_imoveis: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: false,
+    description: 'Busca imóveis. Marketplace: só publicados (todas as empresas). Partner: só do companyId.',
+  },
+  detalhar_imovel: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: false,
+    description: 'Detalha um imóvel. Mesmo escopo de buscar_imoveis.',
+  },
+  alterar_imovel: {
+    brains: ['partner'], requiresCompanyId: true, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.BROKER, audit: true,
+    description: 'Altera dados/preço de um imóvel do parceiro. Escrita — exige confirmação.',
+  },
+  // ── Leads / Contatos / Visitas / Propostas ─────────────────────────────────
+  registrar_lead: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'write',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: true,
+    description: 'Registra um lead. No marketplace só grava se houver companyId (anúncio de um parceiro); nunca transfere sem consentimento.',
+  },
+  agendar_visita: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: true, access: 'write',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: true,
+    description: 'Agenda uma visita a um imóvel de um parceiro.',
+  },
+  consultar_contatos: {
+    brains: ['partner'], requiresCompanyId: true, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.BROKER, audit: true,
+    description: 'Lista contatos/clientes internos do parceiro. Só interno (corretor+).',
+  },
+  criar_proposta: {
+    brains: ['partner'], requiresCompanyId: true, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.BROKER, audit: true,
+    description: 'Cria uma proposta. Escrita — exige confirmação.',
+  },
+  // ── Transferência de lead (marketplace → parceiro) ────────────────────────
+  transferir_lead: {
+    brains: ['marketplace'], requiresCompanyId: false, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.anonymous, audit: true,
+    description: 'Transfere um lead do marketplace para um parceiro. SEMPRE exige consentimento explícito e versionado (ver lead-transfer-consent).',
+  },
+  // ── Contratos / Locações / Documentos / Pagamentos (administração+) ────────
+  consultar_contratos: {
+    brains: ['partner'], requiresCompanyId: true, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.ADMIN, audit: true,
+    description: 'Contratos do parceiro. Administração+.',
+  },
+  consultar_locacoes: {
+    brains: ['partner'], requiresCompanyId: true, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.ADMIN, audit: true,
+    description: 'Locações/repasses/inadimplência do parceiro. Administração+.',
+  },
+  consultar_documentos: {
+    brains: ['partner'], requiresCompanyId: true, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.BROKER, audit: true,
+    description: 'Documentos do parceiro. Interno (corretor+).',
+  },
+  gerar_cobranca: {
+    brains: ['partner'], requiresCompanyId: true, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.ADMIN, audit: true,
+    description: 'Gera uma cobrança/boleto. Escrita sensível — administração+ e confirmação.',
+  },
+  // ── Relatórios / Usuários ─────────────────────────────────────────────────
+  gerar_relatorio: {
+    brains: ['partner', 'marketplace'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.ADMIN, audit: true,
+    description: 'Relatórios. Partner: escopado ao companyId (admin+). Marketplace: só dados globais para a direção da plataforma (rank 3).',
+  },
+  alterar_usuario: {
+    brains: ['partner', 'marketplace'], requiresCompanyId: true, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.ADMIN, audit: true,
+    description: 'Cria/edita usuário ou permissão. Escrita crítica — administração+ e confirmação.',
+  },
+  // ── Plataforma (somente cérebro marketplace + direção da plataforma) ───────
+  intel_plataforma: {
+    brains: ['marketplace'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.SUPER_ADMIN, audit: true,
+    description: 'Métricas globais da plataforma (receita/MRR/parceiros). SÓ direção da plataforma. Nunca exposto a um parceiro.',
+  },
+  // ── Comunicação (escrita — sempre confirmação) ────────────────────────────
+  enviar_whatsapp: {
+    brains: ['partner', 'marketplace'], requiresCompanyId: false, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.anonymous, audit: true,
+    description: 'Envia WhatsApp em nome do parceiro/plataforma. Escrita — confirmação + auditoria.',
+  },
+  enviar_email: {
+    brains: ['partner', 'marketplace'], requiresCompanyId: false, access: 'write',
+    requiresConfirmation: true, minRoleRank: R.BROKER, audit: true,
+    description: 'Envia e-mail. Escrita — confirmação + auditoria.',
+  },
+}
+
+export interface PolicyContext {
+  brain: TomasBrain
+  companyId?: string
+  /** Rank do papel do usuário (0 anônimo). */
+  roleRank: number
+  /** true quando o usuário já confirmou explicitamente uma ação de escrita. */
+  confirmed?: boolean
+}
+
+export type PolicyDecision =
+  | { decision: 'allow'; policy: ToolPolicy }
+  | { decision: 'deny'; reason: string }
+  | { decision: 'needs_confirmation'; policy: ToolPolicy; reason: string }
+
+/**
+ * Avalia se uma ferramenta pode rodar no contexto dado. Fail-closed:
+ * ferramenta desconhecida → deny.
+ */
+export function evaluateToolPolicy(toolName: string, ctx: PolicyContext): PolicyDecision {
+  const policy = TOOL_POLICIES[toolName]
+  if (!policy) {
+    return { decision: 'deny', reason: `Ferramenta '${toolName}' não é permitida.` }
+  }
+  if (!policy.brains.includes(ctx.brain)) {
+    return { decision: 'deny', reason: `Ferramenta '${toolName}' não está disponível neste cérebro (${ctx.brain}).` }
+  }
+  if (policy.requiresCompanyId && !ctx.companyId) {
+    return { decision: 'deny', reason: `Ferramenta '${toolName}' exige contexto de empresa (companyId).` }
+  }
+  if (ctx.roleRank < policy.minRoleRank) {
+    return { decision: 'deny', reason: `Permissão insuficiente para '${toolName}'.` }
+  }
+  if (policy.access === 'write' && policy.requiresConfirmation && !ctx.confirmed) {
+    return { decision: 'needs_confirmation', policy, reason: `A ação '${toolName}' é uma escrita e precisa de confirmação explícita.` }
+  }
+  return { decision: 'allow', policy }
+}

--- a/apps/api/src/services/tomas.service.ts
+++ b/apps/api/src/services/tomas.service.ts
@@ -16,6 +16,8 @@ import {
   buildPartnerSystemPrompt,
   type PartnerContext,
 } from '@agoraencontrei/tomas-knowledge'
+import { evaluateToolPolicy, roleRank, type TomasBrain } from './tomas-policy.js'
+import { hasValidConsent } from './lead-transfer-consent.service.js'
 import { env } from '../utils/env.js'
 import { notify } from './notification.service.js'
 import { checkAIQuota } from './plan-gating.service.js'
@@ -73,6 +75,10 @@ export interface TomasChatParams {
   visitorId?: string
   companyId?: string
   userId?: string
+  /** Papel do usuário autenticado (BROKER/ADMIN/SUPER_ADMIN…) — gate de permissão. */
+  role?: string
+  /** Confirmação explícita do usuário para ações de escrita (Fase 4). */
+  confirmed?: boolean
   tenantTheme?: string
   nicheSlug?: string        // Dynamic niche from NicheTemplate table
   propertyContext?: {
@@ -344,18 +350,83 @@ const TOMAS_TOOLS: Anthropic.Tool[] = [
 
 // ── Tool Executor ───────────────────────────────────────────────────────────
 
-async function executeTool(
+interface ToolPolicyContext {
+  brain: TomasBrain
+  roleRank: number
+  confirmed?: boolean
+  visitorId?: string
+  chatId?: string
+  userId?: string
+}
+
+export async function executeTool(
   prisma: PrismaClient,
   toolName: string,
   toolInput: Record<string, unknown>,
   companyId?: string,
   channel: 'site' | 'dashboard' = 'site',
+  policyCtx: ToolPolicyContext = { brain: 'marketplace', roleRank: 0 },
 ): Promise<string> {
+  // ── Fase 4: política por ferramenta (fail-closed) ────────────────────────
+  // Antes de QUALQUER ferramenta rodar: valida cérebro, escopo (companyId),
+  // papel do usuário e confirmação de escrita. Nega por padrão o desconhecido.
+  const decision = evaluateToolPolicy(toolName, {
+    brain: policyCtx.brain,
+    companyId,
+    roleRank: policyCtx.roleRank,
+    confirmed: policyCtx.confirmed,
+  })
+  if (decision.decision === 'deny') {
+    return JSON.stringify({ error: 'not_allowed', reason: decision.reason })
+  }
+  if (decision.decision === 'needs_confirmation') {
+    // Nunca executa escrita silenciosamente: pede confirmação com um resumo.
+    return JSON.stringify({
+      needs_confirmation: true,
+      action: toolName,
+      summary: decision.reason,
+      input: toolInput,
+    })
+  }
+  // Auditoria de toda ação de ESCRITA autorizada.
+  if (decision.policy.audit && decision.policy.access === 'write') {
+    try {
+      await prisma.auditLog.create({
+        data: {
+          companyId: companyId ?? null,
+          userId: policyCtx.userId ?? null,
+          action: `tomas.tool.${toolName}`,
+          resource: 'tomas_tool',
+          payload: { brain: policyCtx.brain, roleRank: policyCtx.roleRank } as Prisma.InputJsonValue,
+        },
+      })
+    } catch { /* auditoria nunca quebra o fluxo */ }
+  }
+
   // Public (site) chats must never expose drafts or cross-tenant inventory.
   // Dashboard (authenticated corretor/admin) queries already carry companyId
   // and legitimately need to see the full catalogue.
   const isPublic = channel === 'site'
   switch (toolName) {
+    // ── Transferência de lead marketplace → parceiro (SÓ com consentimento) ──
+    case 'transferir_lead': {
+      const toCompanyId = typeof toolInput.toCompanyId === 'string' ? toolInput.toCompanyId : ''
+      if (!toCompanyId) {
+        return JSON.stringify({ error: 'missing_partner', reason: 'Informe o parceiro de destino (toCompanyId).' })
+      }
+      const ok = await hasValidConsent(prisma, {
+        toCompanyId,
+        visitorId: policyCtx.visitorId,
+        chatId: policyCtx.chatId,
+      })
+      if (!ok) {
+        return JSON.stringify({
+          error: 'consent_required',
+          reason: 'Transferência bloqueada: falta consentimento explícito do usuário para enviar os dados ao parceiro.',
+        })
+      }
+      return JSON.stringify({ ok: true, transferred: true, toCompanyId })
+    }
     case 'buscar_imoveis': {
       const where: Record<string, unknown> = { status: 'ACTIVE' }
       if (companyId) where.companyId = companyId
@@ -659,6 +730,10 @@ export async function runTomasChat(
     systemPrompt = MARKETPLACE_SYSTEM_PROMPT
   }
 
+  // Contexto de política (Fase 4): cérebro efetivo + rank do papel do usuário.
+  const effectiveBrain: TomasBrain = (!params.companyId || isPlatformOperator) ? 'marketplace' : 'partner'
+  const userRoleRank = roleRank(params.role)
+
   if (params.channel === 'dashboard') {
     systemPrompt += DASHBOARD_ADDENDUM
 
@@ -787,6 +862,14 @@ export async function runTomasChat(
           tb.input as Record<string, unknown>,
           params.companyId,
           params.channel,
+          {
+            brain: effectiveBrain,
+            roleRank: userRoleRank,
+            confirmed: params.confirmed,
+            visitorId: params.visitorId,
+            chatId: params.chatId,
+            userId: params.userId,
+          },
         )
 
         // Track consecutive zero results from buscar_imoveis

--- a/apps/api/test/lead-transfer-consent.test.ts
+++ b/apps/api/test/lead-transfer-consent.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  minimalLeadData,
+  buildConsentText,
+  recordLeadTransferConsent,
+  hasValidConsent,
+  revokeLeadTransferConsent,
+  CONSENT_TEXT_VERSION,
+} from '../src/services/lead-transfer-consent.service.js'
+
+// Store em memória imitando a tabela lead_transfer_consents.
+function memPrisma() {
+  const rows: any[] = []
+  let seq = 0
+  return {
+    _rows: rows,
+    auditLog: { create: async () => ({}) },
+    leadTransferConsent: {
+      create: async ({ data }: any) => { const r = { id: `k${++seq}`, ...data }; rows.push(r); return r },
+      findFirst: async ({ where }: any) => {
+        const ors = where.OR || []
+        return rows.filter(r =>
+          r.toCompanyId === where.toCompanyId && r.granted === true && r.revokedAt == null &&
+          ors.some((o: any) => (o.visitorId && r.visitorId === o.visitorId) || (o.chatId && r.chatId === o.chatId)),
+        ).slice(-1)[0] || null
+      },
+      updateMany: async ({ where, data }: any) => {
+        const ors = where.OR || []
+        let count = 0
+        for (const r of rows) {
+          if (r.toCompanyId === where.toCompanyId && r.granted === true && r.revokedAt == null &&
+              ors.some((o: any) => (o.visitorId && r.visitorId === o.visitorId) || (o.chatId && r.chatId === o.chatId))) {
+            Object.assign(r, data); count++
+          }
+        }
+        return { count }
+      },
+    },
+  } as any
+}
+
+test('minimalLeadData: mantém só o mínimo e descarta o resto (LGPD)', () => {
+  const out = minimalLeadData({
+    name: 'João', phone: '16999', email: 'a@b.com', city: 'Franca',
+    cpf: '12345678900', rg: 'x', fullChatHistory: 'tudo', senha: 'secreta',
+  } as any)
+  assert.deepEqual(Object.keys(out).sort(), ['city', 'email', 'name', 'phone'])
+  assert.equal((out as any).cpf, undefined)
+  assert.equal((out as any).fullChatHistory, undefined)
+})
+
+test('buildConsentText: informa parceiro, dados, finalidade e canal', () => {
+  const t = buildConsentText({
+    partnerName: 'Imobiliária Lemos',
+    data: { name: 'João', phone: '16999' },
+    purpose: 'apresentar imóveis',
+    channel: 'WhatsApp',
+  })
+  assert.match(t, /Imobiliária Lemos/)
+  assert.match(t, /nome, telefone/)
+  assert.match(t, /apresentar imóveis/)
+  assert.match(t, /WhatsApp/)
+  assert.match(t, /revogar/)
+})
+
+test('fluxo: registrar → consentimento válido → revogar → inválido', async () => {
+  const p = memPrisma()
+  const rec = await recordLeadTransferConsent(p, {
+    visitorId: 'v1', toCompanyId: 'lemos', toCompanyName: 'Imobiliária Lemos',
+    purpose: 'contato', channel: 'whatsapp', data: { name: 'João', phone: '16999', cpf: 'x' } as any,
+  })
+  // versão e minimização gravadas
+  assert.equal(rec.consentVersion, CONSENT_TEXT_VERSION)
+  assert.deepEqual(Object.keys(rec.dataShared).sort(), ['name', 'phone'])
+
+  assert.equal(await hasValidConsent(p, { toCompanyId: 'lemos', visitorId: 'v1' }), true)
+  // outro parceiro não herda o consentimento
+  assert.equal(await hasValidConsent(p, { toCompanyId: 'outra', visitorId: 'v1' }), false)
+  // outro visitante não herda
+  assert.equal(await hasValidConsent(p, { toCompanyId: 'lemos', visitorId: 'v2' }), false)
+
+  const n = await revokeLeadTransferConsent(p, { toCompanyId: 'lemos', visitorId: 'v1' })
+  assert.equal(n, 1)
+  assert.equal(await hasValidConsent(p, { toCompanyId: 'lemos', visitorId: 'v1' }), false)
+})
+
+test('hasValidConsent: sem visitorId/chatId → false (nunca "vale por padrão")', async () => {
+  assert.equal(await hasValidConsent(memPrisma(), { toCompanyId: 'lemos' }), false)
+})

--- a/apps/api/test/tomas-policy.test.ts
+++ b/apps/api/test/tomas-policy.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { evaluateToolPolicy, roleRank, ROLE_RANK } from '../src/services/tomas-policy.js'
+
+const partner = (over: any = {}) => ({ brain: 'partner' as const, companyId: 'c1', roleRank: ROLE_RANK.ADMIN, ...over })
+const market = (over: any = {}) => ({ brain: 'marketplace' as const, roleRank: ROLE_RANK.anonymous, ...over })
+
+test('ferramenta desconhecida = negada (fail-closed)', () => {
+  const d = evaluateToolPolicy('drop_all_tables', partner())
+  assert.equal(d.decision, 'deny')
+})
+
+test('intel da plataforma: só marketplace + direção (rank 3); parceiro negado', () => {
+  assert.equal(evaluateToolPolicy('intel_plataforma', market({ roleRank: ROLE_RANK.SUPER_ADMIN })).decision, 'allow')
+  assert.equal(evaluateToolPolicy('intel_plataforma', market({ roleRank: ROLE_RANK.ADMIN })).decision, 'deny')
+  // parceiro NUNCA acessa intel global, nem como admin
+  assert.equal(evaluateToolPolicy('intel_plataforma', partner({ roleRank: ROLE_RANK.SUPER_ADMIN })).decision, 'deny')
+})
+
+test('ferramenta de parceiro exige companyId', () => {
+  assert.equal(evaluateToolPolicy('consultar_contatos', partner({ companyId: undefined })).decision, 'deny')
+  assert.equal(evaluateToolPolicy('consultar_contatos', partner()).decision, 'allow')
+})
+
+test('corretor (rank 1) NÃO executa ação administrativa (rank 2)', () => {
+  const broker = partner({ roleRank: ROLE_RANK.BROKER })
+  assert.equal(evaluateToolPolicy('consultar_contratos', broker).decision, 'deny') // admin+
+  assert.equal(evaluateToolPolicy('consultar_documentos', broker).decision, 'allow') // broker+
+})
+
+test('escrita exige confirmação explícita', () => {
+  const ctx = partner({ roleRank: ROLE_RANK.ADMIN })
+  const noConfirm = evaluateToolPolicy('criar_proposta', ctx)
+  assert.equal(noConfirm.decision, 'needs_confirmation')
+  const confirmed = evaluateToolPolicy('criar_proposta', { ...ctx, confirmed: true })
+  assert.equal(confirmed.decision, 'allow')
+})
+
+test('transferir_lead: só marketplace, escrita, exige confirmação', () => {
+  assert.equal(evaluateToolPolicy('transferir_lead', partner()).decision, 'deny') // não existe no cérebro partner
+  const m = evaluateToolPolicy('transferir_lead', market())
+  assert.equal(m.decision, 'needs_confirmation')
+  assert.equal(evaluateToolPolicy('transferir_lead', market({ confirmed: true })).decision, 'allow')
+})
+
+test('gerar_cobranca: escrita sensível, administração+ e confirmação', () => {
+  assert.equal(evaluateToolPolicy('gerar_cobranca', partner({ roleRank: ROLE_RANK.BROKER })).decision, 'deny')
+  assert.equal(evaluateToolPolicy('gerar_cobranca', partner({ roleRank: ROLE_RANK.ADMIN })).decision, 'needs_confirmation')
+})
+
+test('leitura pública de imóveis liberada para anônimo nos dois cérebros', () => {
+  assert.equal(evaluateToolPolicy('buscar_imoveis', market()).decision, 'allow')
+  assert.equal(evaluateToolPolicy('buscar_imoveis', { brain: 'partner', companyId: 'c1', roleRank: 0 }).decision, 'allow')
+})
+
+test('roleRank: desconhecido/nulo → 0 (anônimo)', () => {
+  assert.equal(roleRank(null), 0)
+  assert.equal(roleRank('HACKER'), 0)
+  assert.equal(roleRank('SUPER_ADMIN'), 3)
+})

--- a/apps/api/test/tomas-tool-enforcement.test.ts
+++ b/apps/api/test/tomas-tool-enforcement.test.ts
@@ -1,0 +1,87 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { executeTool } from '../src/services/tomas.service.js'
+import { ROLE_RANK } from '../src/services/tomas-policy.js'
+
+// Prisma falso: registra auditLog e resolve consentimento conforme o teste.
+function fakePrisma(opts: { consent?: any } = {}): any {
+  const audits: any[] = []
+  const captured: any = {}
+  return {
+    _audits: audits,
+    _captured: captured,
+    auditLog: { create: async (a: any) => { audits.push(a.data); return a.data } },
+    leadTransferConsent: { findFirst: async () => opts.consent ?? null },
+    property: {
+      findMany: async (args: any) => { captured.where = args?.where; return [] },
+      findFirst: async () => null,
+    },
+  }
+}
+const parse = (s: string) => JSON.parse(s)
+
+test('ferramenta desconhecida → not_allowed (nem toca no banco)', async () => {
+  const r = parse(await executeTool(fakePrisma(), 'rm_rf', {}, 'c1', 'dashboard', { brain: 'partner', roleRank: ROLE_RANK.ADMIN }))
+  assert.equal(r.error, 'not_allowed')
+})
+
+test('parceiro: ferramenta interna sem companyId → not_allowed', async () => {
+  const r = parse(await executeTool(fakePrisma(), 'consultar_contatos', {}, undefined, 'site', { brain: 'partner', roleRank: ROLE_RANK.ADMIN }))
+  assert.equal(r.error, 'not_allowed')
+})
+
+test('parceiro: corretor NÃO acessa contratos (admin+) → not_allowed', async () => {
+  const r = parse(await executeTool(fakePrisma(), 'consultar_contratos', {}, 'c1', 'dashboard', { brain: 'partner', roleRank: ROLE_RANK.BROKER }))
+  assert.equal(r.error, 'not_allowed')
+})
+
+test('intel da plataforma NUNCA no cérebro do parceiro → not_allowed', async () => {
+  const r = parse(await executeTool(fakePrisma(), 'intel_plataforma', {}, 'c1', 'dashboard', { brain: 'partner', roleRank: ROLE_RANK.SUPER_ADMIN }))
+  assert.equal(r.error, 'not_allowed')
+})
+
+test('escrita sensível sem confirmação → needs_confirmation (não executa)', async () => {
+  const p = fakePrisma()
+  const r = parse(await executeTool(p, 'criar_proposta', { valor: 1 }, 'c1', 'dashboard', { brain: 'partner', roleRank: ROLE_RANK.ADMIN }))
+  assert.equal(r.needs_confirmation, true)
+  assert.equal(r.action, 'criar_proposta')
+  assert.equal(p._audits.length, 0) // não auditou porque não executou
+})
+
+test('transferir_lead SEM consentimento → consent_required (bloqueado)', async () => {
+  const r = parse(await executeTool(fakePrisma({ consent: null }), 'transferir_lead', { toCompanyId: 'p1' }, undefined, 'site', {
+    brain: 'marketplace', roleRank: ROLE_RANK.anonymous, confirmed: true, visitorId: 'v1',
+  }))
+  assert.equal(r.error, 'consent_required')
+})
+
+test('transferir_lead COM consentimento → ok + auditado', async () => {
+  const p = fakePrisma({ consent: { id: 'k1', granted: true } })
+  const r = parse(await executeTool(p, 'transferir_lead', { toCompanyId: 'p1' }, undefined, 'site', {
+    brain: 'marketplace', roleRank: ROLE_RANK.anonymous, confirmed: true, visitorId: 'v1',
+  }))
+  assert.equal(r.ok, true)
+  assert.equal(r.toCompanyId, 'p1')
+  // escrita autorizada foi auditada
+  assert.ok(p._audits.some((a: any) => a.action === 'tomas.tool.transferir_lead'))
+})
+
+test('leitura pública de imóveis continua liberada (sem regressão)', async () => {
+  const r = parse(await executeTool(fakePrisma(), 'buscar_imoveis', { city: 'Franca' }, undefined, 'site', { brain: 'marketplace', roleRank: 0 }))
+  assert.equal(r.found, 0) // mock retorna [], mas passou pela política sem erro
+})
+
+test('anti-injeção: companyId injetado no tool input é IGNORADO (usa o do servidor)', async () => {
+  const p = fakePrisma()
+  // Usuário/modelo tenta forçar outra empresa via toolInput.companyId.
+  await executeTool(p, 'buscar_imoveis', { companyId: 'EMPRESA_DE_OUTRO_TENANT', city: 'X' }, 'company_do_jwt', 'dashboard', { brain: 'partner', roleRank: 1 })
+  // O escopo real usa o companyId do servidor (JWT), nunca o do input.
+  assert.equal(p._captured.where.companyId, 'company_do_jwt')
+})
+
+test('anti-injeção: marketplace público força authorizedPublish e não vaza rascunhos', async () => {
+  const p = fakePrisma()
+  await executeTool(p, 'buscar_imoveis', { city: 'X' }, undefined, 'site', { brain: 'marketplace', roleRank: 0 })
+  assert.equal(p._captured.where.authorizedPublish, true)
+  assert.equal(p._captured.where.companyId, undefined) // nacional: sem filtro de empresa, mas só publicados
+})

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2947,6 +2947,36 @@ model TomasChatMessage {
   @@map("tomas_chat_messages")
 }
 
+/// Consentimento explícito para transferir um lead do MARKETPLACE para um
+/// parceiro. Nenhuma transferência acontece silenciosamente — cada registro
+/// guarda o que foi mostrado ao usuário, o que foi enviado, a finalidade, o
+/// canal, a versão do texto, a origem e uma eventual revogação (trilha LGPD).
+model LeadTransferConsent {
+  id             String    @id @default(cuid())
+  chatId         String?
+  visitorId      String?
+  leadId         String?
+  fromBrain      String    @default("marketplace")
+  toCompanyId    String    // parceiro de destino
+  toCompanyName  String?
+  purpose        String    // finalidade do contato
+  channel        String    // canal autorizado (whatsapp | email | phone)
+  dataShared     Json      @default("{}")  // dados MÍNIMOS transferidos
+  consentText    String    @db.Text         // texto exato exibido ao usuário
+  consentVersion String                     // versão do texto de consentimento
+  source         String?                    // origem (ex.: "tomas_widget")
+  granted        Boolean   @default(true)
+  grantedAt      DateTime  @default(now())
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+
+  @@index([toCompanyId])
+  @@index([visitorId])
+  @@index([chatId])
+  @@index([leadId])
+  @@map("lead_transfer_consents")
+}
+
 // =============================================================================
 // TOUR VIRTUAL
 // =============================================================================


### PR DESCRIPTION
Fecha a separação dos dois cérebros com **política por ferramenta**, **confirmação de escrita** e **consentimento explícito** para transferir lead marketplace → parceiro.

## Verificação prévia (antes da Fase 4)
- CI `test` na main após #272: ✅ **success** (f0491a5).
- API (Railway): ✅ healthy, `db: connected`. Web: ✅ HTTP 200.
- **Marketplace brain LIVE**: "Sou Tomás IA, do AgoraEncontrei — o marketplace imobiliário… em todo o Brasil" → identidade nacional/imparcial correta, criou `chatId`. Sem regressão.
- Partner brain LIVE: não testável (tenant `lemos` = `TENANT_NOT_FOUND`, provisionamento pausado — esperado). Validado por testes de código.
- Áudio: manual (browser). **Nenhuma regressão encontrada.**

## A — Consentimento marketplace → parceiro (LGPD)
- **`LeadTransferConsent`** (schema + boot migration idempotente `CREATE TABLE IF NOT EXISTS`): guarda parceiro de destino, **dados mínimos**, finalidade, canal, **texto exato**, **versão**, origem, carimbo de tempo e **revogação**.
- **`lead-transfer-consent.service`**: `minimalLeadData` (descarta tudo além do mínimo — **nunca o chat inteiro**), `buildConsentText` (informa parceiro/dados/finalidade/canal), `recordLeadTransferConsent`/`hasValidConsent`/`revokeLeadTransferConsent` + **trilha de auditoria**. Sem consentimento vigente → transferência **bloqueada**. O usuário pode recusar e seguir no marketplace.

## B/C — Matriz de política por ferramenta (`tomas-policy.ts`)
Fonte única de permissões por cérebro/ferramenta: cérebros permitidos, `requiresCompanyId`, leitura/escrita, `requiresConfirmation`, papel mínimo, auditoria. **Fail-closed**: ferramenta desconhecida é **negada**. Cobre os domínios pedidos (imóveis, leads, contatos, propostas, visitas, contratos, locações, documentos, pagamentos, relatórios, usuários, transferência, comunicação, plataforma) — ferramentas já implementadas são enforçadas; as futuras ficam declaradas para não regredir.
- Parceiro só toca o **próprio companyId**; **nunca** intel global da plataforma; papéis (corretor/administração/direção) com capacidades distintas.
- Intel da plataforma reservado ao cérebro **marketplace + direção da plataforma** (rank 3).

## D — Confirmação de escrita
`executeTool` aplica a política **antes** de qualquer ferramenta. Escrita sensível sem confirmação → `needs_confirmation` (com resumo da ação), **nunca executa em silêncio**. Toda escrita autorizada é **auditada**. O escopo (`companyId`) vem **sempre do servidor** (JWT/tenant), nunca do tool input.

## E — Testes (23 novos · **70/70 na API**)
`tomas-policy.test.ts` (9), `tomas-tool-enforcement.test.ts` (10), `lead-transfer-consent.test.ts` (4) — cobrem: fail-closed; intel só plataforma; parceiro sem companyId negado; **corretor ≠ admin**; **escrita → confirmação**; **transferir sem consentimento bloqueado**; **consentimento versionado/auditado**; **revogação respeitada**; **anti-injeção** (companyId do tool input é ignorado; marketplace força `authorizedPublish`); isolamento entre parceiros/visitantes.

## Arquivos
**Novos:** `services/tomas-policy.ts`, `services/lead-transfer-consent.service.ts`, 3 arquivos de teste.
**Editados:** `services/tomas.service.ts` (gate de política + auditoria + `transferir_lead` + `executeTool` exportado + params `role`/`confirmed`), `routes/tomas/index.ts` (thread `role`+`confirm`), `server.ts` (boot migration da tabela de consentimento), `schema.prisma` (modelo `LeadTransferConsent`).

## Verificação
`build packages` ✓ · `prisma generate/validate` ✓ · `verify:boot` ✓ (98 rotas) · `typecheck` API sem erros novos (só o pré-existente `plugins/automation.ts`) · **70/70 testes**. Web não foi tocado nesta fase.

## Riscos & rollback
- **Risco baixo**: mudanças aditivas. As 4 ferramentas hoje expostas ao LLM (`buscar_imoveis`, `detalhar_imovel`, `registrar_lead`, `agendar_visita`) continuam liberadas nos caminhos válidos — a política só **nega** o que já era indevido e pede confirmação em escritas sensíveis (nenhuma delas está no conjunto atual de tools do LLM, então **sem mudança de comportamento** para chats atuais).
- **Migração**: `CREATE TABLE IF NOT EXISTS` no boot — aditiva, idempotente, sem reescrita de dados.
- **Rollback**: reverter o merge; a tabela `lead_transfer_consents` pode permanecer (não usada) sem efeito. Nenhuma coluna existente foi alterada.

## Follow-up (fora desta fase)
- Expor `transferir_lead`/`revogar_consentimento` como tools do LLM + UX de botão de confirmação/consentimento no widget.
- Implementar as ferramentas internas declaradas na matriz (contratos/locações/pagamentos) conforme forem necessárias — já governadas pela política.

Não inclui provisionamento/migração da Lemos. Sem auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_