### PR TITLE
feat: site do parceiro completo — catálogo + detalhe + corretor + link marketplace→parceiro

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -177,6 +177,27 @@ async function resolveCompany(app: FastifyInstance) {
   return company
 }
 
+// Resolve o companyId de um endpoint público de DETALHE. Se a query trouxer
+// `tenantSlug` (site de parceiro em subdomínio/domínio próprio), escopa àquele
+// tenant; caso contrário usa a empresa pública padrão (resolveCompany /
+// PUBLIC_COMPANY_ID). Se o tenantSlug for informado mas não existir, retorna
+// null — NÃO cai na empresa padrão (evita servir o imóvel de outro parceiro sob
+// o domínio errado). Assim o detalhe passa a funcionar no site do parceiro em
+// vez de dar 404 por resolver sempre a empresa principal.
+async function resolveScopedCompanyId(app: FastifyInstance, query: unknown): Promise<string | null> {
+  const q = (query ?? {}) as Record<string, unknown>
+  const tenantSlug = typeof q.tenantSlug === 'string' ? q.tenantSlug.trim() : ''
+  if (tenantSlug) {
+    const tenant = await (app.prisma as any).tenant?.findUnique?.({
+      where: { subdomain: tenantSlug },
+      select: { companyId: true },
+    }).catch(() => null)
+    return tenant?.companyId ?? null
+  }
+  const company = await resolveCompany(app)
+  return company?.id ?? null
+}
+
 // ── In-memory fallback cache (when Redis is unavailable) ──────────────────────
 const _memCache = new Map<string, { value: unknown; expiresAt: number }>()
 
@@ -510,11 +531,11 @@ export default async function publicRoutes(app: FastifyInstance) {
   // GET /api/v1/public/properties/:slug — single property detail
   app.get('/properties/:slug', async (req, reply) => {
     const { slug } = req.params as { slug: string }
-    const company  = await resolveCompany(app)
-    if (!company) return reply.status(503).send({ error: 'SERVICE_UNAVAILABLE' })
+    const companyId = await resolveScopedCompanyId(app, req.query)
+    if (!companyId) return reply.status(503).send({ error: 'SERVICE_UNAVAILABLE' })
 
     const property = await app.prisma.property.findFirst({
-      where:  { slug, companyId: company.id, status: 'ACTIVE', authorizedPublish: true },
+      where:  { slug, companyId, status: 'ACTIVE', authorizedPublish: true },
       select: PUBLIC_PROPERTY_SELECT,
     })
 
@@ -532,18 +553,18 @@ export default async function publicRoutes(app: FastifyInstance) {
   // GET /api/v1/public/properties/:slug/similar — similar properties (same type + city)
   app.get('/properties/:slug/similar', async (req, reply) => {
     const { slug } = req.params as { slug: string }
-    const company  = await resolveCompany(app)
-    if (!company) return reply.status(503).send({ error: 'SERVICE_UNAVAILABLE' })
+    const companyId = await resolveScopedCompanyId(app, req.query)
+    if (!companyId) return reply.status(503).send({ error: 'SERVICE_UNAVAILABLE' })
 
     const base = await app.prisma.property.findFirst({
-      where:  { slug, companyId: company.id, status: 'ACTIVE', authorizedPublish: true },
+      where:  { slug, companyId, status: 'ACTIVE', authorizedPublish: true },
       select: { id: true, type: true, purpose: true, city: true, price: true, priceRent: true },
     })
 
     if (!base) return reply.status(404).send({ error: 'NOT_FOUND' })
 
     const baseWhere = {
-      companyId: company.id,
+      companyId,
       status: 'ACTIVE' as const,
       authorizedPublish: true,
       id: { not: base.id },

--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -547,7 +547,20 @@ export default async function publicRoutes(app: FastifyInstance) {
       data:  { views: { increment: 1 } },
     }).catch(() => {})
 
-    return reply.send(applyLocationPrivacy(property))
+    // Site do parceiro (tenant) dono do imóvel — para o marketplace ENCAMINHAR
+    // ao parceiro ("ver todos os imóveis desta imobiliária"). Só quando o tenant
+    // está ativo e não suspenso. Lookup barato (1 registro, só no detalhe).
+    const partnerTenant = await (app.prisma as any).tenant?.findFirst?.({
+      where: { companyId, isActive: true, planStatus: { not: 'SUSPENDED' } },
+      select: { subdomain: true, customDomain: true, name: true },
+    }).catch(() => null)
+
+    return reply.send({
+      ...applyLocationPrivacy(property),
+      partnerSite: partnerTenant
+        ? { subdomain: partnerTenant.subdomain, customDomain: partnerTenant.customDomain, name: partnerTenant.name }
+        : null,
+    })
   })
 
   // GET /api/v1/public/properties/:slug/similar — similar properties (same type + city)

--- a/apps/web/src/app/(dashboard)/dashboard/meu-site/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/meu-site/page.tsx
@@ -176,6 +176,10 @@ export default function MeuSitePage() {
     logoPosition: 'left' as 'left' | 'center',
   })
   const [saved, setSaved] = useState(false)
+  // Domínio próprio — fluxo à parte (POST /:id/domain com integração Vercel).
+  const [domainInput, setDomainInput] = useState('')
+  const [dnsInfo, setDnsInfo] = useState<{ aRecord?: any; cnameRecord?: any } | null>(null)
+  const [domainError, setDomainError] = useState('')
 
   useEffect(() => {
     if (tenant) {
@@ -210,6 +214,29 @@ export default function MeuSitePage() {
       qc.invalidateQueries({ queryKey: ['tenant-mine'] })
     },
     onError: (e: Error) => alert('Erro ao salvar: ' + e.message),
+  })
+
+  const domainMutation = useMutation({
+    mutationFn: async () => {
+      if (!tenant) return
+      const domain = domainInput.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+      if (domain.length < 4 || !domain.includes('.')) throw new Error('Informe um domínio válido (ex.: www.suaimobiliaria.com.br)')
+      const token = await getValidToken()
+      const res = await fetch(`${API_URL}/api/v1/tenants/${tenant.id}/domain`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ domain }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok || json?.success === false) throw new Error(json?.error ?? json?.message ?? 'Não foi possível conectar o domínio')
+      return json
+    },
+    onSuccess: (json: any) => {
+      setDomainError('')
+      setDnsInfo(json?.data?.dnsInstructions ?? null)
+      qc.invalidateQueries({ queryKey: ['tenant-mine'] })
+    },
+    onError: (e: Error) => { setDomainError(e.message); setDnsInfo(null) },
   })
 
   if (isLoading) {
@@ -270,6 +297,60 @@ export default function MeuSitePage() {
         >
           <Globe className="w-4 h-4" /> {siteUrl.replace(/^https?:\/\//, '')} <ExternalLink className="w-3.5 h-3.5" />
         </a>
+      </div>
+
+      {/* Domínio próprio (opcional) — conecta um domínio do parceiro via Vercel */}
+      <div className="bg-white/5 border border-white/10 rounded-2xl p-5">
+        <h2 className="text-sm font-bold text-white flex items-center gap-2 mb-1">
+          <Globe className="w-4 h-4 text-yellow-400/80" /> Domínio próprio
+        </h2>
+        <p className="text-white/50 text-xs mb-3">
+          Use seu próprio domínio (ex.: <span className="text-white/70">www.suaimobiliaria.com.br</span>) no lugar de
+          {' '}<span className="text-white/70">{tenant.subdomain}.{SITE_ROOT}</span>. Grátis — você aponta o DNS conforme as instruções.
+        </p>
+
+        {tenant.customDomain && (
+          <p className="text-xs text-green-400/90 mb-3">
+            ✓ Domínio conectado: <span className="font-semibold">{tenant.customDomain}</span>
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <input
+            type="text"
+            value={domainInput}
+            onChange={e => setDomainInput(e.target.value)}
+            placeholder={tenant.customDomain || 'www.suaimobiliaria.com.br'}
+            className="flex-1 min-w-[220px] bg-white/5 border border-white/10 rounded-xl px-4 py-2.5 text-sm text-white outline-none focus:border-yellow-400/50"
+          />
+          <button
+            type="button"
+            onClick={() => domainMutation.mutate()}
+            disabled={domainMutation.isPending}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-bold disabled:opacity-60"
+            style={{ backgroundColor: '#C9A84C', color: '#143A1F' }}
+          >
+            {domainMutation.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+            Conectar domínio
+          </button>
+        </div>
+
+        {domainError && <p className="text-xs text-red-400 mt-2">{domainError}</p>}
+
+        {dnsInfo && (
+          <div className="mt-4 bg-black/20 border border-white/10 rounded-xl p-4">
+            <p className="text-xs text-white/70 mb-2 font-semibold">Configure estes registros no seu provedor de DNS:</p>
+            <div className="space-y-1.5 text-[11px] font-mono text-white/80">
+              {dnsInfo.aRecord && (
+                <div className="flex flex-wrap gap-x-3"><span className="text-yellow-400/80">A</span><span>{dnsInfo.aRecord.name}</span><span>→</span><span>{dnsInfo.aRecord.value}</span></div>
+              )}
+              {dnsInfo.cnameRecord && (
+                <div className="flex flex-wrap gap-x-3"><span className="text-yellow-400/80">CNAME</span><span>{dnsInfo.cnameRecord.name}</span><span>→</span><span>{dnsInfo.cnameRecord.value}</span></div>
+              )}
+            </div>
+            <p className="text-[11px] text-white/40 mt-2">A propagação do DNS pode levar de alguns minutos a algumas horas.</p>
+          </div>
+        )}
       </div>
 
       {tenant.planStatus === 'SUSPENDED' && (

--- a/apps/web/src/app/(public)/imoveis/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/[slug]/page.tsx
@@ -870,7 +870,7 @@ export default async function PropertyDetailPage(props: { params: Promise<{ slug
               </div>
             </div>
 
-            {/* Company info */}
+            {/* Company info — encaminha ao site do parceiro (marketplace → parceiro) */}
             {p.company && (
               <div className="bg-white rounded-2xl border p-4 text-center" style={{ borderColor: '#ddd9d0' }}>
                 <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Anúncio de</p>
@@ -882,6 +882,19 @@ export default async function PropertyDetailPage(props: { params: Promise<{ slug
                   </a>
                 )}
                 <p className="text-[10px] text-gray-500 mt-1">CRECI 61053-F</p>
+                {p.partnerSite && (
+                  <a
+                    href={p.partnerSite.customDomain
+                      ? `https://${p.partnerSite.customDomain}`
+                      : `https://${p.partnerSite.subdomain}.agoraencontrei.com.br`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-3 inline-flex items-center justify-center gap-1 w-full py-2 rounded-lg text-xs font-bold text-white hover:opacity-90 transition"
+                    style={{ backgroundColor: '#143A1F' }}
+                  >
+                    Ver todos os imóveis desta imobiliária →
+                  </a>
+                )}
               </div>
             )}
           </div>

--- a/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
@@ -1,0 +1,334 @@
+/**
+ * Tenant Property Detail — página de detalhe do imóvel no site do PARCEIRO.
+ *
+ * Acessada via subdomínio/domínio próprio: parceiro.agoraencontrei.com.br/imoveis/{slug}
+ * → middleware reescreve para /_tenant/{parceiro}/imoveis/{slug}.
+ *
+ * Consome o endpoint público de detalhe COM tenantSlug (ciente do parceiro), então
+ * mostra só imóveis daquele parceiro e nunca dá 404 por resolver a empresa errada.
+ * Exibe galeria, descrição completa, características e o CORRETOR RESPONSÁVEL real
+ * (nome + CRECI + WhatsApp/telefone vindos do cadastro — genérico p/ qualquer parceiro).
+ */
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { resolveTheme } from '@/lib/site-factory/theme-registry'
+import TomasWidget from '@/components/tomas/TomasWidget'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+interface TenantData {
+  id: string
+  name: string
+  subdomain: string
+  customDomain: string | null
+  layoutType: string
+  primaryColor: string
+  logoUrl: string | null
+  planStatus: string
+  isActive: boolean
+  settings: { logoWordmarkUrl?: string | null; logoVisible?: boolean; logoShowText?: boolean; [k: string]: any }
+}
+
+interface PropertyDetail {
+  id: string
+  title: string
+  slug: string
+  description: string | null
+  type: string
+  purpose: string
+  price: number | null
+  priceRent: number | null
+  condoFee: number | null
+  iptu: number | null
+  city: string | null
+  state: string | null
+  neighborhood: string | null
+  bedrooms: number | null
+  suites: number | null
+  bathrooms: number | null
+  parkingSpaces: number | null
+  totalArea: number | null
+  builtArea: number | null
+  landArea: number | null
+  coverImage: string | null
+  images: string[]
+  features: string[]
+  reference: string | null
+  isFeatured: boolean
+  isPremium: boolean
+  company?: { name: string; phone: string | null; email: string | null; logoUrl: string | null } | null
+  user?: { name: string; phone: string | null; email: string | null; avatarUrl: string | null; creciNumber: string | null } | null
+}
+
+async function getTenant(slug: string): Promise<TenantData | null> {
+  try {
+    const res = await fetch(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, { next: { revalidate: 60 } })
+    if (!res.ok) return null
+    const data = await res.json()
+    return data.data || null
+  } catch {
+    return null
+  }
+}
+
+async function getProperty(tenantSlug: string, propertySlug: string): Promise<PropertyDetail | null> {
+  try {
+    // Endpoint ciente do parceiro: escopa ao companyId do tenant (ver resolveScopedCompanyId na API).
+    const url = `${API_URL}/api/v1/public/properties/${encodeURIComponent(propertySlug)}?tenantSlug=${encodeURIComponent(tenantSlug)}`
+    const res = await fetch(url, { next: { revalidate: 120 } })
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+function formatPrice(p: number | null): string {
+  if (!p) return 'Consultar'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(p)
+}
+
+// WhatsApp do responsável: prioriza o corretor (user.phone), depois a imobiliária
+// (company.phone). Retorna só dígitos com DDI 55. Null quando ninguém tem número.
+function waNumber(p: PropertyDetail): string | null {
+  const raw = p.user?.phone || p.company?.phone || ''
+  const digits = String(raw).replace(/\D/g, '')
+  if (!digits) return null
+  return digits.startsWith('55') ? digits : `55${digits}`
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; propertySlug: string }>
+}): Promise<Metadata> {
+  const { slug, propertySlug } = await params
+  const [tenant, property] = await Promise.all([getTenant(slug), getProperty(slug, propertySlug)])
+  if (!tenant || !property) return { title: 'Imóvel não encontrado' }
+  const cover = property.coverImage || property.images?.[0]
+  return {
+    title: `${property.title} — ${tenant.name}`,
+    description: (property.description || '').slice(0, 160) || `${property.title} em ${property.city ?? ''}`,
+    openGraph: { title: property.title, ...(cover && { images: [cover] }) },
+  }
+}
+
+export default async function TenantPropertyPage({
+  params,
+}: {
+  params: Promise<{ slug: string; propertySlug: string }>
+}) {
+  const { slug, propertySlug } = await params
+  const [tenant, property] = await Promise.all([getTenant(slug), getProperty(slug, propertySlug)])
+
+  if (!tenant || !tenant.isActive) notFound()
+  if (!property) notFound()
+
+  const theme = resolveTheme(tenant.layoutType)
+  const accentColor = tenant.primaryColor || theme.accentHex
+  const logoVisible = tenant.settings?.logoVisible !== false
+  const logoShowText = tenant.settings?.logoShowText !== false
+
+  const isRent = property.purpose === 'RENT'
+  const priceLabel = isRent ? formatPrice(property.priceRent) : formatPrice(property.price)
+  const gallery = [property.coverImage, ...(property.images || [])].filter(Boolean) as string[]
+  const wa = waNumber(property)
+  const brokerName = property.user?.name || property.company?.name || tenant.name
+  const waText = encodeURIComponent(`Olá! Tenho interesse no imóvel "${property.title}" (ref. ${property.reference ?? property.slug}) anunciado em ${tenant.name}.`)
+
+  const specs: { label: string; value: string }[] = []
+  if (property.bedrooms) specs.push({ label: 'Quartos', value: `${property.bedrooms}` })
+  if (property.suites) specs.push({ label: 'Suítes', value: `${property.suites}` })
+  if (property.bathrooms) specs.push({ label: 'Banheiros', value: `${property.bathrooms}` })
+  if (property.parkingSpaces) specs.push({ label: 'Vagas', value: `${property.parkingSpaces}` })
+  if (property.totalArea) specs.push({ label: 'Área total', value: `${property.totalArea} m²` })
+  if (property.builtArea) specs.push({ label: 'Área construída', value: `${property.builtArea} m²` })
+
+  return (
+    <div className={`min-h-screen ${theme.bg} ${theme.text}`}>
+      <style>{`:root{--color-primary:${accentColor};}`}</style>
+
+      {/* Header (marca do parceiro) */}
+      <header className={`${theme.headerBg} sticky top-0 z-50`}>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-3">
+            {logoVisible && tenant.logoUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={tenant.logoUrl} alt={tenant.name} className="h-10 w-auto object-contain" />
+            )}
+            {logoShowText && (
+              tenant.settings?.logoWordmarkUrl
+                // eslint-disable-next-line @next/next/no-img-element
+                ? <img src={tenant.settings.logoWordmarkUrl} alt={tenant.name} className="h-8 w-auto object-contain" />
+                : <span className={`text-xl ${theme.fontHeading} font-bold`} style={{ color: accentColor }}>{tenant.name}</span>
+            )}
+          </Link>
+          <Link href="/imoveis" className={`text-sm font-semibold`} style={{ color: accentColor }}>
+            Ver todos os imóveis →
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6">
+        {/* Breadcrumb */}
+        <nav className={`text-xs ${theme.textMuted} mb-4`}>
+          <Link href="/" className="hover:underline">Início</Link>
+          {' / '}
+          <Link href="/imoveis" className="hover:underline">Imóveis</Link>
+          {' / '}
+          <span>{property.title}</span>
+        </nav>
+
+        <div className="grid lg:grid-cols-3 gap-6">
+          {/* Coluna principal */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* Galeria */}
+            <div className={`${theme.card} border rounded-2xl overflow-hidden`}>
+              {gallery.length > 0 ? (
+                <>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={gallery[0]} alt={property.title} className="w-full h-[280px] sm:h-[420px] object-cover" />
+                  {gallery.length > 1 && (
+                    <div className="grid grid-cols-4 gap-1 p-1">
+                      {gallery.slice(1, 9).map((img, i) => (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img key={i} src={img} alt={`${property.title} ${i + 2}`} className="w-full h-20 sm:h-24 object-cover rounded" />
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="w-full h-[280px] flex items-center justify-center" style={{ background: `linear-gradient(135deg, ${accentColor}22, ${accentColor}0a)` }}>
+                  <span className="text-5xl opacity-20">🏠</span>
+                </div>
+              )}
+            </div>
+
+            {/* Título + specs */}
+            <div className={`${theme.card} border rounded-2xl p-5`}>
+              <div className="flex flex-wrap items-center gap-2 mb-2">
+                <span className="rounded-full px-2.5 py-0.5 text-[11px] font-semibold" style={{ backgroundColor: `${accentColor}22`, color: accentColor }}>
+                  {isRent ? 'Aluguel' : property.purpose === 'BOTH' ? 'Venda/Aluguel' : 'Venda'}
+                </span>
+                {property.isPremium && <span className="rounded-full px-2.5 py-0.5 text-[11px] font-bold text-white" style={{ backgroundColor: '#e11d48' }}>🌟 Super Destaque</span>}
+                {property.isFeatured && !property.isPremium && <span className="rounded-full px-2.5 py-0.5 text-[11px] font-bold text-white" style={{ backgroundColor: accentColor }}>⭐ Destaque</span>}
+                {property.reference && <span className={`text-[11px] ${theme.textMuted}`}>Ref. {property.reference}</span>}
+              </div>
+              <h1 className={`text-xl sm:text-2xl ${theme.fontHeading} font-bold leading-tight`}>{property.title}</h1>
+              <p className={`text-sm ${theme.textMuted} mt-1`}>
+                {[property.neighborhood, property.city, property.state].filter(Boolean).join(' • ')}
+              </p>
+              {specs.length > 0 && (
+                <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-4">
+                  {specs.map(s => (
+                    <div key={s.label} className="text-center">
+                      <p className="text-sm font-bold" style={{ color: accentColor }}>{s.value}</p>
+                      <p className={`text-[10px] ${theme.textMuted}`}>{s.label}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Descrição */}
+            {property.description && (
+              <div className={`${theme.card} border rounded-2xl p-5`}>
+                <h2 className={`text-lg ${theme.fontHeading} font-bold mb-3`}>Descrição</h2>
+                <div className={`text-sm leading-relaxed whitespace-pre-line ${theme.textMuted}`}>{property.description}</div>
+              </div>
+            )}
+
+            {/* Características */}
+            {property.features && property.features.length > 0 && (
+              <div className={`${theme.card} border rounded-2xl p-5`}>
+                <h2 className={`text-lg ${theme.fontHeading} font-bold mb-3`}>Características</h2>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {property.features.map((f, i) => (
+                    <span key={i} className={`text-sm ${theme.textMuted} flex items-center gap-1.5`}>
+                      <span style={{ color: accentColor }}>✓</span> {f}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Coluna lateral — preço + corretor */}
+          <aside className="space-y-4">
+            <div className={`${theme.card} border rounded-2xl p-5 lg:sticky lg:top-24`}>
+              <p className={`text-xs ${theme.textMuted}`}>{isRent ? 'Aluguel' : 'Valor'}</p>
+              <p className="text-3xl font-bold" style={{ color: accentColor }}>{priceLabel}</p>
+              {(property.condoFee || property.iptu) && (
+                <div className={`mt-2 text-xs ${theme.textMuted} space-y-0.5`}>
+                  {property.condoFee ? <p>Condomínio: {formatPrice(property.condoFee)}</p> : null}
+                  {property.iptu ? <p>IPTU: {formatPrice(property.iptu)}</p> : null}
+                </div>
+              )}
+
+              {/* Corretor responsável */}
+              <div className="mt-5 pt-5 border-t border-gray-200/20">
+                <div className="flex items-center gap-3">
+                  <div className="w-11 h-11 rounded-xl flex items-center justify-center text-white font-bold flex-shrink-0" style={{ backgroundColor: accentColor }}>
+                    {brokerName.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <p className={`text-sm font-bold ${theme.text} truncate`}>{brokerName}</p>
+                    <p className={`text-xs ${theme.textMuted}`}>
+                      Corretor de Imóveis{property.user?.creciNumber ? ` · CRECI ${property.user.creciNumber}` : ''}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  {wa ? (
+                    <a
+                      href={`https://wa.me/${wa}?text=${waText}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center justify-center gap-2 w-full py-3 rounded-xl text-white font-bold text-sm"
+                      style={{ backgroundColor: '#25D366' }}
+                    >
+                      💬 Falar com o Corretor
+                    </a>
+                  ) : (
+                    <a
+                      href="#contato"
+                      className={`flex items-center justify-center gap-2 w-full py-3 rounded-xl font-bold text-sm ${theme.buttonPrimary}`}
+                    >
+                      💬 Tenho interesse
+                    </a>
+                  )}
+                  {wa && (
+                    <a
+                      href={`tel:+${wa}`}
+                      className={`flex items-center justify-center gap-2 w-full py-2.5 rounded-xl font-semibold text-sm ${theme.buttonSecondary}`}
+                    >
+                      📞 Ligar
+                    </a>
+                  )}
+                </div>
+
+                {property.company?.name && (
+                  <p className={`mt-4 text-[11px] ${theme.textMuted} text-center`}>
+                    Anunciado por {property.company.name}
+                  </p>
+                )}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className={`${theme.footerBg} py-8 px-4 mt-8`}>
+        <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 text-sm opacity-60">
+          <p>&copy; {new Date().getFullYear()} {tenant.name}. Todos os direitos reservados.</p>
+          <p>Powered by <a href="https://www.agoraencontrei.com.br" className="underline">AgoraEncontrei</a></p>
+        </div>
+      </footer>
+
+      <TomasWidget tenantSlug={slug} partnerName={tenant.name} />
+    </div>
+  )
+}

--- a/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
@@ -1,0 +1,235 @@
+/**
+ * Tenant Catalog — catálogo completo de imóveis no site do PARCEIRO.
+ *
+ * parceiro.agoraencontrei.com.br/imoveis → /_tenant/{parceiro}/imoveis
+ * Lista TODOS os imóveis publicados do parceiro, paginados, com busca/filtro
+ * simples. Escopado pelo tenant (tenantSlug), então nunca mostra imóvel de outra
+ * empresa. Cada card leva ao detalhe do imóvel no próprio site do parceiro.
+ */
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { resolveTheme } from '@/lib/site-factory/theme-registry'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+const PAGE_SIZE = 24
+
+interface TenantData {
+  name: string
+  layoutType: string
+  primaryColor: string
+  logoUrl: string | null
+  isActive: boolean
+  settings: { logoWordmarkUrl?: string | null; logoVisible?: boolean; logoShowText?: boolean; [k: string]: any }
+}
+
+interface Property {
+  id: string
+  title: string
+  slug: string
+  purpose: string
+  price: number | null
+  priceRent: number | null
+  city: string | null
+  state: string | null
+  neighborhood: string | null
+  bedrooms: number | null
+  bathrooms: number | null
+  parkingSpaces: number | null
+  totalArea: number | null
+  coverImage: string | null
+  images: string[]
+  isFeatured: boolean
+  isPremium: boolean
+}
+
+interface Meta { total: number; page: number; limit: number; totalPages: number }
+
+async function getTenant(slug: string): Promise<TenantData | null> {
+  try {
+    const res = await fetch(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, { next: { revalidate: 60 } })
+    if (!res.ok) return null
+    const data = await res.json()
+    return data.data || null
+  } catch { return null }
+}
+
+async function getProperties(slug: string, sp: Record<string, string>): Promise<{ items: Property[]; meta: Meta }> {
+  const qs = new URLSearchParams({
+    tenantSlug: slug,
+    limit: String(PAGE_SIZE),
+    page: sp.page && /^\d+$/.test(sp.page) ? sp.page : '1',
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+  })
+  if (sp.purpose) qs.set('purpose', sp.purpose)
+  if (sp.type) qs.set('type', sp.type)
+  if (sp.search) qs.set('search', sp.search)
+  try {
+    const res = await fetch(`${API_URL}/api/v1/public/properties?${qs.toString()}`, { next: { revalidate: 120 } })
+    if (!res.ok) return { items: [], meta: { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 } }
+    const data = await res.json()
+    return {
+      items: Array.isArray(data?.data) ? data.data : [],
+      meta: data?.meta ?? { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 },
+    }
+  } catch {
+    return { items: [], meta: { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 } }
+  }
+}
+
+function formatPrice(price: number | null, priceRent: number | null, purpose: string): string {
+  const p = purpose === 'RENT' ? priceRent : price
+  if (!p) return 'Consultar'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(p)
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params
+  const tenant = await getTenant(slug)
+  return { title: tenant ? `Imóveis — ${tenant.name}` : 'Imóveis' }
+}
+
+export default async function TenantCatalogPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const { slug } = await params
+  const spRaw = await searchParams
+  const sp: Record<string, string> = {}
+  for (const [k, v] of Object.entries(spRaw)) if (typeof v === 'string') sp[k] = v
+
+  const tenant = await getTenant(slug)
+  if (!tenant || !tenant.isActive) notFound()
+
+  const { items, meta } = await getProperties(slug, sp)
+  const theme = resolveTheme(tenant.layoutType)
+  const accentColor = tenant.primaryColor || theme.accentHex
+  const logoVisible = tenant.settings?.logoVisible !== false
+  const logoShowText = tenant.settings?.logoShowText !== false
+
+  const currentPage = meta.page
+  const buildHref = (page: number) => {
+    const q = new URLSearchParams(sp)
+    q.set('page', String(page))
+    return `/imoveis?${q.toString()}`
+  }
+
+  return (
+    <div className={`min-h-screen ${theme.bg} ${theme.text}`}>
+      <style>{`:root{--color-primary:${accentColor};}`}</style>
+
+      {/* Header */}
+      <header className={`${theme.headerBg} sticky top-0 z-50`}>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
+          <a href="/" className="flex items-center gap-3">
+            {logoVisible && tenant.logoUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={tenant.logoUrl} alt={tenant.name} className="h-10 w-auto object-contain" />
+            )}
+            {logoShowText && (
+              tenant.settings?.logoWordmarkUrl
+                // eslint-disable-next-line @next/next/no-img-element
+                ? <img src={tenant.settings.logoWordmarkUrl} alt={tenant.name} className="h-8 w-auto object-contain" />
+                : <span className={`text-xl ${theme.fontHeading} font-bold`} style={{ color: accentColor }}>{tenant.name}</span>
+            )}
+          </a>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
+        <div className="mb-6">
+          <h1 className={`text-2xl ${theme.fontHeading} font-bold`}>Imóveis disponíveis</h1>
+          <p className={`text-sm ${theme.textMuted} mt-1`}>{meta.total} imóve{meta.total === 1 ? 'l' : 'is'} encontrado{meta.total === 1 ? '' : 's'}</p>
+        </div>
+
+        {/* Filtro simples (GET form) */}
+        <form method="get" className="flex flex-wrap gap-2 mb-6">
+          <input
+            type="text"
+            name="search"
+            defaultValue={sp.search ?? ''}
+            placeholder="Buscar por bairro, cidade ou título..."
+            className="flex-1 min-w-[200px] px-4 py-2.5 rounded-lg border border-gray-300 bg-white text-gray-900 text-sm focus:outline-none"
+          />
+          <select name="purpose" defaultValue={sp.purpose ?? ''} className="px-3 py-2.5 rounded-lg border border-gray-300 bg-white text-gray-900 text-sm">
+            <option value="">Venda e Aluguel</option>
+            <option value="SALE">Venda</option>
+            <option value="RENT">Aluguel</option>
+          </select>
+          <button type="submit" className={`${theme.buttonPrimary} px-5 py-2.5 rounded-lg text-sm`}>Buscar</button>
+        </form>
+
+        {items.length > 0 ? (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {items.map(property => (
+                <a
+                  key={property.id}
+                  href={`/imoveis/${property.slug}`}
+                  className={`${theme.card} ${theme.cardHover} border rounded-xl overflow-hidden transition-all duration-300 block`}
+                >
+                  <div className="h-48 relative overflow-hidden">
+                    {property.coverImage || property.images?.[0] ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={property.coverImage || property.images[0]} alt={property.title} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center" style={{ background: `linear-gradient(135deg, ${accentColor}33, ${accentColor}11)` }}>
+                        <span className="text-4xl opacity-20">🏠</span>
+                      </div>
+                    )}
+                    {property.isPremium && <span className="absolute top-2 left-2 rounded-full px-2 py-0.5 text-[10px] font-bold text-white" style={{ backgroundColor: '#e11d48' }}>🌟 Super Destaque</span>}
+                    {property.isFeatured && !property.isPremium && <span className="absolute top-2 left-2 rounded-full px-2 py-0.5 text-[10px] font-bold text-white" style={{ backgroundColor: accentColor }}>⭐ Destaque</span>}
+                    <span className="absolute top-2 right-2 rounded-full px-2 py-0.5 text-[10px] font-semibold" style={{ backgroundColor: `${accentColor}22`, color: accentColor, backdropFilter: 'blur(4px)' }}>
+                      {property.purpose === 'RENT' ? 'Aluguel' : property.purpose === 'BOTH' ? 'Venda/Aluguel' : 'Venda'}
+                    </span>
+                  </div>
+                  <div className="p-4">
+                    <p className={`text-sm font-semibold ${theme.text} leading-tight mb-1`}>{property.title}</p>
+                    <p className={`text-xs ${theme.textMuted} mb-2`}>{[property.neighborhood, property.city, property.state].filter(Boolean).join(' • ')}</p>
+                    <p className="mt-1 text-lg font-bold" style={{ color: accentColor }}>{formatPrice(property.price, property.priceRent, property.purpose)}</p>
+                    <div className={`mt-2 flex items-center gap-3 text-[11px] ${theme.textMuted}`}>
+                      {property.bedrooms ? <span>🛏 {property.bedrooms} qts</span> : null}
+                      {property.bathrooms ? <span>🚿 {property.bathrooms} bnh</span> : null}
+                      {property.totalArea ? <span>📐 {property.totalArea}m²</span> : null}
+                      {property.parkingSpaces ? <span>🚗 {property.parkingSpaces} vg</span> : null}
+                    </div>
+                  </div>
+                </a>
+              ))}
+            </div>
+
+            {/* Paginação */}
+            {meta.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 mt-10">
+                {currentPage > 1 && (
+                  <a href={buildHref(currentPage - 1)} className={`${theme.buttonSecondary} px-4 py-2 rounded-lg text-sm`}>← Anterior</a>
+                )}
+                <span className={`text-sm ${theme.textMuted} px-3`}>Página {currentPage} de {meta.totalPages}</span>
+                {currentPage < meta.totalPages && (
+                  <a href={buildHref(currentPage + 1)} className={`${theme.buttonPrimary} px-4 py-2 rounded-lg text-sm`}>Próxima →</a>
+                )}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="text-center py-16">
+            <div className="text-6xl mb-4 opacity-30">🔍</div>
+            <h4 className={`text-xl font-bold mb-2 ${theme.text}`}>Nenhum imóvel encontrado</h4>
+            <p className={`${theme.textMuted}`}>Tente ajustar a busca ou os filtros.</p>
+            <a href="/imoveis" className={`inline-block mt-6 px-6 py-3 rounded-lg font-medium ${theme.buttonPrimary}`}>Ver todos os imóveis</a>
+          </div>
+        )}
+      </main>
+
+      <footer className={`${theme.footerBg} py-8 px-4 mt-8`}>
+        <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 text-sm opacity-60">
+          <p>&copy; {new Date().getFullYear()} {tenant.name}. Todos os direitos reservados.</p>
+          <p>Powered by <a href="https://www.agoraencontrei.com.br" className="underline">AgoraEncontrei</a></p>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/src/app/_tenant/[slug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/page.tsx
@@ -318,7 +318,7 @@ export default async function TenantPage({
               )}
             </div>
             {hasProperties && (
-              <a href="#contato" className={`hidden sm:inline-flex items-center gap-1 text-sm font-semibold`} style={{ color: accentColor }}>
+              <a href="/imoveis" className={`hidden sm:inline-flex items-center gap-1 text-sm font-semibold`} style={{ color: accentColor }}>
                 Ver todos →
               </a>
             )}
@@ -386,11 +386,9 @@ export default async function TenantPage({
                         <span>🚗 {property.parkingSpaces} vg</span>
                       )}
                     </div>
-                    {/* CTA */}
+                    {/* CTA → página de detalhe do imóvel no site do parceiro */}
                     <a
-                      href={`https://wa.me/?text=Olá! Tenho interesse no imóvel "${property.title}" anunciado em ${tenant.name}.`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      href={`/imoveis/${property.slug}`}
                       className={`mt-3 block w-full text-center py-2 rounded-lg text-xs font-bold transition-all ${theme.buttonPrimary}`}
                     >
                       Ver detalhes


### PR DESCRIPTION
## Objetivo
Fazer o site do parceiro (`lemos.agoraencontrei.com.br` e domínio próprio) mostrar a carteira inteira, com página de detalhe e **corretor responsável real**, e o marketplace **encaminhar ao parceiro** — do jeito que qualquer parceiro que compra os serviços vai usar (genérico, nada chumbado na Lemos).

## O que entra neste PR

**Backend (`apps/api/src/routes/public/index.ts`)**
- `resolveScopedCompanyId(tenantSlug)`: os endpoints de detalhe (`/properties/:slug` e `/:slug/similar`) passam a ser **cientes do parceiro** — antes resolviam sempre a empresa principal e davam **404** no site do parceiro.
- `/properties/:slug` retorna `partnerSite { subdomain, customDomain, name }` do tenant dono do imóvel (para o marketplace encaminhar).

**Site do parceiro (`apps/web/src/app/_tenant/`)**
- **Página de detalhe** `imoveis/[propertySlug]`: galeria, descrição completa, características, preço/condomínio/IPTU + card do **corretor responsável** (nome + CRECI + WhatsApp/Ligar). Contato vem do **cadastro** (`user.phone` → `company.phone`), genérico; fallback gracioso sem número.
- **Catálogo** `imoveis/`: todos os imóveis do parceiro, **paginado (24/pág)**, com busca e filtro Venda/Aluguel. Cada card leva ao detalhe.
- **Home** `[slug]`: "Ver detalhes" agora linka para `/imoveis/{slug}` (antes: `wa.me` sem número); "Ver todos" → catálogo.

**Marketplace → parceiro (`apps/web/.../imoveis/[slug]`)**
- O bloco "Anúncio de {imobiliária}" ganha **"Ver todos os imóveis desta imobiliária →"** que leva ao site do parceiro.

Tudo escopado por tenant (nunca vaza imóvel de outra empresa) e com a marca/tema do parceiro. Typecheck limpo (API + web) nos arquivos alterados.

## ⚠️ Depende de você (infra, fora do código)
- **DNS curinga** `*.agoraencontrei.com.br` → Vercel + adicionar o domínio curinga na Vercel, senão `lemos.agoraencontrei.com.br` não resolve (hoje dá NXDOMAIN).

## Ainda nesta branch (em andamento)
- [ ] Campo de **domínio próprio** editável no "Meu Site" (Fase D — vou adicionar).
- [ ] Busca funcional no hero da home do parceiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_