### PR TITLE
feat(site do parceiro): seção "Nossa Equipe" com fotos reais + /team por tenant

### DIFF
--- a/apps/api/src/routes/public/index.ts
+++ b/apps/api/src/routes/public/index.ts
@@ -1605,19 +1605,21 @@ export default async function publicRoutes(app: FastifyInstance) {
     }
   })
 
-  // GET /api/v1/public/team — lista pública de corretores com creciNumber
-  app.get('/team', async (_req, reply) => {
+  // GET /api/v1/public/team — lista pública de corretores com creciNumber.
+  // Aceita ?tenantSlug=... para escopar pelo parceiro (site do parceiro).
+  // Sem tenantSlug, cai na empresa pública padrão (site principal).
+  app.get('/team', async (req, reply) => {
     try {
-      const company = await resolveCompany(app)
-      if (!company) return reply.send([])
+      const companyId = await resolveScopedCompanyId(app, req.query)
+      if (!companyId) return reply.send([])
 
-      const cacheKey = `pub:team:v1:${company.id}`
+      const cacheKey = `pub:team:v2:${companyId}`
       const cached = await cacheGet(app.redis, cacheKey)
       if (cached) return reply.send(cached)
 
       const users = await app.prisma.user.findMany({
         where: {
-          companyId: company.id,
+          companyId,
           status: 'ACTIVE',
         },
         select: {
@@ -1626,6 +1628,7 @@ export default async function publicRoutes(app: FastifyInstance) {
           email: true,
           phone: true,
           avatarUrl: true,
+          bio: true,
           role: true,
           creciNumber: true,
         },

--- a/apps/web/src/app/parceiro/[slug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/page.tsx
@@ -62,6 +62,17 @@ interface Property {
   company?: { name: string; phone: string | null; logoUrl: string | null }
 }
 
+interface TeamMember {
+  id: string
+  name: string
+  email: string | null
+  phone: string | null
+  avatarUrl: string | null
+  bio: string | null
+  role: string
+  creciNumber: string | null
+}
+
 async function getTenantBySubdomain(slug: string): Promise<TenantData | null> {
   // Retry em falhas de rede (ECONNRESET/TLS do SSR → API): sem isso, um blip de
   // conexão fazia o site do parceiro cair em notFound() (404). 404 real (tenant
@@ -98,10 +109,49 @@ async function getTenantProperties(tenantSlug: string, limit = 9): Promise<Prope
   }
 }
 
+async function getTeam(tenantSlug: string): Promise<TeamMember[]> {
+  try {
+    const url = `${API_URL}/api/v1/public/team?tenantSlug=${encodeURIComponent(tenantSlug)}`
+    const res = await fetch(url, { next: { revalidate: 300 } })
+    if (!res.ok) return []
+    const data = await res.json()
+    return Array.isArray(data) ? data : (Array.isArray(data?.data) ? data.data : [])
+  } catch {
+    return []
+  }
+}
+
 function formatPrice(price: number | null, priceRent: number | null, purpose: string): string {
   const p = purpose === 'RENT' ? priceRent : price
   if (!p) return 'Consultar'
   return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(p)
+}
+
+// Rótulo de função amigável quando a pessoa ainda não preencheu a bio.
+function roleLabel(role: string): string {
+  switch (role) {
+    case 'BROKER': return 'Corretor(a) de Imóveis'
+    case 'ADMIN': return 'Equipe Imobiliária'
+    case 'SUPER_ADMIN': return 'Diretoria'
+    default: return 'Equipe'
+  }
+}
+
+// Iniciais para o avatar quando não há foto cadastrada.
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+// Normaliza telefone BR para link wa.me (só dígitos, com DDI 55).
+function waLink(phone: string | null): string | null {
+  if (!phone) return null
+  const digits = phone.replace(/\D/g, '')
+  if (digits.length < 10) return null
+  const withCountry = digits.startsWith('55') ? digits : `55${digits}`
+  return `https://wa.me/${withCountry}`
 }
 
 function PropertyBadge({ property, theme, accentColor }: { property: Property; theme: ThemeConfig; accentColor: string }) {
@@ -152,9 +202,10 @@ export default async function TenantPage({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  const [tenant, properties] = await Promise.all([
+  const [tenant, properties, teamRaw] = await Promise.all([
     getTenantBySubdomain(slug),
     getTenantProperties(slug, 9),
+    getTeam(slug),
   ])
 
   if (!tenant || !tenant.isActive) {
@@ -191,6 +242,13 @@ export default async function TenantPage({
 
   const hasProperties = sortedProperties.length > 0
 
+  // "Nossa Equipe": exclui a conta institucional (usuário com o mesmo nome da
+  // empresa, ex.: "Imobiliária Lemos") — ela representa a empresa, não uma
+  // pessoa. Gabriel e demais desligados já saem por status !== ACTIVE na API.
+  const tenantNameNorm = tenant.name.trim().toLowerCase()
+  const team = teamRaw.filter(m => m.name?.trim().toLowerCase() !== tenantNameNorm)
+  const hasTeam = team.length > 0
+
   return (
     <div className={`min-h-screen ${theme.bg} ${theme.text}`}>
       {/* CSS Variables for dynamic theming */}
@@ -226,7 +284,7 @@ export default async function TenantPage({
           ) : <div />}
           <nav className={`hidden md:flex items-center gap-6 text-sm ${theme.textMuted}`}>
             <a href="#imoveis" className="hover:opacity-80 transition">Imóveis</a>
-            <a href="#sobre" className="hover:opacity-80 transition">Sobre</a>
+            <a href="#equipe" className="hover:opacity-80 transition">Equipe</a>
             <a href="#contato" className="hover:opacity-80 transition">Contato</a>
           </nav>
           {/* Botão Tomás IA */}
@@ -426,6 +484,66 @@ export default async function TenantPage({
           )}
         </div>
       </section>
+
+      {/* Nossa Equipe — pessoas reais da imobiliária (fotos e dados do cadastro) */}
+      {hasTeam && (
+        <section id="equipe" className="py-16 px-4 border-t border-gray-200/10">
+          <div className="max-w-7xl mx-auto">
+            <div className="text-center mb-10">
+              <h3 className={`text-2xl ${theme.fontHeading} font-bold`}>Nossa Equipe</h3>
+              <p className={`text-sm ${theme.textMuted} mt-1`}>
+                Atendimento humano e próximo. Conheça quem cuida do seu imóvel.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
+              {team.map(member => {
+                const wa = waLink(member.phone)
+                return (
+                  <div key={member.id} className={`${theme.card} border rounded-2xl p-5 flex flex-col items-center text-center`}>
+                    {/* Avatar redondo: foto do cadastro ou iniciais */}
+                    {member.avatarUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={member.avatarUrl}
+                        alt={member.name}
+                        className="w-24 h-24 rounded-full object-cover ring-2"
+                        style={{ '--tw-ring-color': `${accentColor}55` } as React.CSSProperties}
+                      />
+                    ) : (
+                      <div
+                        className="w-24 h-24 rounded-full flex items-center justify-center text-2xl font-bold ring-2"
+                        style={{ backgroundColor: `${accentColor}18`, color: accentColor, '--tw-ring-color': `${accentColor}55` } as React.CSSProperties}
+                      >
+                        {initials(member.name)}
+                      </div>
+                    )}
+                    <p className={`mt-4 text-sm font-semibold ${theme.text} leading-tight`}>{member.name}</p>
+                    <p className={`text-xs ${theme.textMuted} mt-0.5`}>
+                      {member.bio?.trim() || roleLabel(member.role)}
+                    </p>
+                    {member.creciNumber && (
+                      <span className="mt-1 text-[10px] font-medium px-2 py-0.5 rounded-full" style={{ backgroundColor: `${accentColor}18`, color: accentColor }}>
+                        CRECI {member.creciNumber}
+                      </span>
+                    )}
+                    {wa && (
+                      <a
+                        href={`${wa}?text=${encodeURIComponent(`Olá ${member.name.split(' ')[0]}, vi você no site da ${tenant.name} e gostaria de falar sobre imóveis.`)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg text-white"
+                        style={{ backgroundColor: '#25D366' }}
+                      >
+                        💬 WhatsApp
+                      </a>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Contact Section */}
       <section id="contato" className="py-16 px-4 border-t border-gray-200/10">


### PR DESCRIPTION
## O que muda

Adiciona a seção **"Nossa Equipe"** dentro do site do parceiro (`lemos.agoraencontrei.com.br`), **depois dos imóveis e antes do contato** — exatamente onde você pediu.

### Frontend (`app/parceiro/[slug]/page.tsx`)
- Nova seção "Nossa Equipe" com card por pessoa:
  - **Avatar redondo** — foto do cadastro (`avatarUrl`) ou **iniciais** como fallback (ninguém subiu foto ainda; assim que subirem, aparece automático)
  - Nome, função (usa a **bio** da pessoa; se vazia, um rótulo pelo papel: "Corretor(a) de Imóveis" / "Equipe Imobiliária")
  - Badge **CRECI** quando houver
  - Botão **WhatsApp** por pessoa (com DDI 55 e mensagem pronta) quando há telefone
- **Exclui a conta institucional**: o usuário cujo nome é igual ao da empresa ("Imobiliária Lemos") representa a empresa, não uma pessoa — não entra na equipe.
- Gabriel e demais desligados **já não aparecem** (a API só retorna `status = ACTIVE`).
- Nav do header: `Sobre` (âncora que não existia) → **`Equipe`**.

### Backend (`routes/public/index.ts`)
- `GET /api/v1/public/team` agora aceita **`?tenantSlug=`** e é escopado pela empresa daquele parceiro (via `resolveScopedCompanyId`). Sem `tenantSlug`, mantém o comportamento antigo (empresa pública padrão) — os callers existentes (`/corretores`, página institucional) não mudam.
- Passa a retornar **`bio`** para alimentar a função de cada pessoa.
- Cache key `v1` → `v2` (novo shape).

## Verificação
`pnpm --filter web build` passou (exit 0). Rotas do parceiro seguem registradas (`ƒ /parceiro/[slug]`).

## Pendente (não bloqueia este PR)
- **Endereço + horário de atendimento** no bloco de contato: preciso que o Tomás me envie o endereço completo e horário para preencher com o dado correto.
- Fotos e bios de cada pessoa: cada membro completa no próprio cadastro (aparecem sozinhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_