### PR TITLE
fix(provision): remap cobre invoice.paidBy + formalNotice.operator; erro legível

### DIFF
--- a/scripts/provision-imobiliaria-lemos.ts
+++ b/scripts/provision-imobiliaria-lemos.ts
@@ -217,11 +217,12 @@ const USER_FK_FIELDS: { key: string; fields: string[] }[] = [
   { key: 'agreement',          fields: ['createdBy'] },
   { key: 'commission',         fields: ['brokerId'] },
   { key: 'financing',          fields: ['brokerId'] },
-  { key: 'invoice',            fields: ['reversedBy', 'emittedBy'] },
+  { key: 'invoice',            fields: ['paidBy', 'reversedBy', 'emittedBy'] },
   { key: 'fiscalNote',         fields: ['createdById'] },
   { key: 'iptuCarne',          fields: ['createdBy'] },
   { key: 'accountPayable',     fields: ['createdBy'] },
   { key: 'bankReconciliation', fields: ['createdBy'] },
+  { key: 'formalNotice',       fields: ['operator'] },
   { key: 'legalCaseUpdate',    fields: ['userId'] },
   { key: 'propertyVisit',      fields: ['brokerId'] },
   { key: 'document',           fields: ['uploadedBy'] },
@@ -534,7 +535,12 @@ async function remapUserRefs(scopeCompanyId: string, snap: Snapshot): Promise<nu
             log(`   • ${m.key}.${field}: ${res.count} (${p.fromEmail} → ${p.toEmail})`)
           }
         } catch (e) {
-          log(`   • ${m.key}.${field}: (ignorado — ${(e as Error).message.slice(0, 60)})`)
+          // Extrai a linha mais útil do erro do Prisma (ex.: coluna inexistente
+          // por drift do schema) em vez do prefixo genérico "Invalid invocation".
+          const msg = (e as Error).message
+          const detail = msg.split('\n').map(l => l.trim())
+            .find(l => /column|does not exist|Unknown|Argument|constraint/i.test(l)) || msg.replace(/\s+/g, ' ').slice(0, 120)
+          log(`   • ${m.key}.${field}: (ignorado — ${detail})`)
         }
       }
     }


### PR DESCRIPTION
## Contexto

A migração real da Lemos **concluiu com sucesso** (3.878 imóveis + 125.847 registros de CRM movidos, backup do Neon criado antes, gabriel desativado, 8 credenciais geradas, snapshot `completed`). Mas os logs mostraram:

- O remapeamento de responsáveis tocou **2 vínculos** (`activity.userId`: 2 → tomas@agora → tomascesarlemossilva@gmail — registros operacionais do Tomás).
- `invoice.reversedBy` / `invoice.emittedBy` deram **"Invalid updateMany invocation"** e foram ignorados. Reproduzido localmente: com o schema atual o `updateMany` é válido — logo o erro em produção é **drift de schema** (as colunas novas de `Invoice` não existem no banco de produção, criado por um `db push` anterior). Como as colunas não existem, **não havia o que remapear ali**.

## O que muda

- `USER_FK_FIELDS` ganha campos de responsável que faltavam: **`invoice.paidBy`** (userId da baixa) e **`formalNotice.operator`** (userId que emitiu).
- O `catch` do remap passa a extrair a linha útil do erro do Prisma (ex.: `column ... does not exist`) em vez do prefixo genérico — drift fica diagnosticável no log.

## Segurança / idempotência

- Um novo run do workflow remapeia **apenas** o que ainda aponta para contas `@agora` (0 se já estiver limpo) e move 0 registros (já migrados).
- Campos cuja coluna não existe no banco continuam sendo **ignorados com mensagem clara**, sem abortar.

## Validação
- Field names confirmados válidos no client Prisma (`invoice.paidBy`, `formalNotice.operator`).
- `invoice.reversedBy`/`rental.reversedBy` `updateMany` funcionam com o schema atual (o erro em prod é drift de coluna, não de código).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_