### PR TITLE
feat(visits): envio automático de confirmação ao cliente (desligado por padrão)

### DIFF
--- a/apps/api/src/routes/public/visits.ts
+++ b/apps/api/src/routes/public/visits.ts
@@ -201,6 +201,23 @@ export default async function visitRoutes(app: FastifyInstance) {
       }
     }
 
+    // 5. Confirmação automática ao CLIENTE via WhatsApp — DESLIGADA por padrão.
+    //    Só envia com VISIT_CLIENT_WHATSAPP_AUTO=true (+ template aprovado no
+    //    Meta em VISIT_CONFIRMATION_TEMPLATE_NAME). Best-effort, nunca quebra.
+    try {
+      const { maybeSendVisitConfirmation } = await import('../../services/visit-confirmation.service.js')
+      const result = await maybeSendVisitConfirmation({
+        visitorName: body.name,
+        visitorPhone: body.phone,
+        propertyTitle: title,
+        scheduledAt: visitDateTime,
+      })
+      if (result === 'sent') app.log.info({ visitId: propertyVisit.id }, 'visit: client WhatsApp confirmation sent')
+      else if (result === 'failed') app.log.warn({ visitId: propertyVisit.id }, 'visit: client WhatsApp confirmation failed')
+    } catch (err) {
+      app.log.warn({ err }, 'visit: client confirmation errored (non-fatal)')
+    }
+
     return reply.send({ success: true, visitId: propertyVisit.id, activityId: activity?.id ?? null, contactId: contact?.id ?? null })
   })
 

--- a/apps/api/src/services/visit-confirmation.service.ts
+++ b/apps/api/src/services/visit-confirmation.service.ts
@@ -1,0 +1,100 @@
+/**
+ * Confirmação automática de visita ao CLIENTE via WhatsApp Cloud API.
+ *
+ * DESLIGADO POR PADRÃO. Só envia quando `VISIT_CLIENT_WHATSAPP_AUTO=true` e as
+ * credenciais do WhatsApp estão configuradas. Chamado no momento do agendamento
+ * (rota pública de visitas), de forma best-effort — nunca lança.
+ *
+ * ⚠️ Janela de 24h do Meta: uma mensagem iniciada pela empresa para um cliente
+ * que NÃO te escreveu nas últimas 24h só é entregue via TEMPLATE pré-aprovado.
+ * O cliente agenda pelo site (sem abrir conversa), então o caminho correto em
+ * produção é `VISIT_CONFIRMATION_TEMPLATE_NAME` apontando para um template
+ * aprovado no Meta Business Manager com 3 variáveis no corpo:
+ *   {{1}} = nome do cliente, {{2}} = título do imóvel, {{3}} = data/hora.
+ *
+ * Sem template configurado, cai para texto livre (útil só em teste/dev, dentro
+ * da janela de 24h) para não travar o fluxo.
+ */
+
+import { env } from '../utils/env.js'
+
+export interface VisitConfirmationInput {
+  visitorName: string
+  visitorPhone: string
+  propertyTitle: string
+  scheduledAt: Date
+}
+
+/** Normaliza telefone BR para o formato da Cloud API (dígitos + DDI 55). */
+function normalizeBrPhone(raw: string): string {
+  const digits = (raw || '').replace(/\D/g, '')
+  if (!digits) return ''
+  if (digits.startsWith('55') && digits.length >= 12) return digits
+  return `55${digits}`
+}
+
+/** Ex.: "sábado, 18/07 às 10:30". */
+function formatDateLabel(d: Date): string {
+  const day = d.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: '2-digit' })
+  const time = d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+  return `${day} às ${time}`
+}
+
+/** Texto livre de fallback (só entregue dentro da janela de 24h). */
+function confirmationText(i: VisitConfirmationInput): string {
+  const first = (i.visitorName || '').trim().split(/\s+/)[0] || 'tudo bem'
+  return [
+    `Olá ${first}! 👋`,
+    ``,
+    `Recebemos seu agendamento de visita:`,
+    ``,
+    `🏡 ${i.propertyTitle}`,
+    `📅 ${formatDateLabel(i.scheduledAt)}`,
+    ``,
+    `Em breve confirmamos os detalhes com você. Qualquer coisa, é só responder por aqui. 😊`,
+  ].join('\n')
+}
+
+/**
+ * Envia a confirmação ao cliente se o recurso estiver ativado.
+ * Retorna 'disabled' | 'skipped' | 'sent' | 'failed'. Nunca lança.
+ */
+export async function maybeSendVisitConfirmation(
+  input: VisitConfirmationInput,
+): Promise<'disabled' | 'skipped' | 'sent' | 'failed'> {
+  // Trava mestra: desligado por padrão.
+  if (!env.VISIT_CLIENT_WHATSAPP_AUTO) return 'disabled'
+  if (!env.WHATSAPP_TOKEN || !env.WHATSAPP_PHONE_ID) return 'skipped'
+
+  const to = normalizeBrPhone(input.visitorPhone)
+  if (!to) return 'skipped'
+
+  try {
+    const { whatsappService } = await import('./whatsapp.service.js')
+
+    if (env.VISIT_CONFIRMATION_TEMPLATE_NAME) {
+      // Caminho de produção: template aprovado no Meta.
+      await whatsappService.sendTemplate(
+        to,
+        env.VISIT_CONFIRMATION_TEMPLATE_NAME,
+        env.VISIT_CONFIRMATION_TEMPLATE_LANG,
+        [
+          {
+            type: 'body',
+            parameters: [
+              { type: 'text', text: input.visitorName || 'Cliente' },
+              { type: 'text', text: input.propertyTitle || 'o imóvel' },
+              { type: 'text', text: formatDateLabel(input.scheduledAt) },
+            ],
+          },
+        ],
+      )
+    } else {
+      // Fallback texto livre (só entrega dentro da janela de 24h).
+      await whatsappService.sendText(to, confirmationText(input))
+    }
+    return 'sent'
+  } catch {
+    return 'failed'
+  }
+}

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -44,6 +44,17 @@ const envSchema = z.object({
   WHATSAPP_VERIFY_TOKEN: z.string().optional().default('lemoschat_verify'),
   WHATSAPP_BUSINESS_ID: z.string().optional(),
 
+  // Confirmação automática de visita ao CLIENTE (via WhatsApp Cloud API).
+  // Desligado por padrão. Para ativar em produção:
+  //   1) VISIT_CLIENT_WHATSAPP_AUTO=true
+  //   2) VISIT_CONFIRMATION_TEMPLATE_NAME=<nome do template aprovado no Meta>
+  //      (o template deve ter 3 variáveis no corpo, na ordem:
+  //       {{1}}=nome do cliente, {{2}}=título do imóvel, {{3}}=data/hora)
+  // Sem um template aprovado, a Meta bloqueia mensagens fora da janela de 24h.
+  VISIT_CLIENT_WHATSAPP_AUTO: z.string().optional().transform((v) => v === '1' || v === 'true'),
+  VISIT_CONFIRMATION_TEMPLATE_NAME: z.string().optional(),
+  VISIT_CONFIRMATION_TEMPLATE_LANG: z.string().optional().default('pt_BR'),
+
   // Storage
   AWS_REGION: z.string().default('us-east-1'),
   AWS_ACCESS_KEY_ID: z.string().optional(),


### PR DESCRIPTION
## Contexto

Continuação do #281 (notificação de visita clicável + WhatsApp com modelos). Aqui deixamos **preparado** o envio **automático** de confirmação ao **cliente** no momento do agendamento — reutilizando o WhatsApp Cloud API que já existe no projeto.

> ⚠️ **Vem DESLIGADO por padrão.** Nada muda no comportamento atual até ser ativado por variável de ambiente.

## O que muda

- **Novo `apps/api/src/services/visit-confirmation.service.ts`** — `maybeSendVisitConfirmation`: best-effort, nunca lança, respeita a trava mestra.
- **`apps/api/src/routes/public/visits.ts`** — chamada na etapa 5, logo após a notificação ao corretor.
- **`apps/api/src/utils/env.ts`** — 3 variáveis novas:
  - `VISIT_CLIENT_WHATSAPP_AUTO` — trava mestra (default: off)
  - `VISIT_CONFIRMATION_TEMPLATE_NAME` — nome do template aprovado no Meta
  - `VISIT_CONFIRMATION_TEMPLATE_LANG` — idioma (default: `pt_BR`)

## Como ativar em produção

1. `VISIT_CLIENT_WHATSAPP_AUTO=true`
2. `VISIT_CONFIRMATION_TEMPLATE_NAME=<template aprovado no Meta>`

O template no Meta Business Manager deve ter **3 variáveis no corpo, nesta ordem**: `{{1}}` nome do cliente, `{{2}}` título do imóvel, `{{3}}` data/hora.

## Regra da Meta (janela de 24h)

Sem template aprovado, o serviço cai para **texto livre** — mas a Meta só entrega texto livre dentro da janela de 24h (cliente que já escreveu). Como o cliente agenda pelo site sem abrir conversa, **em produção o template aprovado é obrigatório**. O texto livre fica apenas como fallback de teste/dev.

## Verificação

- `tsc --noEmit` limpo nos arquivos alterados (sem novos erros de typecheck).
- Best-effort: uma falha no envio não afeta o registro da visita nem a resposta da API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Th8rD19NaqdRhJHRev5v8y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8rD19NaqdRhJHRev5v8y)_