### PR TITLE
fix(site do parceiro): corrige 404 (retry no SSR→API) + quadro do corretor redondo/clicável

### DIFF
--- a/apps/web/src/app/(public)/imoveis/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/imoveis/[slug]/page.tsx
@@ -869,34 +869,8 @@ export default async function PropertyDetailPage(props: { params: Promise<{ slug
                 </a>
               </div>
             </div>
-
-            {/* Company info — encaminha ao site do parceiro (marketplace → parceiro) */}
-            {p.company && (
-              <div className="bg-white rounded-2xl border p-4 text-center" style={{ borderColor: '#ddd9d0' }}>
-                <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Anúncio de</p>
-                <p className="font-bold text-sm" style={{ color: '#143A1F' }}>{p.company.name}</p>
-                {p.company.phone && (
-                  <a href={`tel:${p.company.phone}`} className="text-xs mt-0.5 block hover:opacity-80 flex items-center justify-center gap-1"
-                    style={{ color: '#C9A84C' }}>
-                    <Phone className="w-3 h-3" />{p.company.phone}
-                  </a>
-                )}
-                <p className="text-[10px] text-gray-500 mt-1">CRECI 61053-F</p>
-                {p.partnerSite && (
-                  <a
-                    href={p.partnerSite.customDomain
-                      ? `https://${p.partnerSite.customDomain}`
-                      : `https://${p.partnerSite.subdomain}.agoraencontrei.com.br`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="mt-3 inline-flex items-center justify-center gap-1 w-full py-2 rounded-lg text-xs font-bold text-white hover:opacity-90 transition"
-                    style={{ backgroundColor: '#143A1F' }}
-                  >
-                    Ver todos os imóveis desta imobiliária →
-                  </a>
-                )}
-              </div>
-            )}
+            {/* (O bloco da imobiliária anunciante agora vive DENTRO do quadro do
+                corretor — perfil + rodapé clicáveis levam ao site do parceiro.) */}
           </div>
         </div>
       </div>
@@ -917,6 +891,16 @@ function BrokerCard({ broker, whatsappNum, whatsappMsg, visitMsg, p, condoName }
   const totalRent = hasRent ? (
     Number(p.priceRent) + (iptu ? iptu / 12 : 0) + (condoFeeNum ?? 0)
   ) : null
+
+  // Link para o site do parceiro anunciante (quando o imóvel pertence a um
+  // tenant com site próprio). Clicar no perfil do corretor / rodapé da
+  // imobiliária encaminha para a página do parceiro.
+  const partnerHref = p?.partnerSite
+    ? (p.partnerSite.customDomain
+        ? `https://${p.partnerSite.customDomain}`
+        : `https://${p.partnerSite.subdomain}.agoraencontrei.com.br`)
+    : null
+  const companyName = p?.company?.name || p?.partnerSite?.name || 'Imobiliária Lemos'
 
   function fmtCurr(v: number) {
     return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 2 }).format(v)
@@ -978,38 +962,52 @@ function BrokerCard({ broker, whatsappNum, whatsappMsg, visitMsg, p, condoName }
         )}
       </div>
 
-      {/* Broker profile */}
-      <div className="px-5 pt-4 pb-3">
-        <div className="flex items-center gap-3.5">
-          {/* Avatar */}
-          {broker?.avatarUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={broker.avatarUrl} alt={broker.name} loading="lazy"
-              className="h-16 w-16 rounded-2xl object-cover flex-shrink-0 shadow-md"
-              style={{ border: '2.5px solid #C9A84C' }} />
-          ) : (
-            <div className="h-16 w-16 rounded-2xl flex items-center justify-center text-white text-2xl font-bold flex-shrink-0 shadow-md"
-              style={{ background: 'linear-gradient(135deg, #143A1F, #2d4a8a)', border: '2.5px solid #C9A84C' }}>
-              {broker?.name?.charAt(0).toUpperCase() ?? 'L'}
-            </div>
-          )}
-          {/* Info */}
-          <div className="min-w-0 flex-1">
-            <p className="font-bold text-base leading-tight truncate" style={{ color: '#143A1F' }}>
-              {broker?.name ?? 'Imobiliária Lemos'}
-            </p>
-            <p className="text-xs text-gray-500 mt-0.5">{(broker as any)?.cargo ?? 'Corretor de Imóveis'}</p>
-            <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
-              <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(201,168,76,0.12)', color: '#92710a' }}>
-                CRECI {broker?.creciNumber || '279051-F'}
-              </span>
-              <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">
-                Verificado ✓
-              </span>
+      {/* Broker profile — avatar redondo (foto/logo do corretor). Clicar no
+          perfil encaminha para a página do parceiro anunciante. */}
+      {(() => {
+        const content = (
+          <div className="flex items-center gap-3.5">
+            {/* Avatar redondo: foto/logo que o corretor escolher; fallback = inicial */}
+            {broker?.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={broker.avatarUrl} alt={broker.name} loading="lazy"
+                className="h-16 w-16 rounded-full object-cover flex-shrink-0 shadow-md"
+                style={{ border: '2.5px solid #C9A84C' }} />
+            ) : (
+              <div className="h-16 w-16 rounded-full flex items-center justify-center text-white text-2xl font-bold flex-shrink-0 shadow-md"
+                style={{ background: 'linear-gradient(135deg, #143A1F, #2d4a8a)', border: '2.5px solid #C9A84C' }}>
+                {broker?.name?.charAt(0).toUpperCase() ?? 'L'}
+              </div>
+            )}
+            {/* Info */}
+            <div className="min-w-0 flex-1">
+              <p className="font-bold text-base leading-tight truncate" style={{ color: '#143A1F' }}>
+                {broker?.name ?? companyName}
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">{(broker as any)?.cargo ?? 'Corretor de Imóveis'}</p>
+              <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
+                <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(201,168,76,0.12)', color: '#92710a' }}>
+                  CRECI {broker?.creciNumber || '279051-F'}
+                </span>
+                <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">
+                  Verificado ✓
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
+        )
+        return (
+          <div className="px-5 pt-4 pb-3">
+            {partnerHref ? (
+              <a href={partnerHref} target="_blank" rel="noreferrer"
+                className="block rounded-xl -mx-1 px-1 py-1 hover:bg-black/[0.03] transition-colors"
+                title={`Ver imóveis de ${companyName}`}>
+                {content}
+              </a>
+            ) : content}
+          </div>
+        )
+      })()}
 
       {/* CTA buttons */}
       <div className="px-5 pb-5 space-y-2.5">
@@ -1050,19 +1048,36 @@ function BrokerCard({ broker, whatsappNum, whatsappMsg, visitMsg, p, condoName }
           </div>
         )}
 
-        {/* Imobiliária info footer */}
-        <div className="flex items-center gap-2.5 pt-3 mt-1 border-t" style={{ borderColor: '#ede9df' }}>
-          <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#143A1F' }}>
-            <svg className="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-              <polyline points="9 22 9 12 15 12 15 22"/>
-            </svg>
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-bold truncate" style={{ color: '#143A1F' }}>Imobiliária Lemos</p>
-            <p className="text-[11px] text-gray-400">(16) 3723-0045 · CRECI-J 61053-F</p>
-          </div>
-        </div>
+        {/* Rodapé da imobiliária anunciante — clicável → site do parceiro */}
+        {(() => {
+          const footer = (
+            <div className="flex items-center gap-2.5">
+              <div className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0" style={{ backgroundColor: '#143A1F' }}>
+                <svg className="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                  <polyline points="9 22 9 12 15 12 15 22"/>
+                </svg>
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-bold truncate" style={{ color: '#143A1F' }}>{companyName}</p>
+                <p className="text-[11px] text-gray-400">
+                  {p?.company?.phone || '(16) 3723-0045'}{partnerHref ? ' · Ver todos os imóveis →' : ''}
+                </p>
+              </div>
+            </div>
+          )
+          return (
+            <div className="pt-3 mt-1 border-t" style={{ borderColor: '#ede9df' }}>
+              {partnerHref ? (
+                <a href={partnerHref} target="_blank" rel="noreferrer"
+                  className="block rounded-lg -mx-1 px-1 py-1 hover:bg-black/[0.03] transition-colors"
+                  title={`Ver imóveis de ${companyName}`}>
+                  {footer}
+                </a>
+              ) : footer}
+            </div>
+          )
+        })()}
       </div>
     </>
   )

--- a/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
@@ -61,27 +61,33 @@ interface PropertyDetail {
   user?: { name: string; phone: string | null; email: string | null; avatarUrl: string | null; creciNumber: string | null } | null
 }
 
-async function getTenant(slug: string): Promise<TenantData | null> {
-  try {
-    const res = await fetch(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, { next: { revalidate: 60 } })
-    if (!res.ok) return null
-    const data = await res.json()
-    return data.data || null
-  } catch {
-    return null
+// Retry em falhas de rede do SSR → API (ECONNRESET/TLS). 404 real não é retentado.
+async function fetchJsonRetry(url: string, revalidate: number): Promise<any | null> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { next: { revalidate } })
+      if (res.status === 404) return null
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return await res.json()
+    } catch {
+      if (attempt === 2) return null
+      await new Promise(r => setTimeout(r, 200 * (attempt + 1)))
+    }
   }
+  return null
+}
+
+async function getTenant(slug: string): Promise<TenantData | null> {
+  const data = await fetchJsonRetry(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, 60)
+  return data?.data || null
 }
 
 async function getProperty(tenantSlug: string, propertySlug: string): Promise<PropertyDetail | null> {
-  try {
-    // Endpoint ciente do parceiro: escopa ao companyId do tenant (ver resolveScopedCompanyId na API).
-    const url = `${API_URL}/api/v1/public/properties/${encodeURIComponent(propertySlug)}?tenantSlug=${encodeURIComponent(tenantSlug)}`
-    const res = await fetch(url, { next: { revalidate: 120 } })
-    if (!res.ok) return null
-    return await res.json()
-  } catch {
-    return null
-  }
+  // Endpoint ciente do parceiro: escopa ao companyId do tenant (ver resolveScopedCompanyId na API).
+  return await fetchJsonRetry(
+    `${API_URL}/api/v1/public/properties/${encodeURIComponent(propertySlug)}?tenantSlug=${encodeURIComponent(tenantSlug)}`,
+    120,
+  )
 }
 
 function formatPrice(p: number | null): string {

--- a/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
@@ -44,13 +44,25 @@ interface Property {
 
 interface Meta { total: number; page: number; limit: number; totalPages: number }
 
+// Retry em falhas de rede do SSR → API (ECONNRESET/TLS). 404 real não é retentado.
+async function fetchJsonRetry(url: string, revalidate: number): Promise<any | null> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { next: { revalidate } })
+      if (res.status === 404) return null
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return await res.json()
+    } catch {
+      if (attempt === 2) return null
+      await new Promise(r => setTimeout(r, 200 * (attempt + 1)))
+    }
+  }
+  return null
+}
+
 async function getTenant(slug: string): Promise<TenantData | null> {
-  try {
-    const res = await fetch(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, { next: { revalidate: 60 } })
-    if (!res.ok) return null
-    const data = await res.json()
-    return data.data || null
-  } catch { return null }
+  const data = await fetchJsonRetry(`${API_URL}/api/v1/public/tenant/${encodeURIComponent(slug)}`, 60)
+  return data?.data || null
 }
 
 async function getProperties(slug: string, sp: Record<string, string>): Promise<{ items: Property[]; meta: Meta }> {
@@ -64,16 +76,10 @@ async function getProperties(slug: string, sp: Record<string, string>): Promise<
   if (sp.purpose) qs.set('purpose', sp.purpose)
   if (sp.type) qs.set('type', sp.type)
   if (sp.search) qs.set('search', sp.search)
-  try {
-    const res = await fetch(`${API_URL}/api/v1/public/properties?${qs.toString()}`, { next: { revalidate: 120 } })
-    if (!res.ok) return { items: [], meta: { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 } }
-    const data = await res.json()
-    return {
-      items: Array.isArray(data?.data) ? data.data : [],
-      meta: data?.meta ?? { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 },
-    }
-  } catch {
-    return { items: [], meta: { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 } }
+  const data = await fetchJsonRetry(`${API_URL}/api/v1/public/properties?${qs.toString()}`, 120)
+  return {
+    items: Array.isArray(data?.data) ? data.data : [],
+    meta: data?.meta ?? { total: 0, page: 1, limit: PAGE_SIZE, totalPages: 0 },
   }
 }
 

--- a/apps/web/src/app/_tenant/[slug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/page.tsx
@@ -60,16 +60,24 @@ interface Property {
 }
 
 async function getTenantBySubdomain(slug: string): Promise<TenantData | null> {
-  try {
-    const res = await fetch(`${API_URL}/api/v1/public/tenant/${slug}`, {
-      next: { revalidate: 60 },
-    })
-    if (!res.ok) return null
-    const data = await res.json()
-    return data.data || null
-  } catch {
-    return null
+  // Retry em falhas de rede (ECONNRESET/TLS do SSR → API): sem isso, um blip de
+  // conexão fazia o site do parceiro cair em notFound() (404). 404 real (tenant
+  // inexistente) não é retentado — retorna null na hora.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(`${API_URL}/api/v1/public/tenant/${slug}`, {
+        next: { revalidate: 60 },
+      })
+      if (res.status === 404) return null
+      if (!res.ok) throw new Error(`tenant ${slug}: HTTP ${res.status}`)
+      const data = await res.json()
+      return data.data || null
+    } catch {
+      if (attempt === 2) return null
+      await new Promise(r => setTimeout(r, 200 * (attempt + 1)))
+    }
   }
+  return null
 }
 
 async function getTenantProperties(tenantSlug: string, limit = 9): Promise<Property[]> {


### PR DESCRIPTION
## Por quê
O `lemos.agoraencontrei.com.br` estava dando **404** mesmo com o tenant válido no banco (ACTIVE, companyId certo). A causa raiz (achada nos runtime errors da Vercel): o **SSR falha ao conectar na API** com `ECONNRESET`/TLS (`api-production-669c.up.railway.app`). Nas páginas do parceiro — novas, sem cache ISR ainda — isso fazia o `getTenant` virar `null` → `notFound()` → 404.

Estes 2 commits ficaram na branch do #280 **depois** do squash-merge, então não chegaram na main. Este PR os traz.

## O que entra
- **fix(tenant): retry no fetch SSR→API** — tenant/imóveis buscados com 3 tentativas + backoff, na home, catálogo e detalhe do parceiro. 404 real (recurso inexistente) não é retentado. **Isto conserta o 404.**
- **feat(imóvel): quadro do corretor** — avatar **redondo** (foto/logo do corretor via `user.avatarUrl`), bloco da imobiliária **dentro** do card, e **clique no perfil/rodapé → página do parceiro**. Botões de ação mantêm suas funções.

Typecheck limpo (web).

## Recomendado junto (infra, você faz)
Trocar `NEXT_PUBLIC_API_URL` na Vercel da URL crua do Railway para o domínio estável **`https://api.agoraencontrei.com.br`** reduz os blips de conexão na origem. O retry já resolve o 404; isto melhora a robustez geral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_