### PR TITLE
feat(agenda): notificação de visita clicável + WhatsApp com modelos p…

### DIFF
--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -119,6 +119,7 @@ export default async function visitRoutes(app: FastifyInstance) {
         payload: {
           visitId: propertyVisit?.id ?? null,
           propertyId: body.propertyId,
+          propertyTitle: title,
           visitorName: body.name,
           visitorPhone: body.phone,
           scheduledAt: visitDateTime.toISOString(),

--- a/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/agenda/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
 import Link from 'next/link'
-import { Calendar, Loader2, RefreshCw, Check, X, Phone, MessageCircle, Star, TrendingUp, AlertTriangle, Award } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
+import { Calendar, Loader2, RefreshCw, Check, X, Phone, MessageCircle, Star, TrendingUp, AlertTriangle, Award, ChevronDown } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
+import { buildWaLink, VISIT_TEMPLATES } from '@/lib/whatsapp-templates'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -41,7 +43,17 @@ function fmtDate(iso: string) {
 }
 
 export default function AgendaPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-gray-950" />}>
+      <AgendaContent />
+    </Suspense>
+  )
+}
+
+function AgendaContent() {
   const { getValidToken } = useAuth()
+  const searchParams = useSearchParams()
+  const focusId = searchParams.get('focus')
   const [visits, setVisits] = useState<Visit[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(false)
@@ -50,6 +62,8 @@ export default function AgendaPage() {
   const [feedbackFor, setFeedbackFor] = useState<string | null>(null)
   const [rating, setRating] = useState(5)
   const [fbText, setFbText] = useState('')
+  const [waMenuFor, setWaMenuFor] = useState<string | null>(null)
+  const focusRef = useRef<HTMLDivElement | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -69,6 +83,13 @@ export default function AgendaPage() {
   }, [filter, getValidToken])
 
   useEffect(() => { load() }, [load])
+
+  // Rola até a visita vinda da notificação (?focus=<visitId>) e a destaca.
+  useEffect(() => {
+    if (focusId && !loading && focusRef.current) {
+      focusRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }, [focusId, loading, visits])
 
   async function patch(id: string, data: Record<string, unknown>) {
     setBusy(id)
@@ -216,9 +237,16 @@ export default function AgendaPage() {
             {visits.map(v => {
               const s = STATUS[v.status] ?? STATUS.pending
               const busyThis = busy === v.id
-              const phoneClean = v.visitorPhone.replace(/\D/g, '')
+              const isFocused = focusId === v.id
+              const waInput = { visitorName: v.visitorName, propertyTitle: v.property?.title, scheduledAt: v.scheduledAt }
               return (
-                <div key={v.id} className="rounded-xl border border-gray-800 bg-gray-900/40 p-4">
+                <div
+                  key={v.id}
+                  ref={isFocused ? focusRef : undefined}
+                  className={`rounded-xl border bg-gray-900/40 p-4 transition-colors ${
+                    isFocused ? 'border-amber-500 ring-1 ring-amber-500/40' : 'border-gray-800'
+                  }`}
+                >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
@@ -245,15 +273,43 @@ export default function AgendaPage() {
                       )}
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
-                      <a href={`https://wa.me/55${phoneClean}`} target="_blank" rel="noopener noreferrer"
-                        className="text-emerald-400 hover:text-emerald-300" title="WhatsApp">
-                        <MessageCircle size={16} />
-                      </a>
-                      <a href={`tel:${phoneClean}`} className="text-gray-400 hover:text-white" title="Ligar">
+                      <button
+                        onClick={() => setWaMenuFor(waMenuFor === v.id ? null : v.id)}
+                        className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors ${
+                          waMenuFor === v.id
+                            ? 'border-emerald-500/60 bg-emerald-500/20 text-emerald-200'
+                            : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20'
+                        }`}
+                        title="Enviar mensagem no WhatsApp">
+                        <MessageCircle size={14} /> WhatsApp <ChevronDown size={12} />
+                      </button>
+                      <a href={`tel:${v.visitorPhone.replace(/\D/g, '')}`} className="text-gray-400 hover:text-white" title="Ligar">
                         <Phone size={16} />
                       </a>
                     </div>
                   </div>
+
+                  {/* Modelos de mensagem — abre o WhatsApp com o texto já pronto */}
+                  {waMenuFor === v.id && (
+                    <div className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-2">
+                      <p className="px-1 pb-1.5 text-[10px] uppercase tracking-wider text-emerald-300/70">
+                        Enviar para {v.visitorName.split(' ')[0]} no WhatsApp
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {VISIT_TEMPLATES.map(t => (
+                          <a
+                            key={t.key}
+                            href={buildWaLink(v.visitorPhone, t.build(waInput))}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => setWaMenuFor(null)}
+                            className="flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-200 hover:bg-emerald-500/20">
+                            <MessageCircle size={12} /> {t.label}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
 
                   {/* Actions */}
                   {v.status === 'pending' || v.status === 'confirmed' ? (

--- a/apps/web/src/app/(dashboard)/dashboard/notifications/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/notifications/page.tsx
@@ -1,7 +1,36 @@
 'use client'
 
-import { Bell, CheckCheck, Trash2 } from 'lucide-react'
-import { useNotifications, type AppNotification } from '@/stores/notifications.store'
+import { Bell, CheckCheck, Trash2, MessageCircle } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useNotifications, type AppNotification, type NotificationType } from '@/stores/notifications.store'
+import { buildWaLink, visitConfirmationMsg } from '@/lib/whatsapp-templates'
+
+/** Para onde cada tipo de notificação leva ao ser clicada. */
+function getActionRoute(type: NotificationType, payload?: Record<string, unknown>): string {
+  const contactId = payload?.contactId as string | undefined
+  const propertyId = payload?.propertyId as string | undefined
+  switch (type) {
+    case 'visit_requested':
+      // Agenda de visitas — confirmar, cancelar, WhatsApp e feedback num só lugar.
+      return payload?.visitId ? `/dashboard/agenda?focus=${payload.visitId}` : '/dashboard/agenda'
+    case 'hunter_lead':
+    case 'lead_captured':
+    case 'lead_created':
+    case 'lead_updated':
+      return contactId ? `/dashboard/contacts/${contactId}` : '/dashboard/leads'
+    case 'proposal_received':
+      return propertyId ? `/dashboard/properties/${propertyId}` : '/dashboard/propostas'
+    case 'deal_updated':
+      return '/dashboard/deals'
+    case 'plan_sale':
+    case 'partner_registered':
+      return '/dashboard/admin/tenants'
+    case 'whatsapp_message':
+      return '/dashboard/inbox'
+    default:
+      return ''
+  }
+}
 
 const TYPE_COLORS: Record<AppNotification['type'], string> = {
   lead_created:      'bg-blue-50 text-blue-700',
@@ -22,6 +51,13 @@ const TYPE_COLORS: Record<AppNotification['type'], string> = {
 
 export default function NotificationsPage() {
   const { notifications, unreadCount, markRead, markAllRead, clear } = useNotifications()
+  const router = useRouter()
+
+  function handleClick(n: AppNotification) {
+    markRead(n.id)
+    const route = getActionRoute(n.type, n.payload)
+    if (route) router.push(route)
+  }
 
   return (
     <div className="p-6 space-y-6">
@@ -67,30 +103,53 @@ export default function NotificationsPage() {
         </div>
       ) : (
         <div className="space-y-2">
-          {notifications.map(n => (
-            <div
-              key={n.id}
-              onClick={() => markRead(n.id)}
-              className={`bg-white border rounded-xl p-4 cursor-pointer transition-colors hover:border-gray-200 ${
-                n.read ? 'border-gray-100 opacity-70' : 'border-blue-100 shadow-sm'
-              }`}
-            >
-              <div className="flex items-start gap-3">
-                {!n.read && <span className="mt-1.5 h-2 w-2 rounded-full bg-blue-500 flex-shrink-0" />}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[n.type]}`}>
-                      {n.title}
-                    </span>
-                    <span className="text-xs text-gray-400">
-                      {new Date(n.createdAt).toLocaleString('pt-BR')}
-                    </span>
+          {notifications.map(n => {
+            const isVisit = n.type === 'visit_requested'
+            const visitorPhone = n.payload?.visitorPhone as string | undefined
+            const waLink = isVisit && visitorPhone
+              ? buildWaLink(visitorPhone, visitConfirmationMsg({
+                  visitorName: n.payload?.visitorName as string | undefined,
+                  propertyTitle: n.payload?.propertyTitle as string | undefined,
+                  scheduledAt: n.payload?.scheduledAt as string | undefined,
+                }))
+              : null
+            return (
+              <div
+                key={n.id}
+                onClick={() => handleClick(n)}
+                className={`bg-white border rounded-xl p-4 cursor-pointer transition-colors hover:border-gray-200 ${
+                  n.read ? 'border-gray-100 opacity-70' : 'border-blue-100 shadow-sm'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  {!n.read && <span className="mt-1.5 h-2 w-2 rounded-full bg-blue-500 flex-shrink-0" />}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[n.type]}`}>
+                        {n.title}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {new Date(n.createdAt).toLocaleString('pt-BR')}
+                      </span>
+                    </div>
+                    {n.body && <p className="text-sm text-gray-600 mt-1 whitespace-pre-line">{n.body}</p>}
+                    {waLink && (
+                      <a
+                        href={waLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => { e.stopPropagation(); markRead(n.id) }}
+                        className="mt-2 inline-flex items-center gap-1.5 rounded-lg bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100"
+                      >
+                        <MessageCircle className="w-3.5 h-3.5" />
+                        Enviar confirmação no WhatsApp
+                      </a>
+                    )}
                   </div>
-                  {n.body && <p className="text-sm text-gray-600 mt-1">{n.body}</p>}
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/apps/web/src/lib/whatsapp-templates.ts
+++ b/apps/web/src/lib/whatsapp-templates.ts
@@ -1,0 +1,106 @@
+/**
+ * WhatsApp click-to-chat helpers + modelos de mensagem para visitas.
+ *
+ * Estes modelos são para o envio manual de 1 clique (link `wa.me`), que abre o
+ * WhatsApp do corretor com a mensagem já escrita para o cliente. Não dependem de
+ * template aprovado no Meta — funcionam para qualquer número, na hora.
+ */
+
+/** Normaliza um telefone brasileiro para o formato do wa.me (só dígitos, com DDI 55). */
+export function normalizeBrPhone(raw: string | null | undefined): string {
+  const digits = (raw ?? '').replace(/\D/g, '')
+  if (!digits) return ''
+  // Evita duplicar o DDI quando o número já vem com 55.
+  if (digits.startsWith('55') && digits.length >= 12) return digits
+  return `55${digits}`
+}
+
+/** Monta o link wa.me (click-to-chat) com a mensagem pré-preenchida. */
+export function buildWaLink(phone: string | null | undefined, message: string): string {
+  const dest = normalizeBrPhone(phone)
+  return `https://wa.me/${dest}?text=${encodeURIComponent(message)}`
+}
+
+/** Primeiro nome, para deixar a mensagem pessoal. */
+function firstName(name: string | null | undefined): string {
+  const n = (name ?? '').trim()
+  if (!n) return 'tudo bem'
+  return n.split(/\s+/)[0]
+}
+
+/** Ex.: "sábado, 18/07 às 10:30". Aceita ISO string ou Date. */
+function formatVisitDate(scheduledAt: string | Date | null | undefined): string {
+  if (!scheduledAt) return ''
+  const d = typeof scheduledAt === 'string' ? new Date(scheduledAt) : scheduledAt
+  if (isNaN(d.getTime())) return ''
+  const day = d.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: '2-digit' })
+  const time = d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+  return `${day} às ${time}`
+}
+
+export interface VisitMessageInput {
+  visitorName: string | null | undefined
+  propertyTitle: string | null | undefined
+  scheduledAt: string | Date | null | undefined
+}
+
+export type VisitTemplateKey = 'confirm' | 'reminder' | 'reschedule'
+
+/** Mensagem de confirmação — enviada logo após o agendamento. */
+export function visitConfirmationMsg(i: VisitMessageInput): string {
+  const first = firstName(i.visitorName)
+  const prop = i.propertyTitle?.trim() || 'o imóvel'
+  const when = formatVisitDate(i.scheduledAt)
+  return [
+    `Olá ${first}! 👋 Tudo bem?`,
+    ``,
+    `Estou confirmando sua visita:`,
+    ``,
+    `🏡 *${prop}*`,
+    when ? `📅 ${when}` : ``,
+    ``,
+    `Consigo confirmar esse horário com você? Qualquer coisa, é só me chamar por aqui. 😊`,
+  ].filter(Boolean).join('\n')
+}
+
+/** Mensagem de lembrete — reforço no dia/véspera da visita. */
+export function visitReminderMsg(i: VisitMessageInput): string {
+  const first = firstName(i.visitorName)
+  const prop = i.propertyTitle?.trim() || 'o imóvel'
+  const when = formatVisitDate(i.scheduledAt)
+  return [
+    `Oi ${first}! 👋 Passando para lembrar da sua visita:`,
+    ``,
+    `🏡 *${prop}*`,
+    when ? `📅 ${when}` : ``,
+    ``,
+    `Nos vemos lá! Se precisar remarcar, é só me avisar. 🙌`,
+  ].filter(Boolean).join('\n')
+}
+
+/** Mensagem de reagendamento — quando o horário precisa mudar. */
+export function visitRescheduleMsg(i: VisitMessageInput): string {
+  const first = firstName(i.visitorName)
+  const prop = i.propertyTitle?.trim() || 'o imóvel'
+  const when = formatVisitDate(i.scheduledAt)
+  return [
+    `Olá ${first}! Precisamos ajustar o horário da sua visita${when ? ` (${when})` : ''}:`,
+    ``,
+    `🏡 *${prop}*`,
+    ``,
+    `Qual outro dia e horário ficam melhores para você? 🗓️`,
+  ].filter(Boolean).join('\n')
+}
+
+export interface VisitTemplate {
+  key: VisitTemplateKey
+  label: string
+  build: (i: VisitMessageInput) => string
+}
+
+/** Modelos disponíveis, na ordem de uso mais comum. */
+export const VISIT_TEMPLATES: VisitTemplate[] = [
+  { key: 'confirm', label: 'Confirmar visita', build: visitConfirmationMsg },
+  { key: 'reminder', label: 'Lembrete', build: visitReminderMsg },
+  { key: 'reschedule', label: 'Reagendar', build: visitRescheduleMsg },
+]


### PR DESCRIPTION
…rontos

Antes, clicar na notificação "Nova visita agendada" só a marcava como lida — não levava a lugar nenhum ("clico no lead e não acontece nada").

- Notificações agora navegam ao serem clicadas. Visita → /dashboard/agenda com a visita destacada (?focus=<visitId>); demais tipos → contato/imóvel/inbox.
- Novo helper `whatsapp-templates.ts` com modelos de mensagem ao cliente (confirmação, lembrete, reagendamento) e link wa.me com telefone normalizado.
- Agenda: botão "WhatsApp" por visita abre um menu com os 3 modelos, cada um abrindo o WhatsApp já com o texto pronto (1 clique, sem depender de template aprovado no Meta).
- Notificação de visita ganha atalho "Enviar confirmação no WhatsApp".
- API: payload da notificação de visita passa a incluir `propertyTitle` para a mensagem sair completa.


Claude-Session: https://claude.ai/code/session_01Th8rD19NaqdRhJHRev5v8y