### PR TITLE
fix(site do parceiro): corrige 404 definitivo — rota _tenant não era roteável no Next.js

### DIFF
--- a/apps/web/src/app/parceiro/[slug]/imoveis/[propertySlug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/imoveis/[propertySlug]/page.tsx
@@ -2,7 +2,7 @@
  * Tenant Property Detail — página de detalhe do imóvel no site do PARCEIRO.
  *
  * Acessada via subdomínio/domínio próprio: parceiro.agoraencontrei.com.br/imoveis/{slug}
- * → middleware reescreve para /_tenant/{parceiro}/imoveis/{slug}.
+ * → middleware reescreve para /parceiro/{parceiro}/imoveis/{slug}.
  *
  * Consome o endpoint público de detalhe COM tenantSlug (ciente do parceiro), então
  * mostra só imóveis daquele parceiro e nunca dá 404 por resolver a empresa errada.

--- a/apps/web/src/app/parceiro/[slug]/imoveis/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/imoveis/page.tsx
@@ -1,7 +1,7 @@
 /**
  * Tenant Catalog — catálogo completo de imóveis no site do PARCEIRO.
  *
- * parceiro.agoraencontrei.com.br/imoveis → /_tenant/{parceiro}/imoveis
+ * parceiro.agoraencontrei.com.br/imoveis → /parceiro/{parceiro}/imoveis
  * Lista TODOS os imóveis publicados do parceiro, paginados, com busca/filtro
  * simples. Escopado pelo tenant (tenantSlug), então nunca mostra imóvel de outra
  * empresa. Cada card leva ao detalhe do imóvel no próprio site do parceiro.

--- a/apps/web/src/app/parceiro/[slug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/page.tsx
@@ -1,7 +1,7 @@
 /**
  * Tenant Home Page — Renders a clone site based on subdomain slug
  *
- * Accessed via middleware rewrite: parceiro.agoraencontrei.com.br → /_tenant/parceiro
+ * Accessed via middleware rewrite: parceiro.agoraencontrei.com.br → /parceiro/lemos
  * Fetches tenant config from API and renders appropriate layout.
  * 
  * v2: Carrega imóveis REAIS do banco de dados (com destaque e super destaque por região)

--- a/apps/web/src/app/parceiro/dominio/[[...path]]/page.tsx
+++ b/apps/web/src/app/parceiro/dominio/[[...path]]/page.tsx
@@ -39,6 +39,8 @@ export default async function DomainPage({
     notFound()
   }
 
-  // Redirect to the subdomain tenant page which handles rendering
-  redirect(`/_tenant/${tenant.subdomain}`)
+  // Redirect to the routable tenant page which handles rendering.
+  // Safe from loops: /parceiro/ is in the middleware BYPASS_PATHS, so this
+  // path renders directly on the custom-domain host without being re-rewritten.
+  redirect(`/parceiro/${tenant.subdomain}`)
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,8 +2,13 @@
  * Next.js Middleware — Subdomain/Custom Domain Routing for Multi-tenant SaaS
  *
  * Detects tenant subdomains (e.g., parceiro.agoraencontrei.com.br) and
- * custom domains, rewriting requests to /_tenant/[slug] pages.
+ * custom domains, rewriting requests to /parceiro/[slug] pages.
  * The main domain (www / naked / Vercel preview) passes through normally.
+ *
+ * IMPORTANT: the rewrite target MUST be a routable folder (no leading "_").
+ * Next.js treats "_"-prefixed folders as private and opts them out of routing,
+ * so an internal rewrite to such a path silently falls through to the SEO
+ * catch-all and 404s. Hence /parceiro (not /_tenant).
  */
 
 import { NextRequest, NextResponse } from 'next/server'
@@ -33,13 +38,16 @@ const RESERVED_SUBDOMAINS = [
   'www', 'api', 'admin', 'app', 'mail', 'smtp', 'ftp', 'ns1', 'ns2',
   'dashboard', 'portal', 'blog', 'help', 'support', 'docs', 'status',
   'staging', 'dev', 'test', 'demo',
+  // Reserved so a partner subdomain can't collide with the internal
+  // rewrite path segments (/parceiro/[slug] and /parceiro/dominio).
+  'parceiro', 'dominio',
 ]
 
 // Paths that should never be intercepted by tenant routing
 const BYPASS_PATHS = [
   '/api/',
   '/_next/',
-  '/_tenant/',
+  '/parceiro/',
   '/favicon.ico',
   '/robots.txt',
   '/sitemap',
@@ -74,7 +82,7 @@ export function middleware(request: NextRequest) {
     const subdomain = hostWithoutPort.replace(`.${BASE_DOMAIN}`, '')
     if (subdomain && !RESERVED_SUBDOMAINS.includes(subdomain)) {
       const url = request.nextUrl.clone()
-      url.pathname = `/_tenant/${subdomain}${pathname === '/' ? '' : pathname}`
+      url.pathname = `/parceiro/${subdomain}${pathname === '/' ? '' : pathname}`
       return NextResponse.rewrite(url)
     }
     // Reserved subdomain — pass through to main site
@@ -85,7 +93,7 @@ export function middleware(request: NextRequest) {
   // registered by a tenant. Rewrite to domain resolver.
   if (!hostWithoutPort.includes(BASE_DOMAIN)) {
     const url = request.nextUrl.clone()
-    url.pathname = `/_tenant/_domain${pathname}`
+    url.pathname = `/parceiro/dominio${pathname}`
     url.searchParams.set('__host', hostWithoutPort)
     return NextResponse.rewrite(url)
   }


### PR DESCRIPTION
## Causa-raiz (finalmente encontrada)

O site do parceiro (`lemos.agoraencontrei.com.br`) retornava **404** de forma persistente. A causa **não era cache, nem `force-dynamic`, nem a API** — era **estrutural**:

O site morava em `apps/web/src/app/_tenant/`. No **App Router do Next.js, qualquer pasta iniciada com `_` é uma "private folder" e fica FORA do roteamento**. Então quando o middleware reescrevia `lemos.agoraencontrei.com.br/imoveis` → `/_tenant/lemos/imoveis`, esse caminho **não existia como rota** e caía no catch-all de SEO do site principal (`/[estado]/[cidade]/[cluster]`), que retorna 404.

Confirmado **ao vivo** pelo header de resposta:
```
x-matched-path: /[estado]/[cidade]      (para lemos.agoraencontrei.com.br/)
x-matched-path: /[estado]/[cidade]/[cluster]   (para /imoveis)
```
Ou seja: a rota do parceiro **nunca foi roteável** desde que foi criada. Nenhum ajuste de cache poderia ter resolvido.

## Correção

- `app/_tenant` → **`app/parceiro`** e `app/_tenant/_domain` → **`app/parceiro/dominio`** (nomes roteáveis, sem `_`)
- `middleware.ts`:
  - rewrite de subdomínio → `/parceiro/{slug}`
  - domínio próprio → `/parceiro/dominio`
  - `BYPASS_PATHS`: `/_tenant/` → `/parceiro/`
  - `RESERVED_SUBDOMAINS`: adicionados `parceiro` e `dominio` (evita colisão de subdomínio com os segmentos internos)
- resolver de domínio próprio: `redirect` → `/parceiro/{sub}` (agora **sem loop**, pois `/parceiro/` está no `BYPASS_PATHS` e renderiza direto no host do domínio próprio)

## Verificação

`pnpm --filter web build` passou (exit 0) e o manifesto de rotas agora registra as rotas como server-rendered (`ƒ`), o que **não acontecia** com `_tenant`:
```
ƒ /parceiro/[slug]
ƒ /parceiro/[slug]/imoveis
ƒ /parceiro/[slug]/imoveis/[propertySlug]
ƒ /parceiro/dominio/[[...path]]
```

## Impacto
- Corrige o site do parceiro em subdomínio (`lemos.agoraencontrei.com.br`) **e** o fluxo de domínio próprio.
- Site principal e API **não são afetados** (apenas o caminho interno de reescrita mudou).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_