### PR TITLE
fix(tenant): force-dynamic nas páginas do parceiro (elimina 404 preso no cache)

### DIFF
--- a/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/[propertySlug]/page.tsx
@@ -15,6 +15,9 @@ import Link from 'next/link'
 import { resolveTheme } from '@/lib/site-factory/theme-registry'
 import TomasWidget from '@/components/tomas/TomasWidget'
 
+// Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
+export const dynamic = 'force-dynamic'
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
 interface TenantData {

--- a/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/imoveis/page.tsx
@@ -10,6 +10,9 @@ import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { resolveTheme } from '@/lib/site-factory/theme-registry'
 
+// Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
+export const dynamic = 'force-dynamic'
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 const PAGE_SIZE = 24
 

--- a/apps/web/src/app/_tenant/[slug]/page.tsx
+++ b/apps/web/src/app/_tenant/[slug]/page.tsx
@@ -11,6 +11,9 @@ import type { Metadata } from 'next'
 import { resolveTheme, type ThemeConfig } from '@/lib/site-factory/theme-registry'
 import TomasWidget from '@/components/tomas/TomasWidget'
 
+// Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
+export const dynamic = 'force-dynamic'
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
 interface TenantData {


### PR DESCRIPTION
## Contexto
O site principal voltou (corrigido o `NEXT_PUBLIC_API_URL` para a URL do Railway que responde 200). Mas o **site do parceiro** (`lemos.agoraencontrei.com.br`) continuava **404** mesmo com a API de volta.

Causa: os runtime logs mostram `cache=STALE` nas rotas do parceiro. Quando a API teve o blip, a página renderizou `notFound()` e o **CDN/ISR cacheou esse 404**, ficando preso nele mesmo depois da API voltar.

## Fix
`export const dynamic = 'force-dynamic'` nas 3 páginas do parceiro (home, catálogo, detalhe) → **sempre renderizam ao vivo**, sem cachear o 404. Como a API está de pé e o retry (do #282) já está em produção, o tenant resolve a cada request. Baixo tráfego → render dinâmico é aceitável.

Typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_