### PR TITLE
ci: workflow DRY-RUN do provisionamento Lemos (disparável pelo celular)

### DIFF
--- a/.github/workflows/lemos-provision-dryrun.yml
+++ b/.github/workflows/lemos-provision-dryrun.yml
@@ -1,0 +1,71 @@
+name: Lemos Provisioning — DRY-RUN (seguro)
+
+# Dispara pelo celular: aba Actions → este workflow → "Run workflow".
+# SEGURANÇA: este workflow FORÇA DRY_RUN=true e NUNCA define
+# CONFIRM_PRODUCTION_MIGRATION — por construção é IMPOSSÍVEL ele executar a
+# migração real. Ele só PRÉ-VISUALIZA os números (não grava nada).
+#
+# Pré-requisito (uma vez, pelo GitHub do celular):
+#   Settings → Secrets and variables → Actions → New repository secret
+#     LEMOS_PROVISION_DATABASE_URL   = <URL Postgres de produção do Neon>
+#     LEMOS_PROVISION_DIRECT_URL     = <URL DIRETA do Neon> (opcional; senão usa a de cima)
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_mode:
+        description: 'SOURCE_MODE (company | user | company_and_user)'
+        required: true
+        default: 'company'
+      source_company_id:
+        description: 'SOURCE_COMPANY_ID (company de origem dos imóveis)'
+        required: false
+        default: 'cmnhzieqf0000mx1cqcqgfv4n'
+      source_user_email:
+        description: 'SOURCE_USER_EMAIL (só se SOURCE_MODE usar user)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: ${{ secrets.LEMOS_PROVISION_DATABASE_URL }}
+      DIRECT_DATABASE_URL: ${{ secrets.LEMOS_PROVISION_DIRECT_URL || secrets.LEMOS_PROVISION_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Checar segredo configurado
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::Falta o segredo LEMOS_PROVISION_DATABASE_URL. Adicione em Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          echo "Segredo presente ✅ (valor mascarado pelo GitHub)."
+
+      - name: Install
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Prisma generate
+        run: pnpm db:generate
+
+      - name: DRY-RUN (NUNCA grava — DRY_RUN forçado true, sem CONFIRM)
+        env:
+          DRY_RUN: 'true'
+          SOURCE_MODE: ${{ inputs.source_mode }}
+          SOURCE_COMPANY_ID: ${{ inputs.source_company_id }}
+          SOURCE_USER_EMAIL: ${{ inputs.source_user_email }}
+        run: npx tsx scripts/provision-imobiliaria-lemos.ts


### PR DESCRIPTION
Permite rodar o **dry-run** do provisionamento da Lemos direto do **GitHub Actions** — pensado para disparar **pelo celular**, sem terminal.

## Por que
Você está no celular e não dá para rodar `pg_dump`/`npx tsx` na mão. Com este workflow, você abre a aba **Actions**, clica **Run workflow**, e lê os números no log.

## Segurança (por construção)
- O workflow **força `DRY_RUN=true`** e **nunca** define `CONFIRM_PRODUCTION_MIGRATION`. É **impossível** ele executar a migração real — só **pré-visualiza** (não grava nada).
- A URL do banco fica num **segredo do repositório** (`LEMOS_PROVISION_DATABASE_URL`), nunca no código nem no chat. O GitHub mascara o valor nos logs.
- `permissions: contents: read` (menor privilégio).

## Como usar (tudo pelo app do GitHub no celular)
1. **Merge deste PR** (o botão "Run workflow" só aparece com o workflow na `main`).
2. **Settings → Secrets and variables → Actions → New repository secret**:
   - `LEMOS_PROVISION_DATABASE_URL` = URL Postgres de produção do Neon (`...neon.../...?sslmode=require`)
   - *(opcional)* `LEMOS_PROVISION_DIRECT_URL` = URL direta do Neon
3. **Actions → "Lemos Provisioning — DRY-RUN (seguro)" → Run workflow** (deixe os inputs padrão: `source_mode=company`, `source_company_id=cmnhzieqf0000mx1cqcqgfv4n`).
4. Abra o log do passo **DRY-RUN** e me mande **só os números**:
   - `Imóveis a mover: N`
   - `Usuários: 9 (X já existem → movidos; Y novos)`
   - `Contatos-proprietários: movíveis N`

Com isso eu confirmo se o `SOURCE_COMPANY_ID` está certo (se "Imóveis a mover" vier **0**, o id de origem está errado).

## Observações
- O **backup do Neon** (snapshot) só é necessário **antes da execução real** — o dry-run não grava nada, então não precisa de backup para este passo. Quando formos executar de verdade, aí sim criamos o branch/snapshot no Neon primeiro.
- A execução real continuará sendo um passo **separado e deliberado**, com sua confirmação explícita — este workflow não a permite.

Sem auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_