### PR TITLE
fix(site do parceiro): tira o card institucional de "Nossa Equipe" (acento NFC×NFD)

### DIFF
--- a/apps/web/src/app/parceiro/[slug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/page.tsx
@@ -245,8 +245,11 @@ export default async function TenantPage({
   // "Nossa Equipe": exclui a conta institucional (usuário com o mesmo nome da
   // empresa, ex.: "Imobiliária Lemos") — ela representa a empresa, não uma
   // pessoa. Gabriel e demais desligados já saem por status !== ACTIVE na API.
-  const tenantNameNorm = tenant.name.trim().toLowerCase()
-  const team = teamRaw.filter(m => m.name?.trim().toLowerCase() !== tenantNameNorm)
+  // Normaliza removendo acentos: o nome do usuário e o do tenant podem diferir
+  // só na forma Unicode do acento (NFC × NFD), o que quebraria um === simples.
+  const nameKey = (s: string) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase()
+  const tenantNameNorm = nameKey(tenant.name)
+  const team = teamRaw.filter(m => m.name && nameKey(m.name) !== tenantNameNorm)
   const hasTeam = team.length > 0
 
   return (


### PR DESCRIPTION
## Bug encontrado na verificação ao vivo

Com a seção "Nossa Equipe" já em produção, a conta institucional **"Imobiliária Lemos"** (o usuário que representa a empresa, com o WhatsApp `16981010004`) **continuava aparecendo como um card de pessoa** na equipe.

**Causa:** o filtro que remove a conta institucional comparava `nome === nome_do_tenant` (após `toLowerCase`). Mas o "**á**" de "Imobiliária" vinha em **formas Unicode diferentes** no cadastro do usuário e no nome do tenant (NFC = `á` pré-composto × NFD = `a` + acento combinante). Bytes diferentes ⇒ `===` nunca batia ⇒ o card não era removido.

## Correção
A comparação agora normaliza para **NFD e remove os diacríticos combinantes** (`/[̀-ͯ]/`) antes de comparar. Assim "Imobiliária Lemos" bate independentemente da forma do acento, e a conta institucional sai da lista. **Só as 9 pessoas reais permanecem** (Gabriel já não aparecia).

## Verificação
- Confirmei ao vivo que o card institucional renderizava (`wa.me/5516981010004` presente na home).
- `pnpm --filter web build` passou (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_