### PR TITLE
feat(web): logo completo AgoraEncontrei na barra superior da home + editável no admin

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -1070,6 +1070,7 @@ export default async function publicRoutes(app: FastifyInstance) {
       // ── Marca do cabeçalho (ícone + escrita, editável no admin) ────────
       logoIconUrl:     settings.logoIconUrl     ?? companyConfig.logoIconUrl     ?? null,
       logoWordmarkUrl: settings.logoWordmarkUrl ?? companyConfig.logoWordmarkUrl ?? null,
+      logoFullUrl:     settings.logoFullUrl     ?? companyConfig.logoFullUrl     ?? null,
       logoVisible:     settings.logoVisible     ?? companyConfig.logoVisible     ?? true,
       logoShowText:    settings.logoShowText    ?? companyConfig.logoShowText    ?? true,
       logoPosition:    settings.logoPosition    ?? companyConfig.logoPosition    ?? 'left',

--- a/apps/api/src/routes/system-config/index.ts
+++ b/apps/api/src/routes/system-config/index.ts
@@ -400,6 +400,10 @@ export const DEFAULT_SYSTEM_CONFIG = {
     // controla o alinhamento do bloco de marca no cabeçalho.
     logoIconUrl:       '',
     logoWordmarkUrl:   '',
+    // logoFullUrl: imagem única (emblema + escrita, como no login) exibida no
+    // canto esquerdo do cabeçalho da home. Quando definida, substitui o par
+    // ícone + marca escrita. Vazio → usa o logo completo padrão do AE.
+    logoFullUrl:       '',
     logoVisible:       true,
     logoShowText:      true,
     logoPosition:      'left',
@@ -595,7 +599,7 @@ export default async function systemConfigRoutes(app: FastifyInstance) {
     for (const field of ['heroVideoUrl', 'heroVideoType', 'heroImageUrl'] as const) {
       if (newSite[field] !== undefined) heroMirror[field] = newSite[field]
     }
-    for (const field of ['logoUrl', 'logoIconUrl', 'logoWordmarkUrl', 'logoVisible', 'logoShowText', 'logoPosition'] as const) {
+    for (const field of ['logoUrl', 'logoIconUrl', 'logoWordmarkUrl', 'logoFullUrl', 'logoVisible', 'logoShowText', 'logoPosition'] as const) {
       if (newCompany[field] !== undefined) heroMirror[field] = newCompany[field]
     }
 

--- a/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/SystemConfigPanel.tsx
@@ -1260,6 +1260,15 @@ export function SystemConfigPanel() {
                     token={apiToken}
                     placeholder="Cole uma URL ou envie uma imagem"
                   />
+                  <MediaUploadInput
+                    label="Logo Completo (emblema + escrita — igual ao login)"
+                    hint="Imagem única com o emblema e a escrita juntos, exibida no canto esquerdo do cabeçalho da home (substitui ícone + marca escrita separados). Deixe em branco para usar o logo completo padrão do AgoraEncontrei."
+                    value={cfg.company?.logoFullUrl ?? ''}
+                    onChange={v => updateCfg('company','logoFullUrl', v)}
+                    kind="image"
+                    token={apiToken}
+                    placeholder="Cole uma URL ou envie uma imagem"
+                  />
                 </div>
 
                 <div className="border-t border-white/10 pt-4 space-y-3">

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -155,6 +155,7 @@ export default async function PublicLayout({ children }: { children: React.React
       <Navbar
         logoUrl={brand.logoUrl}
         wordmarkUrl={brand.wordmarkUrl}
+        fullLogoUrl={brand.fullLogoUrl}
         companyName={brand.companyName}
         hasCustomLogo={brand.hasCustomLogo}
         visible={brand.visible}

--- a/apps/web/src/components/public/Navbar.tsx
+++ b/apps/web/src/components/public/Navbar.tsx
@@ -79,6 +79,9 @@ const DEFAULT_NAV_WORDMARK = '/brand/ae-wordmark-light.png'
 interface NavbarProps {
   logoUrl?: string
   wordmarkUrl?: string | null
+  /** Logo COMPLETO (emblema + escrita). Quando presente, é renderizado como uma
+   *  única imagem (igual ao login), no lugar de ícone + wordmark separados. */
+  fullLogoUrl?: string | null
   companyName?: string | null
   hasCustomLogo?: boolean
   visible?: boolean
@@ -89,6 +92,7 @@ interface NavbarProps {
 export function Navbar({
   logoUrl,
   wordmarkUrl,
+  fullLogoUrl,
   companyName,
   hasCustomLogo,
   visible = true,
@@ -155,38 +159,53 @@ export function Navbar({
               className={`flex items-center gap-2.5 group flex-shrink-0 ${position === 'center' ? 'md:absolute md:left-1/2 md:-translate-x-1/2' : ''}`}
               aria-label={`${brandName ?? 'AgoraEncontrei'} — Marketplace Imobiliário`}
             >
-              <Image
-                src={brandLogo}
-                alt={brandName ? `${brandName} Marketplace` : 'AgoraEncontrei Marketplace'}
-                width={44}
-                height={44}
-                className="flex-shrink-0"
-                style={{ borderRadius: '50%' }}
-                priority
-                unoptimized={brandLogoUnoptimized}
-              />
-              {showText && (
-                brandName ? (
-                  <div className="flex flex-col leading-none">
-                    <span className="text-base tracking-tight" style={{ fontFamily: 'Arial, Helvetica, sans-serif', letterSpacing: '-0.01em', color: '#d1d5db', fontWeight: 700 }}>
-                      {brandName}
-                    </span>
-                    <span className="text-[9px] font-medium" style={{ color: '#9ca3af', letterSpacing: '0.04em' }}>
-                      Marketplace
-                    </span>
-                  </div>
-                ) : (
-                  // Marca escrita padrão "Agora Encontrei Marketplace" (imagem),
-                  // editável pelo admin (systemConfig.company.logoWordmarkUrl).
+              {fullLogoUrl ? (
+                // Logo COMPLETO (emblema + escrita) — igual ao login, sem caixa.
+                <Image
+                  src={fullLogoUrl}
+                  alt={brandName ? `${brandName}` : 'AgoraEncontrei — Marketplace Imobiliário'}
+                  width={320}
+                  height={116}
+                  className="w-auto h-9 sm:h-10 object-contain flex-shrink-0"
+                  priority
+                  unoptimized={fullLogoUrl.startsWith('data:')}
+                />
+              ) : (
+                <>
                   <Image
-                    src={brandWordmark}
-                    alt="Agora Encontrei Marketplace"
-                    width={148}
-                    height={40}
-                    className="flex-shrink-0 h-9 w-auto"
+                    src={brandLogo}
+                    alt={brandName ? `${brandName} Marketplace` : 'AgoraEncontrei Marketplace'}
+                    width={44}
+                    height={44}
+                    className="flex-shrink-0"
+                    style={{ borderRadius: '50%' }}
                     priority
+                    unoptimized={brandLogoUnoptimized}
                   />
-                )
+                  {showText && (
+                    brandName ? (
+                      <div className="flex flex-col leading-none">
+                        <span className="text-base tracking-tight" style={{ fontFamily: 'Arial, Helvetica, sans-serif', letterSpacing: '-0.01em', color: '#d1d5db', fontWeight: 700 }}>
+                          {brandName}
+                        </span>
+                        <span className="text-[9px] font-medium" style={{ color: '#9ca3af', letterSpacing: '0.04em' }}>
+                          Marketplace
+                        </span>
+                      </div>
+                    ) : (
+                      // Marca escrita padrão "Agora Encontrei Marketplace" (imagem),
+                      // editável pelo admin (systemConfig.company.logoWordmarkUrl).
+                      <Image
+                        src={brandWordmark}
+                        alt="Agora Encontrei Marketplace"
+                        width={148}
+                        height={40}
+                        className="flex-shrink-0 h-9 w-auto"
+                        priority
+                      />
+                    )
+                  )}
+                </>
               )}
             </Link>
           ) : <div />}

--- a/apps/web/src/lib/site-settings.ts
+++ b/apps/web/src/lib/site-settings.ts
@@ -13,6 +13,10 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 export const DEFAULT_LOGO_URL = '/brand/ae-icon-round.png'
 export const DEFAULT_FOOTER_LOGO_URL = '/brand/ae-icon-round.png'
 export const DEFAULT_WORDMARK_URL = '/brand/ae-wordmark.png'
+// Logo COMPLETO (emblema + escrita) em tom claro — o mesmo do login. Usado na
+// barra superior da home quando não há logo custom configurado. Editável via
+// `settings.logoFullUrl`.
+export const DEFAULT_FULL_LOGO_URL = '/brand/ae-logo-full-light.png'
 export const DEFAULT_PRIMARY_COLOR = '#143A1F'
 export const DEFAULT_ACCENT_COLOR = '#C9A84C'
 
@@ -26,6 +30,7 @@ const STALE_PRIMARY_DEFAULTS = new Set(['#1b2b5b', '#011347'])
 export interface SiteSettings {
   logoUrl?: string | null
   logoIconUrl?: string | null
+  logoFullUrl?: string | null
   logoWordmarkUrl?: string | null
   logoVisible?: boolean | null
   logoShowText?: boolean | null
@@ -117,6 +122,7 @@ export function resolveSiteBrand(
 ): {
   logoUrl: string
   wordmarkUrl: string | null
+  fullLogoUrl: string | null
   companyName: string | null
   hasCustomLogo: boolean
   hasCustomWordmark: boolean
@@ -135,9 +141,18 @@ export function resolveSiteBrand(
   const name = typeof settings.companyName === 'string' && settings.companyName.trim() !== ''
     ? settings.companyName.trim()
     : null
+  // Logo COMPLETO (emblema + escrita), como no login. Prioridade:
+  //   1. logoFullUrl custom do admin (editável);
+  //   2. sem ícone custom → o full padrão do AgoraEncontrei (tom claro);
+  //   3. com ícone custom mas sem full → null (mantém ícone + wordmark).
+  const customFull = typeof settings.logoFullUrl === 'string' && settings.logoFullUrl.trim() !== ''
+    ? settings.logoFullUrl.trim()
+    : null
+  const fullLogoUrl = customFull || (custom ? null : DEFAULT_FULL_LOGO_URL)
   return {
     logoUrl: custom ? (iconCandidate as string).trim() : fallbackLogo,
     wordmarkUrl: wordmarkCandidate,
+    fullLogoUrl,
     companyName: name,
     hasCustomLogo: custom,
     hasCustomWordmark: !!wordmarkCandidate,


### PR DESCRIPTION
## O que muda

Coloca o **logo completo** (emblema + escrita, exatamente o mesmo do login) no **canto esquerdo do cabeçalho da home pública** do AgoraEncontrei, no lugar do par ícone + marca escrita separados, e o torna **editável nas Configurações** (conforme pedido: "coloque nas configurações para ser editável futuramente").

## Detalhes

**Web**
- `lib/site-settings.ts`: `DEFAULT_FULL_LOGO_URL` (`/brand/ae-logo-full-light.png`) + `resolveSiteBrand().fullLogoUrl`. Prioridade: (1) `logoFullUrl` custom do admin; (2) sem ícone custom → full padrão do AE; (3) com ícone custom mas sem full → `null` (mantém ícone + wordmark, sem regressão para parceiros).
- `components/public/Navbar.tsx`: quando `fullLogoUrl` presente, renderiza uma **única imagem sem caixa** (`h-9 sm:h-10`, `object-contain`), igual ao login; senão mantém o bloco ícone + wordmark original.
- `app/(public)/layout.tsx`: passa `fullLogoUrl={brand.fullLogoUrl}` ao `Navbar`.
- `settings/SystemConfigPanel.tsx`: novo campo **"Logo Completo"** na seção Logotipos.

**API**
- `system-config`: persiste e espelha `logoFullUrl` (default `''` + loop de mirror company→settings).
- `public/site-settings`: passa a devolver `logoFullUrl` (`settings.logoFullUrl ?? companyConfig.logoFullUrl ?? null`).

## Verificação
- `tsc --noEmit` (web e API): nenhum erro novo nos arquivos alterados (erros pré-existentes do CLAUDE.md permanecem intocados).
- Asset `apps/web/public/brand/ae-logo-full-light.png` já presente na `main`.
- Sem regressão: parceiros com ícone custom e sem full continuam com ícone + wordmark; toggle "Mostrar logo" (`visible`) e posição continuam funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_