### PR TITLE
feat: módulo de campanhas por WhatsApp com agente (MVP simulado)

### DIFF
--- a/apps/api/src/plugins/automation.ts
+++ b/apps/api/src/plugins/automation.ts
@@ -9,6 +9,7 @@ import { processVisualAIJob } from '../workers/visual-ai.worker.js'
 import { processCampaignJob } from '../workers/campaign.worker.js'
 import { processVideoEditorJob } from '../workers/video-editor.worker.js'
 import { processOutboundJob } from '../services/outbound-queue.service.js'
+import { processWaCampaignJob } from '../workers/wa-campaign.worker.js'
 import type { AutomationEventPayload } from '../services/automation.types.js'
 import { env } from '../utils/env.js'
 
@@ -19,6 +20,7 @@ declare module 'fastify' {
     campaignsQueue:   Queue | null
     outboundQueue:    Queue | null
     videoEditorQueue: Queue | null
+    waCampaignsQueue: Queue | null
   }
 }
 
@@ -30,6 +32,7 @@ export default fp(async (app: FastifyInstance) => {
     app.decorate('campaignsQueue',   null)
     app.decorate('outboundQueue',    null)
     app.decorate('videoEditorQueue', null)
+    app.decorate('waCampaignsQueue', null)
     return
   }
 
@@ -55,12 +58,14 @@ export default fp(async (app: FastifyInstance) => {
   const campaignsQueue   = new Queue('campaigns',    { connection })
   const outboundQueue    = new Queue('outbound',     { connection })
   const videoEditorQueue = new Queue('video-editor', { connection })
+  const waCampaignsQueue = new Queue('wa-campaigns',  { connection })
 
   app.decorate('automationQueue',  automationQueue)
   app.decorate('visualAIQueue',    visualAIQueue)
   app.decorate('campaignsQueue',   campaignsQueue)
   app.decorate('outboundQueue',    outboundQueue)
   app.decorate('videoEditorQueue', videoEditorQueue)
+  app.decorate('waCampaignsQueue', waCampaignsQueue)
 
   // ── Funnel domain events into automation queue ────────────────────────────
   automationEmitter.on('automation:event', async (payload: AutomationEventPayload) => {
@@ -109,12 +114,20 @@ export default fp(async (app: FastifyInstance) => {
     { connection, concurrency: 1 },
   )
 
+  // ── WhatsApp campaigns worker — one recipient per job (simulated no MVP) ──
+  const waCampaignsWorker = new Worker(
+    'wa-campaigns',
+    async (job) => processWaCampaignJob(job, app.prisma),
+    { connection, concurrency: 2 },
+  )
+
   for (const [name, worker] of [
     ['automation',   automationWorker],
     ['visual-ai',    visualAIWorker],
     ['campaigns',    campaignsWorker],
     ['outbound',     outboundWorker],
     ['video-editor', videoEditorWorker],
+    ['wa-campaigns', waCampaignsWorker],
   ] as const) {
     worker.on('failed', (job, err) => {
       app.log.error({ queue: name, jobId: job?.id, err }, `${name} job failed`)
@@ -137,6 +150,7 @@ export default fp(async (app: FastifyInstance) => {
       campaignsWorker.close(),
       outboundWorker.close(),
       videoEditorWorker.close(),
+      waCampaignsWorker.close(),
     ])
     await Promise.all([
       automationQueue.close(),
@@ -144,9 +158,10 @@ export default fp(async (app: FastifyInstance) => {
       campaignsQueue.close(),
       outboundQueue.close(),
       videoEditorQueue.close(),
+      waCampaignsQueue.close(),
     ])
     await connection.quit()
   })
 
-  app.log.info('✅ Automation engine started (queues: automation, visual-ai, campaigns, outbound, video-editor)')
+  app.log.info('✅ Automation engine started (queues: automation, visual-ai, campaigns, outbound, video-editor, wa-campaigns)')
 })

--- a/apps/api/src/routes/wa-campaigns/index.ts
+++ b/apps/api/src/routes/wa-campaigns/index.ts
@@ -1,0 +1,351 @@
+/**
+ * WhatsApp Campaigns Routes — /api/v1/wa-campaigns
+ *
+ * Módulo tenant-facing (escopo por companyId) para disparo profissional de
+ * campanhas de imóveis/empreendimentos. Envio SIMULADO no MVP.
+ *
+ *  POST   /                         — criar campanha
+ *  GET    /                         — listar campanhas
+ *  GET    /:id                      — detalhe + destinatários + risco
+ *  POST   /:id/recipients           — colar/importar lista (normaliza+dedupe+optout)
+ *  DELETE /:id/recipients/:rid      — remover destinatário
+ *  POST   /:id/risk                 — recalcular risco
+ *  POST   /:id/approve              — aprovação humana (ADMIN)
+ *  POST   /:id/dispatch             — enfileirar disparo (simulado)
+ *  POST   /:id/cancel               — cancelar
+ *  GET    /optout                   — listar opt-outs
+ *  POST   /optout                   — adicionar opt-out manual
+ *  POST   /webhook/inbound          — resposta recebida (opt-out / abre CRM)
+ *  POST   /:id/prospect/research    — agente de prospecção (revisão humana)
+ *  GET    /:id/prospect             — listar prospects
+ *  POST   /prospect/:pid/review     — aprovar/rejeitar prospect
+ *  POST   /:id/prospect/import      — importar prospects aprovados
+ */
+
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import {
+  createCampaign,
+  listCampaigns,
+  getCampaign,
+  addRecipients,
+  removeRecipient,
+  recomputeRisk,
+  approveCampaign,
+  dispatchCampaign,
+  cancelCampaign,
+} from '../../services/wa-campaigns/wa-campaigns.service.js'
+import { parsePhoneList, normalizePhoneBR } from '../../services/wa-campaigns/phone.util.js'
+import { addOptOut, handleInboundReply } from '../../services/wa-campaigns/wa-optout.service.js'
+import {
+  researchProspects,
+  listProspects,
+  reviewProspect,
+  importApprovedProspects,
+} from '../../services/wa-campaigns/wa-prospect.service.js'
+
+const ADMIN_ROLES = ['ADMIN', 'OWNER', 'SUPER_ADMIN', 'MANAGER']
+
+const CONSENT_BASES = ['consent', 'legitimate_interest', 'contract', 'existing_customer'] as const
+
+export default async function waCampaignsRoutes(app: FastifyInstance) {
+  // ── Webhook público de resposta (verificado por token) — antes do auth ────
+  // Recebe respostas do provedor (ou simulação) para tratar SAIR e abrir CRM.
+  app.post('/webhook/inbound', {
+    config: { rateLimit: { max: 120, timeWindow: '1 minute' } },
+    schema: { tags: ['wa-campaigns'], summary: 'Inbound reply webhook (opt-out / CRM)' },
+  }, async (req, reply) => {
+    const body = z.object({
+      companyId: z.string().min(1),
+      phone: z.string().min(8),
+      text: z.string().default(''),
+      token: z.string().optional(),
+    }).parse(req.body)
+
+    // Verificação simples por token compartilhado (reuso do verify token do WABA).
+    const expected = process.env.WHATSAPP_VERIFY_TOKEN
+    if (expected && body.token !== expected) {
+      return reply.status(401).send({ error: 'INVALID_TOKEN' })
+    }
+
+    const result = await handleInboundReply(app.prisma, {
+      companyId: body.companyId,
+      phone: body.phone,
+      text: body.text,
+    })
+    return reply.send({ success: true, data: result })
+  })
+
+  // ── Todas as demais rotas exigem autenticação staff ───────────────────────
+  app.addHook('preHandler', app.authenticate)
+
+  // ── POST / — criar campanha ───────────────────────────────────────────────
+  app.post('/', {
+    schema: { tags: ['wa-campaigns'], summary: 'Create campaign' },
+  }, async (req, reply) => {
+    const body = z.object({
+      name: z.string().min(1),
+      propertyId: z.string().optional(),
+      empreendimento: z.string().optional(),
+      templateName: z.string().optional(),
+      templateLang: z.string().optional(),
+      messageBody: z.string().min(1),
+      variables: z.record(z.any()).optional(),
+      scheduledAt: z.string().datetime().optional(),
+    }).parse(req.body)
+
+    const campaign = await createCampaign(app.prisma, {
+      companyId: req.user.cid,
+      createdById: req.user.sub,
+      name: body.name,
+      propertyId: body.propertyId,
+      empreendimento: body.empreendimento,
+      templateName: body.templateName,
+      templateLang: body.templateLang,
+      messageBody: body.messageBody,
+      variables: body.variables,
+      scheduledAt: body.scheduledAt ? new Date(body.scheduledAt) : undefined,
+    })
+
+    return reply.send({ success: true, data: campaign })
+  })
+
+  // ── GET / — listar ────────────────────────────────────────────────────────
+  app.get('/', {
+    schema: { tags: ['wa-campaigns'], summary: 'List campaigns' },
+  }, async (req, reply) => {
+    const q = req.query as any
+    const campaigns = await listCampaigns(app.prisma, req.user.cid, q.status)
+    return reply.send({ success: true, data: campaigns })
+  })
+
+  // ── GET /:id — detalhe ──────────────────────────────────────────────────────
+  app.get('/:id', {
+    schema: { tags: ['wa-campaigns'], summary: 'Campaign detail' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const campaign = await getCampaign(app.prisma, req.user.cid, id)
+    if (!campaign) return reply.status(404).send({ error: 'CAMPAIGN_NOT_FOUND' })
+    return reply.send({ success: true, data: campaign })
+  })
+
+  // ── POST /:id/recipients — colar/importar lista ─────────────────────────────
+  app.post('/:id/recipients', {
+    config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+    schema: { tags: ['wa-campaigns'], summary: 'Add recipients (paste/import list)' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const campaign = await getCampaign(app.prisma, req.user.cid, id)
+    if (!campaign) return reply.status(404).send({ error: 'CAMPAIGN_NOT_FOUND' })
+
+    const body = z.object({
+      // Ou um texto colado (uma coluna) ...
+      rawList: z.string().optional(),
+      // ... ou uma lista estruturada com nome por telefone.
+      contacts: z.array(z.object({
+        phone: z.string(),
+        name: z.string().optional(),
+        variables: z.record(z.any()).optional(),
+      })).optional(),
+      source: z.string().default('import'),
+      consentBasis: z.enum(CONSENT_BASES).default('consent'),
+      sourceRef: z.string().optional(),
+    }).parse(req.body)
+
+    const entries = body.contacts?.length
+      ? body.contacts.map((c) => ({
+          raw: c.phone,
+          name: c.name,
+          source: body.source,
+          consentBasis: body.consentBasis,
+          sourceRef: body.sourceRef,
+          variables: c.variables,
+        }))
+      : parsePhoneList(body.rawList ?? '').map((raw) => ({
+          raw,
+          source: body.source,
+          consentBasis: body.consentBasis,
+          sourceRef: body.sourceRef,
+        }))
+
+    if (entries.length === 0) {
+      return reply.status(400).send({ error: 'EMPTY_LIST' })
+    }
+
+    const report = await addRecipients(app.prisma, {
+      campaignId: id,
+      companyId: req.user.cid,
+      entries,
+    })
+    const updated = await getCampaign(app.prisma, req.user.cid, id)
+    return reply.send({ success: true, data: { report, campaign: updated } })
+  })
+
+  // ── DELETE /:id/recipients/:rid ─────────────────────────────────────────────
+  app.delete('/:id/recipients/:rid', {
+    schema: { tags: ['wa-campaigns'], summary: 'Remove recipient' },
+  }, async (req, reply) => {
+    const { id, rid } = req.params as { id: string; rid: string }
+    await removeRecipient(app.prisma, req.user.cid, id, rid)
+    return reply.send({ success: true })
+  })
+
+  // ── POST /:id/risk — recalcular risco ───────────────────────────────────────
+  app.post('/:id/risk', {
+    schema: { tags: ['wa-campaigns'], summary: 'Recompute risk' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const campaign = await getCampaign(app.prisma, req.user.cid, id)
+    if (!campaign) return reply.status(404).send({ error: 'CAMPAIGN_NOT_FOUND' })
+    const risk = await recomputeRisk(app.prisma, id)
+    return reply.send({ success: true, data: risk })
+  })
+
+  // ── POST /:id/approve — aprovação humana (ADMIN) ────────────────────────────
+  app.post('/:id/approve', {
+    schema: { tags: ['wa-campaigns'], summary: 'Approve campaign (human review)' },
+  }, async (req, reply) => {
+    if (!ADMIN_ROLES.includes(req.user.role)) {
+      return reply.status(403).send({ error: 'FORBIDDEN', message: 'Aprovação exige perfil de gestor/admin' })
+    }
+    const { id } = req.params as { id: string }
+    try {
+      const campaign = await approveCampaign(app.prisma, req.user.cid, id, req.user.sub)
+      return reply.send({ success: true, data: campaign })
+    } catch (err: any) {
+      return reply.status(404).send({ error: err.message })
+    }
+  })
+
+  // ── POST /:id/dispatch — enfileirar disparo (simulado no MVP) ───────────────
+  app.post('/:id/dispatch', {
+    config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
+    schema: { tags: ['wa-campaigns'], summary: 'Dispatch campaign (queued, simulated)' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    try {
+      const result = await dispatchCampaign(app.prisma, app.waCampaignsQueue, {
+        companyId: req.user.cid,
+        campaignId: id,
+      })
+      return reply.send({ success: true, data: result })
+    } catch (err: any) {
+      const code = err.message
+      const status = code === 'CAMPAIGN_NOT_FOUND' ? 404 : 400
+      return reply.status(status).send({ error: code })
+    }
+  })
+
+  // ── POST /:id/cancel ────────────────────────────────────────────────────────
+  app.post('/:id/cancel', {
+    schema: { tags: ['wa-campaigns'], summary: 'Cancel campaign' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    await cancelCampaign(app.prisma, req.user.cid, id)
+    return reply.send({ success: true })
+  })
+
+  // ── Opt-out registry ────────────────────────────────────────────────────────
+  app.get('/optout', {
+    schema: { tags: ['wa-campaigns'], summary: 'List opt-outs' },
+  }, async (req, reply) => {
+    const rows = await (app.prisma as any).waOptOut.findMany({
+      where: { companyId: req.user.cid },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    })
+    return reply.send({ success: true, data: rows })
+  })
+
+  app.post('/optout', {
+    schema: { tags: ['wa-campaigns'], summary: 'Add manual opt-out' },
+  }, async (req, reply) => {
+    const body = z.object({ phone: z.string().min(8), reason: z.string().optional() }).parse(req.body)
+    const norm = normalizePhoneBR(body.phone)
+    if (!norm.valid || !norm.e164) return reply.status(400).send({ error: 'INVALID_PHONE', reason: norm.reason })
+    await addOptOut(app.prisma, {
+      companyId: req.user.cid,
+      phoneE164: norm.e164,
+      reason: body.reason ?? 'manual',
+      source: 'manual',
+    })
+    return reply.send({ success: true, data: { phoneE164: norm.e164 } })
+  })
+
+  // ── Agente de prospecção (sempre com revisão humana) ────────────────────────
+  app.post('/:id/prospect/research', {
+    config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
+    schema: { tags: ['wa-campaigns'], summary: 'Research public business contacts (needs review)' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const campaign = await getCampaign(app.prisma, req.user.cid, id)
+    if (!campaign) return reply.status(404).send({ error: 'CAMPAIGN_NOT_FOUND' })
+    const body = z.object({
+      query: z.string().min(2),
+      city: z.string().optional(),
+      category: z.string().optional(),
+      limit: z.number().int().min(1).max(25).optional(),
+    }).parse(req.body)
+
+    const results = await researchProspects(app.prisma, {
+      companyId: req.user.cid,
+      campaignId: id,
+      query: body.query,
+      city: body.city,
+      category: body.category,
+      limit: body.limit,
+    })
+    return reply.send({
+      success: true,
+      data: results,
+      notice: 'Resultados SIMULADOS. Revise a fonte e valide os telefones antes de aprovar. Nada é enviado sem revisão humana.',
+    })
+  })
+
+  app.get('/:id/prospect', {
+    schema: { tags: ['wa-campaigns'], summary: 'List prospects' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const q = req.query as any
+    const rows = await listProspects(app.prisma, req.user.cid, { campaignId: id, status: q.status })
+    return reply.send({ success: true, data: rows })
+  })
+
+  app.post('/prospect/:pid/review', {
+    schema: { tags: ['wa-campaigns'], summary: 'Review (approve/reject) a prospect' },
+  }, async (req, reply) => {
+    if (!ADMIN_ROLES.includes(req.user.role)) {
+      return reply.status(403).send({ error: 'FORBIDDEN' })
+    }
+    const { pid } = req.params as { pid: string }
+    const body = z.object({
+      action: z.enum(['approve', 'reject']),
+      phone: z.string().optional(),
+      sourceRef: z.string().optional(),
+      notes: z.string().optional(),
+    }).parse(req.body)
+    try {
+      const row = await reviewProspect(app.prisma, req.user.cid, pid, {
+        ...body,
+        reviewedById: req.user.sub,
+      })
+      return reply.send({ success: true, data: row })
+    } catch (err: any) {
+      return reply.status(400).send({ error: err.message })
+    }
+  })
+
+  app.post('/:id/prospect/import', {
+    schema: { tags: ['wa-campaigns'], summary: 'Import approved prospects into campaign' },
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string }
+    const campaign = await getCampaign(app.prisma, req.user.cid, id)
+    if (!campaign) return reply.status(404).send({ error: 'CAMPAIGN_NOT_FOUND' })
+    const result = await importApprovedProspects(app.prisma, {
+      companyId: req.user.cid,
+      campaignId: id,
+    })
+    const updated = await getCampaign(app.prisma, req.user.cid, id)
+    return reply.send({ success: true, data: { ...result, campaign: updated } })
+  })
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -116,6 +116,7 @@ import affiliateRoutes from './routes/affiliates/index.js'
 import saasFinanceRoutes from './routes/saas-finance/index.js'
 import previewRoutes from './routes/preview/index.js'
 import outboundRoutes from './routes/outbound/index.js'
+import waCampaignsRoutes from './routes/wa-campaigns/index.js'
 
 import { sensitiveSerializer } from './utils/log-sanitizer.js'
 import { safeStringEqual } from './utils/crypto-safe.js'
@@ -1510,6 +1511,7 @@ async function bootstrap() {
   await app.register(saasFinanceRoutes,      { prefix: '/api/v1/saas-finance' })
   await app.register(previewRoutes,          { prefix: '/api/v1/preview' })
   await app.register(outboundRoutes,         { prefix: '/api/v1/outbound' })
+  await app.register(waCampaignsRoutes,      { prefix: '/api/v1/wa-campaigns' })
 
   // ── Re-ativar leilões bancários fechados erroneamente pelo cleanup ────
   try {

--- a/apps/api/src/services/wa-campaigns/phone.util.ts
+++ b/apps/api/src/services/wa-campaigns/phone.util.ts
@@ -1,0 +1,141 @@
+/**
+ * Normalização e validação de telefones brasileiros para campanhas de WhatsApp.
+ *
+ * O WhatsApp Business Platform só entrega para números móveis no formato E.164.
+ * Este utilitário é puro (sem I/O) para ser facilmente testável e reutilizável
+ * tanto na API quanto em workers.
+ */
+
+/** DDDs válidos no Brasil (Anatel). Números com DDD fora desta lista são rejeitados. */
+export const VALID_DDDS = new Set<string>([
+  '11', '12', '13', '14', '15', '16', '17', '18', '19',
+  '21', '22', '24', '27', '28',
+  '31', '32', '33', '34', '35', '37', '38',
+  '41', '42', '43', '44', '45', '46', '47', '48', '49',
+  '51', '53', '54', '55',
+  '61', '62', '63', '64', '65', '66', '67', '68', '69',
+  '71', '73', '74', '75', '77', '79',
+  '81', '82', '83', '84', '85', '86', '87', '88', '89',
+  '91', '92', '93', '94', '95', '96', '97', '98', '99',
+])
+
+export type PhoneType = 'mobile' | 'landline'
+
+export interface NormalizedPhone {
+  /** Entrada original, preservada para auditoria. */
+  raw: string
+  /** true apenas quando é um móvel válido (WhatsApp exige móvel). */
+  valid: boolean
+  /** Formato E.164 (+55DDDNUMERO) quando válido; null caso contrário. */
+  e164: string | null
+  /** Motivo da rejeição (código estável para UI/testes). */
+  reason?:
+    | 'empty'
+    | 'too_short'
+    | 'too_long'
+    | 'invalid_ddd'
+    | 'landline_not_whatsapp'
+    | 'invalid_format'
+  type?: PhoneType
+  ddd?: string
+}
+
+/**
+ * Normaliza um telefone brasileiro para E.164.
+ *
+ * Aceita variações comuns de listas coladas: "(11) 91234-5678",
+ * "11912345678", "+55 11 91234-5678", "5511912345678", "011 91234-5678".
+ * Corrige móveis antigos de 8 dígitos inserindo o nono dígito ("9").
+ */
+export function normalizePhoneBR(raw: string): NormalizedPhone {
+  const original = (raw ?? '').toString()
+  let digits = original.replace(/\D/g, '')
+
+  if (!digits) return { raw: original, valid: false, e164: null, reason: 'empty' }
+
+  // Prefixo internacional "00" (ex.: "0055...")
+  if (digits.startsWith('00')) digits = digits.slice(2)
+
+  // Código do país 55 — só remove se o restante ficar com 10 ou 11 dígitos.
+  if (digits.startsWith('55') && (digits.length === 12 || digits.length === 13)) {
+    digits = digits.slice(2)
+  }
+
+  // Prefixo de operadora "0" (ex.: "011...") — remove um zero à esquerda.
+  if (digits.length === 11 && digits.startsWith('0')) digits = digits.slice(1)
+  if (digits.length === 12 && digits.startsWith('0')) digits = digits.slice(1)
+
+  if (digits.length < 10) return { raw: original, valid: false, e164: null, reason: 'too_short' }
+  if (digits.length > 11) return { raw: original, valid: false, e164: null, reason: 'too_long' }
+
+  const ddd = digits.slice(0, 2)
+  let subscriber = digits.slice(2)
+
+  if (!VALID_DDDS.has(ddd)) {
+    return { raw: original, valid: false, e164: null, reason: 'invalid_ddd', ddd }
+  }
+
+  // 10 dígitos: pode ser fixo (inicia 2-5) ou móvel antigo sem o 9 (inicia 6-9).
+  if (subscriber.length === 8) {
+    const first = subscriber[0]
+    if (['6', '7', '8', '9'].includes(first)) {
+      // Móvel antigo — insere o nono dígito.
+      subscriber = '9' + subscriber
+    } else {
+      // Fixo — não é entregável no WhatsApp.
+      return { raw: original, valid: false, e164: null, reason: 'landline_not_whatsapp', type: 'landline', ddd }
+    }
+  }
+
+  // Móvel válido: 9 dígitos começando com 9.
+  if (subscriber.length === 9 && subscriber[0] === '9') {
+    return { raw: original, valid: true, e164: `+55${ddd}${subscriber}`, type: 'mobile', ddd }
+  }
+
+  return { raw: original, valid: false, e164: null, reason: 'invalid_format', ddd }
+}
+
+/**
+ * Quebra um texto colado (uma coluna, CSV simples, separado por vírgula/;/
+ * quebras de linha/espaços) em telefones individuais brutos.
+ */
+export function parsePhoneList(text: string): string[] {
+  if (!text) return []
+  return text
+    .split(/[\n\r,;|\t]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+export interface NormalizeReport {
+  valid: NormalizedPhone[]
+  invalid: NormalizedPhone[]
+  duplicates: string[] // E.164 removidos por duplicidade
+}
+
+/**
+ * Normaliza uma lista, remove duplicados (por E.164) e separa válidos/inválidos.
+ * Mantém a primeira ocorrência de cada número válido.
+ */
+export function normalizeAndDedupe(rawPhones: string[]): NormalizeReport {
+  const valid: NormalizedPhone[] = []
+  const invalid: NormalizedPhone[] = []
+  const duplicates: string[] = []
+  const seen = new Set<string>()
+
+  for (const raw of rawPhones) {
+    const n = normalizePhoneBR(raw)
+    if (!n.valid || !n.e164) {
+      invalid.push(n)
+      continue
+    }
+    if (seen.has(n.e164)) {
+      duplicates.push(n.e164)
+      continue
+    }
+    seen.add(n.e164)
+    valid.push(n)
+  }
+
+  return { valid, invalid, duplicates }
+}

--- a/apps/api/src/services/wa-campaigns/wa-campaigns.service.ts
+++ b/apps/api/src/services/wa-campaigns/wa-campaigns.service.ts
@@ -1,0 +1,462 @@
+/**
+ * Serviço central de campanhas de WhatsApp.
+ *
+ * Orquestra: criação, ingestão de destinatários (normalização + dedupe +
+ * bloqueio de opt-out + registro de origem/base LGPD), cálculo de risco,
+ * aprovação humana e disparo pela fila (com envio simulado no MVP).
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import type { Queue } from 'bullmq'
+import { normalizePhoneBR } from './phone.util.js'
+import { getOptedOutSet } from './wa-optout.service.js'
+import { computeCampaignRisk } from './wa-risk.service.js'
+import { getWaProvider, renderMessage } from './wa-provider.js'
+
+export const WA_CAMPAIGNS_QUEUE = 'wa-campaigns'
+
+// ── Tipos ────────────────────────────────────────────────────────────────────
+
+export interface CreateCampaignInput {
+  companyId: string
+  createdById: string
+  name: string
+  propertyId?: string
+  empreendimento?: string
+  templateName?: string
+  templateLang?: string
+  messageBody: string
+  variables?: Record<string, unknown>
+  scheduledAt?: Date
+}
+
+export interface RecipientEntry {
+  raw: string
+  name?: string
+  source?: string
+  consentBasis?: string
+  sourceRef?: string
+  variables?: Record<string, unknown>
+}
+
+export interface AddRecipientsReport {
+  added: number
+  invalid: number
+  duplicatesInBatch: number
+  duplicatesExisting: number
+  blockedOptOut: number
+  invalidSamples: { raw: string; reason?: string }[]
+}
+
+// ── Criação / leitura ────────────────────────────────────────────────────────
+
+export async function createCampaign(prisma: PrismaClient, input: CreateCampaignInput) {
+  return (prisma as any).waCampaign.create({
+    data: {
+      companyId: input.companyId,
+      createdById: input.createdById,
+      name: input.name,
+      propertyId: input.propertyId,
+      empreendimento: input.empreendimento,
+      templateName: input.templateName,
+      templateLang: input.templateLang ?? 'pt_BR',
+      messageBody: input.messageBody,
+      variables: (input.variables ?? {}) as any,
+      scheduledAt: input.scheduledAt,
+      status: 'DRAFT',
+    },
+  })
+}
+
+export async function getCampaign(prisma: PrismaClient, companyId: string, id: string) {
+  return (prisma as any).waCampaign.findFirst({
+    where: { id, companyId },
+    include: {
+      recipients: { orderBy: { createdAt: 'desc' }, take: 500 },
+    },
+  })
+}
+
+export async function listCampaigns(prisma: PrismaClient, companyId: string, status?: string) {
+  return (prisma as any).waCampaign.findMany({
+    where: { companyId, ...(status ? { status } : {}) },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+  })
+}
+
+// ── Ingestão de destinatários ────────────────────────────────────────────────
+
+/**
+ * Normaliza, deduplica, bloqueia opt-out e persiste destinatários.
+ * Origem (source) e base LGPD (consentBasis) são obrigatórias por contato.
+ */
+export async function addRecipients(
+  prisma: PrismaClient,
+  args: { campaignId: string; companyId: string; entries: RecipientEntry[] },
+): Promise<AddRecipientsReport> {
+  const { campaignId, companyId, entries } = args
+
+  const report: AddRecipientsReport = {
+    added: 0,
+    invalid: 0,
+    duplicatesInBatch: 0,
+    duplicatesExisting: 0,
+    blockedOptOut: 0,
+    invalidSamples: [],
+  }
+
+  // 1) Normaliza e separa válidos/inválidos, deduplicando dentro do lote.
+  const seenInBatch = new Set<string>()
+  const validEntries: { e164: string; entry: RecipientEntry }[] = []
+  const invalidRows: any[] = []
+
+  for (const entry of entries) {
+    const n = normalizePhoneBR(entry.raw)
+    if (!n.valid || !n.e164) {
+      report.invalid++
+      if (report.invalidSamples.length < 20) {
+        report.invalidSamples.push({ raw: entry.raw, reason: n.reason })
+      }
+      invalidRows.push({
+        campaignId,
+        companyId,
+        name: entry.name,
+        rawPhone: entry.raw,
+        phoneE164: null,
+        valid: false,
+        invalidReason: n.reason,
+        source: entry.source ?? 'import',
+        consentBasis: entry.consentBasis ?? 'consent',
+        sourceRef: entry.sourceRef,
+        status: 'SKIPPED',
+        variables: (entry.variables ?? {}) as any,
+      })
+      continue
+    }
+    if (seenInBatch.has(n.e164)) {
+      report.duplicatesInBatch++
+      continue
+    }
+    seenInBatch.add(n.e164)
+    validEntries.push({ e164: n.e164, entry })
+  }
+
+  const batchPhones = validEntries.map((v) => v.e164)
+
+  // 2) Duplicados já existentes na campanha.
+  const existing = await (prisma as any).waCampaignRecipient
+    .findMany({
+      where: { campaignId, phoneE164: { in: batchPhones } },
+      select: { phoneE164: true },
+    })
+    .catch(() => [])
+  const existingSet = new Set<string>(existing.map((r: any) => r.phoneE164))
+
+  // 3) Bloqueio de opt-out (LGPD / descadastro).
+  const optedOut = await getOptedOutSet(prisma, companyId, batchPhones)
+
+  const toCreate: any[] = [...invalidRows]
+
+  for (const { e164, entry } of validEntries) {
+    if (existingSet.has(e164)) {
+      report.duplicatesExisting++
+      continue
+    }
+    const isOptOut = optedOut.has(e164)
+    if (isOptOut) report.blockedOptOut++
+    else report.added++
+
+    toCreate.push({
+      campaignId,
+      companyId,
+      name: entry.name,
+      rawPhone: entry.raw,
+      phoneE164: e164,
+      valid: true,
+      source: entry.source ?? 'import',
+      consentBasis: entry.consentBasis ?? 'consent',
+      sourceRef: entry.sourceRef,
+      status: isOptOut ? 'UNSUBSCRIBED' : 'PENDING',
+      variables: (entry.variables ?? {}) as any,
+    })
+  }
+
+  if (toCreate.length > 0) {
+    await (prisma as any).waCampaignRecipient.createMany({ data: toCreate, skipDuplicates: true })
+  }
+
+  await refreshCampaignCounts(prisma, campaignId)
+  await recomputeRisk(prisma, campaignId).catch(() => null)
+
+  return report
+}
+
+export async function removeRecipient(
+  prisma: PrismaClient,
+  companyId: string,
+  campaignId: string,
+  recipientId: string,
+) {
+  await (prisma as any).waCampaignRecipient
+    .deleteMany({ where: { id: recipientId, campaignId, companyId } })
+    .catch(() => null)
+  await refreshCampaignCounts(prisma, campaignId)
+}
+
+// ── Risco ────────────────────────────────────────────────────────────────────
+
+export async function recomputeRisk(prisma: PrismaClient, campaignId: string) {
+  const campaign = await (prisma as any).waCampaign.findUnique({ where: { id: campaignId } })
+  if (!campaign) return null
+
+  const recipients = await (prisma as any).waCampaignRecipient.findMany({
+    where: { campaignId },
+    select: { valid: true, status: true, consentBasis: true, source: true },
+  })
+
+  let totalValid = 0
+  let totalInvalid = 0
+  let totalBlockedOptOut = 0
+  let prospected = 0
+  const consentBasisCounts: Record<string, number> = {}
+
+  for (const r of recipients) {
+    if (!r.valid) {
+      totalInvalid++
+      continue
+    }
+    if (r.status === 'UNSUBSCRIBED') {
+      totalBlockedOptOut++
+      continue
+    }
+    totalValid++
+    consentBasisCounts[r.consentBasis] = (consentBasisCounts[r.consentBasis] ?? 0) + 1
+    if (r.source === 'prospect_agent') prospected++
+  }
+
+  const risk = computeCampaignRisk({
+    totalValid,
+    totalInvalid,
+    totalBlockedOptOut,
+    consentBasisCounts,
+    hasApprovedTemplate: !!campaign.templateName,
+    messageBody: campaign.messageBody,
+    prospectFraction: totalValid > 0 ? prospected / totalValid : 0,
+  })
+
+  await (prisma as any).waCampaign.update({
+    where: { id: campaignId },
+    data: {
+      riskScore: risk.score,
+      riskLevel: risk.level,
+      riskFactors: risk.factors as any,
+      requiresApproval: risk.requiresApproval,
+    },
+  })
+
+  return risk
+}
+
+// ── Aprovação ────────────────────────────────────────────────────────────────
+
+export async function approveCampaign(
+  prisma: PrismaClient,
+  companyId: string,
+  campaignId: string,
+  approvedById: string,
+) {
+  const campaign = await (prisma as any).waCampaign.findFirst({ where: { id: campaignId, companyId } })
+  if (!campaign) throw new Error('CAMPAIGN_NOT_FOUND')
+  return (prisma as any).waCampaign.update({
+    where: { id: campaignId },
+    data: { status: 'APPROVED', approvedById, approvedAt: new Date() },
+  })
+}
+
+// ── Disparo ──────────────────────────────────────────────────────────────────
+
+export interface DispatchResult {
+  enqueued: number
+  mode: 'queue' | 'inline'
+  simulated: boolean
+}
+
+/**
+ * Enfileira o disparo. Exige aprovação humana quando o risco pede.
+ * Sem Redis/fila, processa inline (útil em dev/testes). No MVP tudo é simulado.
+ */
+export async function dispatchCampaign(
+  prisma: PrismaClient,
+  queue: Queue | null,
+  args: { companyId: string; campaignId: string },
+): Promise<DispatchResult> {
+  const campaign = await (prisma as any).waCampaign.findFirst({
+    where: { id: args.campaignId, companyId: args.companyId },
+  })
+  if (!campaign) throw new Error('CAMPAIGN_NOT_FOUND')
+
+  if (campaign.requiresApproval && campaign.status !== 'APPROVED') {
+    throw new Error('APPROVAL_REQUIRED')
+  }
+  if (['SENDING', 'SENT', 'QUEUED'].includes(campaign.status)) {
+    throw new Error('ALREADY_DISPATCHED')
+  }
+
+  const recipients = await (prisma as any).waCampaignRecipient.findMany({
+    where: { campaignId: args.campaignId, status: 'PENDING', valid: true },
+    select: { id: true },
+  })
+
+  await (prisma as any).waCampaign.update({
+    where: { id: args.campaignId },
+    data: { status: 'SENDING', startedAt: new Date() },
+  })
+
+  const provider = await getWaProvider(prisma, args.companyId)
+  const simulated = provider.name === 'simulated'
+
+  if (queue) {
+    for (const r of recipients) {
+      await queue.add(
+        'send',
+        { recipientId: r.id, campaignId: args.campaignId, companyId: args.companyId },
+        {
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: { count: 500 },
+          removeOnFail: { count: 1000 },
+        },
+      )
+    }
+    await (prisma as any).waCampaignRecipient.updateMany({
+      where: { campaignId: args.campaignId, status: 'PENDING', valid: true },
+      data: { status: 'QUEUED', queuedAt: new Date() },
+    })
+    return { enqueued: recipients.length, mode: 'queue', simulated }
+  }
+
+  // Fallback inline (sem Redis) — processa cada destinatário sequencialmente.
+  for (const r of recipients) {
+    await processRecipient(prisma, r.id).catch(() => null)
+  }
+  await finalizeCampaignIfDone(prisma, args.campaignId)
+  return { enqueued: recipients.length, mode: 'inline', simulated }
+}
+
+/**
+ * Processa um destinatário: revalida opt-out, envia via provider e atualiza
+ * status. Usado tanto pelo worker da fila quanto pelo fallback inline.
+ */
+export async function processRecipient(prisma: PrismaClient, recipientId: string): Promise<void> {
+  const recipient = await (prisma as any).waCampaignRecipient.findUnique({ where: { id: recipientId } })
+  if (!recipient || !recipient.valid || !recipient.phoneE164) return
+  if (['SENT', 'DELIVERED', 'READ', 'REPLIED', 'UNSUBSCRIBED'].includes(recipient.status)) return
+
+  const campaign = await (prisma as any).waCampaign.findUnique({ where: { id: recipient.campaignId } })
+  if (!campaign) return
+
+  // Revalida opt-out no momento do envio (pode ter chegado SAIR depois).
+  const optOut = await (prisma as any).waOptOut
+    .findUnique({
+      where: { companyId_phoneE164: { companyId: recipient.companyId, phoneE164: recipient.phoneE164 } },
+    })
+    .catch(() => null)
+  if (optOut) {
+    await (prisma as any).waCampaignRecipient.update({
+      where: { id: recipientId },
+      data: { status: 'UNSUBSCRIBED' },
+    })
+    await (prisma as any).waCampaign.update({
+      where: { id: campaign.id },
+      data: { totalOptOut: { increment: 1 } },
+    })
+    return
+  }
+
+  const provider = await getWaProvider(prisma, recipient.companyId)
+  const variables = {
+    ...(campaign.variables as Record<string, unknown>),
+    ...(recipient.variables as Record<string, unknown>),
+    nome: recipient.name ?? '',
+  }
+  const body = renderMessage(campaign.messageBody, variables)
+
+  const result = await provider.send({
+    to: recipient.phoneE164,
+    body,
+    templateName: campaign.templateName ?? undefined,
+    templateLang: campaign.templateLang,
+  })
+
+  if (result.status === 'FAILED') {
+    await (prisma as any).waCampaignRecipient.update({
+      where: { id: recipientId },
+      data: { status: 'FAILED', errorMessage: result.errorMessage },
+    })
+    await (prisma as any).waCampaign.update({
+      where: { id: campaign.id },
+      data: { totalFailed: { increment: 1 } },
+    })
+    return
+  }
+
+  // No modo simulado marcamos DELIVERED direto (não há webhook de entrega).
+  const finalStatus = result.simulated ? 'DELIVERED' : 'SENT'
+  await (prisma as any).waCampaignRecipient.update({
+    where: { id: recipientId },
+    data: {
+      status: finalStatus,
+      providerMessageId: result.providerMessageId,
+      sentAt: new Date(),
+      ...(result.simulated ? { deliveredAt: new Date() } : {}),
+    },
+  })
+  await (prisma as any).waCampaign.update({
+    where: { id: campaign.id },
+    data: {
+      totalSent: { increment: 1 },
+      ...(result.simulated ? { totalDelivered: { increment: 1 } } : {}),
+    },
+  })
+}
+
+/** Marca a campanha como SENT quando não há mais destinatários pendentes/na fila. */
+export async function finalizeCampaignIfDone(prisma: PrismaClient, campaignId: string): Promise<void> {
+  const pending = await (prisma as any).waCampaignRecipient.count({
+    where: { campaignId, status: { in: ['PENDING', 'QUEUED'] } },
+  })
+  if (pending === 0) {
+    await (prisma as any).waCampaign.update({
+      where: { id: campaignId },
+      data: { status: 'SENT', completedAt: new Date() },
+    })
+  }
+}
+
+export async function cancelCampaign(prisma: PrismaClient, companyId: string, campaignId: string) {
+  return (prisma as any).waCampaign.updateMany({
+    where: { id: campaignId, companyId, status: { in: ['DRAFT', 'PENDING_APPROVAL', 'APPROVED', 'QUEUED'] } },
+    data: { status: 'CANCELLED' },
+  })
+}
+
+// ── Utilidades ───────────────────────────────────────────────────────────────
+
+/** Recalcula os contadores agregados da campanha a partir dos destinatários. */
+export async function refreshCampaignCounts(prisma: PrismaClient, campaignId: string): Promise<void> {
+  const recipients = await (prisma as any).waCampaignRecipient.findMany({
+    where: { campaignId },
+    select: { status: true, valid: true },
+  })
+  let totalRecipients = 0
+  let totalOptOut = 0
+  for (const r of recipients) {
+    if (r.valid && r.status !== 'SKIPPED') totalRecipients++
+    if (r.status === 'UNSUBSCRIBED') totalOptOut++
+  }
+  await (prisma as any).waCampaign.update({
+    where: { id: campaignId },
+    data: { totalRecipients, totalOptOut },
+  })
+}

--- a/apps/api/src/services/wa-campaigns/wa-optout.service.ts
+++ b/apps/api/src/services/wa-campaigns/wa-optout.service.ts
@@ -1,0 +1,180 @@
+/**
+ * Registro de opt-out (descadastro) por empresa.
+ *
+ * Toda campanha respeita este registro: um número que pediu SAIR/PARAR nunca
+ * mais recebe disparo daquela empresa. Também trata respostas recebidas,
+ * detectando palavras-chave de descadastro e abrindo atendimento no CRM.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { normalizePhoneBR } from './phone.util.js'
+
+/** Palavras-chave que, sozinhas na mensagem, disparam descadastro imediato. */
+export const OPT_OUT_KEYWORDS = [
+  'sair',
+  'parar',
+  'pare',
+  'cancelar',
+  'descadastrar',
+  'remover',
+  'stop',
+  'unsubscribe',
+]
+
+/** true quando o texto recebido é (essencialmente) um pedido de descadastro. */
+export function isOptOutMessage(text: string): boolean {
+  if (!text) return false
+  const normalized = text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // remove acentos
+    .replace(/[^a-z\s]/g, '')
+    .trim()
+
+  if (!normalized) return false
+
+  const words = normalized.split(/\s+/)
+  // Match exato, ou keyword como palavra inteira em mensagem curta (<=4 palavras).
+  // Evita falso positivo em frases longas ("quando sair o lançamento me avise").
+  if (OPT_OUT_KEYWORDS.includes(normalized)) return true
+  if (words.length <= 4 && words.some((w) => OPT_OUT_KEYWORDS.includes(w))) return true
+  return false
+}
+
+/** true se o número está descadastrado para a empresa. */
+export async function isOptedOut(
+  prisma: PrismaClient,
+  companyId: string,
+  phoneE164: string,
+): Promise<boolean> {
+  const row = await (prisma as any).waOptOut
+    .findUnique({ where: { companyId_phoneE164: { companyId, phoneE164 } } })
+    .catch(() => null)
+  return !!row
+}
+
+/** Retorna o conjunto de números (E.164) descadastrados dentre os informados. */
+export async function getOptedOutSet(
+  prisma: PrismaClient,
+  companyId: string,
+  phones: string[],
+): Promise<Set<string>> {
+  if (phones.length === 0) return new Set()
+  const rows = await (prisma as any).waOptOut
+    .findMany({
+      where: { companyId, phoneE164: { in: phones } },
+      select: { phoneE164: true },
+    })
+    .catch(() => [])
+  return new Set(rows.map((r: any) => r.phoneE164))
+}
+
+/** Adiciona (idempotente) um número ao registro de opt-out. */
+export async function addOptOut(
+  prisma: PrismaClient,
+  input: { companyId: string; phoneE164: string; reason?: string; source?: string },
+): Promise<void> {
+  await (prisma as any).waOptOut
+    .upsert({
+      where: { companyId_phoneE164: { companyId: input.companyId, phoneE164: input.phoneE164 } },
+      create: {
+        companyId: input.companyId,
+        phoneE164: input.phoneE164,
+        reason: input.reason ?? 'keyword',
+        source: input.source,
+      },
+      update: {},
+    })
+    .catch(() => null)
+}
+
+export interface InboundReplyResult {
+  handled: boolean
+  optedOut: boolean
+  recipientId?: string
+  leadId?: string
+}
+
+/**
+ * Processa uma resposta recebida via WhatsApp.
+ *
+ * - Se for pedido de descadastro → registra opt-out e marca o destinatário
+ *   como UNSUBSCRIBED (respeitando SAIR).
+ * - Caso contrário → marca REPLIED e abre atendimento no CRM (Lead), para que
+ *   um corretor continue a conversa.
+ */
+export async function handleInboundReply(
+  prisma: PrismaClient,
+  input: { companyId: string; phone: string; text: string },
+): Promise<InboundReplyResult> {
+  const norm = normalizePhoneBR(input.phone)
+  const phoneE164 = norm.e164 ?? input.phone
+
+  // Localiza o destinatário mais recente com este número, para vincular resposta.
+  const recipient = await (prisma as any).waCampaignRecipient
+    .findFirst({
+      where: { companyId: input.companyId, phoneE164 },
+      orderBy: { createdAt: 'desc' },
+    })
+    .catch(() => null)
+
+  if (isOptOutMessage(input.text)) {
+    await addOptOut(prisma, {
+      companyId: input.companyId,
+      phoneE164,
+      reason: 'keyword',
+      source: 'inbound_reply',
+    })
+    if (recipient) {
+      await (prisma as any).waCampaignRecipient
+        .update({ where: { id: recipient.id }, data: { status: 'UNSUBSCRIBED' } })
+        .catch(() => null)
+      await (prisma as any).waCampaign
+        .update({ where: { id: recipient.campaignId }, data: { totalOptOut: { increment: 1 } } })
+        .catch(() => null)
+    }
+    return { handled: true, optedOut: true, recipientId: recipient?.id }
+  }
+
+  // Resposta normal → abre/atualiza atendimento (Lead) e marca REPLIED.
+  let leadId: string | undefined
+  if (recipient) {
+    await (prisma as any).waCampaignRecipient
+      .update({
+        where: { id: recipient.id },
+        data: { status: 'REPLIED', repliedAt: new Date() },
+      })
+      .catch(() => null)
+    await (prisma as any).waCampaign
+      .update({ where: { id: recipient.campaignId }, data: { totalReplied: { increment: 1 } } })
+      .catch(() => null)
+  }
+
+  // Cria um Lead de atendimento (best-effort — não bloqueia a resposta).
+  try {
+    const existing = await prisma.lead.findFirst({
+      where: { companyId: input.companyId, phone: phoneE164 },
+      select: { id: true },
+    })
+    if (existing) {
+      leadId = existing.id
+    } else {
+      const lead = await prisma.lead.create({
+        data: {
+          companyId: input.companyId,
+          name: recipient?.name ?? `Contato ${phoneE164}`,
+          phone: phoneE164,
+          source: 'whatsapp_campaign',
+          status: 'NEW',
+          notes: `Respondeu campanha WhatsApp: "${input.text.slice(0, 280)}"`,
+        },
+        select: { id: true },
+      })
+      leadId = lead.id
+    }
+  } catch {
+    // Schema de Lead pode variar entre ambientes — resposta não deve falhar.
+  }
+
+  return { handled: true, optedOut: false, recipientId: recipient?.id, leadId }
+}

--- a/apps/api/src/services/wa-campaigns/wa-prospect.service.ts
+++ b/apps/api/src/services/wa-campaigns/wa-prospect.service.ts
@@ -1,0 +1,175 @@
+/**
+ * Agente de pesquisa de empresas/contatos comerciais PÚBLICOS.
+ *
+ * Regras de segurança do MVP:
+ *  - NÃO faz scraping de navegador nem automação de WhatsApp Web.
+ *  - NÃO coleta dados pessoais sensíveis — apenas dados comerciais públicos.
+ *  - TODO resultado entra como PENDING_REVIEW e exige revisão humana + fonte
+ *    (sourceRef) antes de poder virar destinatário de campanha.
+ *
+ * No MVP o "agente" é SIMULADO: devolve candidatos de exemplo, claramente
+ * marcados como necessitando verificação, sem inventar números reais. A
+ * integração real (ex.: Google Places API, diretórios públicos de CNPJ) é
+ * plugada depois substituindo `runResearch`.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { normalizePhoneBR } from './phone.util.js'
+import { addRecipients } from './wa-campaigns.service.js'
+
+export interface ResearchInput {
+  companyId: string
+  campaignId?: string
+  query: string
+  city?: string
+  category?: string
+  limit?: number
+}
+
+interface RawProspect {
+  name: string
+  phone?: string
+  category?: string
+  city?: string
+  sourceRef: string
+  sourceUrl?: string
+}
+
+/**
+ * Executa a "pesquisa". Ponto de extensão para integrar uma fonte real.
+ * No MVP retorna candidatos de exemplo determinísticos — sem telefones reais,
+ * forçando o revisor humano a preencher/validar o contato antes do envio.
+ */
+async function runResearch(input: ResearchInput): Promise<RawProspect[]> {
+  const limit = Math.min(input.limit ?? 5, 25)
+  const city = input.city ?? 'sua cidade'
+  const category = input.category ?? input.query
+
+  const results: RawProspect[] = []
+  for (let i = 1; i <= limit; i++) {
+    results.push({
+      name: `${category} — Exemplo ${i}`,
+      phone: undefined, // MVP não inventa telefones; revisor humano preenche.
+      category,
+      city,
+      sourceRef: `SIMULADO: substituir por fonte pública verificável (ex.: perfil comercial de "${category}" em ${city}). Requer verificação humana.`,
+      sourceUrl: undefined,
+    })
+  }
+  return results
+}
+
+export async function researchProspects(prisma: PrismaClient, input: ResearchInput) {
+  const raw = await runResearch(input)
+  const created = []
+  for (const p of raw) {
+    const norm = p.phone ? normalizePhoneBR(p.phone) : null
+    const row = await (prisma as any).waProspectResult.create({
+      data: {
+        companyId: input.companyId,
+        campaignId: input.campaignId,
+        name: p.name,
+        phone: p.phone,
+        phoneE164: norm?.e164 ?? null,
+        category: p.category,
+        city: p.city,
+        sourceRef: p.sourceRef,
+        sourceUrl: p.sourceUrl,
+        status: 'PENDING_REVIEW',
+      },
+    })
+    created.push(row)
+  }
+  return created
+}
+
+export async function listProspects(
+  prisma: PrismaClient,
+  companyId: string,
+  filters?: { campaignId?: string; status?: string },
+) {
+  return (prisma as any).waProspectResult.findMany({
+    where: {
+      companyId,
+      ...(filters?.campaignId ? { campaignId: filters.campaignId } : {}),
+      ...(filters?.status ? { status: filters.status } : {}),
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 200,
+  })
+}
+
+/**
+ * Revisão humana: aprova (opcionalmente corrigindo telefone/fonte) ou rejeita.
+ * Aprovação sem telefone válido é bloqueada — sem contato não há envio.
+ */
+export async function reviewProspect(
+  prisma: PrismaClient,
+  companyId: string,
+  prospectId: string,
+  input: { action: 'approve' | 'reject'; phone?: string; sourceRef?: string; notes?: string; reviewedById: string },
+) {
+  const prospect = await (prisma as any).waProspectResult.findFirst({ where: { id: prospectId, companyId } })
+  if (!prospect) throw new Error('PROSPECT_NOT_FOUND')
+
+  if (input.action === 'reject') {
+    return (prisma as any).waProspectResult.update({
+      where: { id: prospectId },
+      data: { status: 'REJECTED', reviewedById: input.reviewedById, reviewedAt: new Date(), notes: input.notes },
+    })
+  }
+
+  // Aprovação exige telefone válido (do resultado ou corrigido pelo revisor).
+  const phone = input.phone ?? prospect.phone
+  const norm = phone ? normalizePhoneBR(phone) : null
+  if (!norm?.valid || !norm.e164) throw new Error('APPROVE_REQUIRES_VALID_PHONE')
+
+  return (prisma as any).waProspectResult.update({
+    where: { id: prospectId },
+    data: {
+      status: 'APPROVED',
+      phone,
+      phoneE164: norm.e164,
+      sourceRef: input.sourceRef ?? prospect.sourceRef,
+      notes: input.notes,
+      reviewedById: input.reviewedById,
+      reviewedAt: new Date(),
+    },
+  })
+}
+
+/**
+ * Importa prospects APROVADOS para a campanha como destinatários, registrando
+ * origem `prospect_agent`, base LGPD `legitimate_interest` e a fonte pública.
+ */
+export async function importApprovedProspects(
+  prisma: PrismaClient,
+  args: { companyId: string; campaignId: string },
+) {
+  const approved = await (prisma as any).waProspectResult.findMany({
+    where: { companyId: args.companyId, status: 'APPROVED', phoneE164: { not: null } },
+  })
+
+  if (approved.length === 0) {
+    return { imported: 0, report: null }
+  }
+
+  const report = await addRecipients(prisma, {
+    campaignId: args.campaignId,
+    companyId: args.companyId,
+    entries: approved.map((p: any) => ({
+      raw: p.phoneE164,
+      name: p.name,
+      source: 'prospect_agent',
+      consentBasis: 'legitimate_interest',
+      sourceRef: p.sourceRef,
+    })),
+  })
+
+  await (prisma as any).waProspectResult.updateMany({
+    where: { id: { in: approved.map((p: any) => p.id) } },
+    data: { status: 'IMPORTED', campaignId: args.campaignId },
+  })
+
+  return { imported: report.added, report }
+}

--- a/apps/api/src/services/wa-campaigns/wa-provider.ts
+++ b/apps/api/src/services/wa-campaigns/wa-provider.ts
@@ -1,0 +1,121 @@
+/**
+ * Camada de provider de envio — a integração real fica ISOLADA aqui.
+ *
+ * No MVP o provider padrão é o `SimulatedProvider`: ele NÃO envia nada, apenas
+ * devolve um id fake e um status determinístico. A integração oficial (Meta
+ * WhatsApp Cloud API ou provedor parceiro autorizado) implementa a mesma
+ * interface e só é ativada quando `WA_CAMPAIGNS_LIVE=true` e as credenciais
+ * existem. Nenhuma automação de navegador/WhatsApp Web é usada.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { env } from '../../utils/env.js'
+import { getIntegrationConfig } from '../integration-config.service.js'
+import { whatsappService } from '../whatsapp.service.js'
+
+export interface SendMessageInput {
+  to: string // E.164
+  /** Corpo já renderizado (variáveis substituídas). */
+  body: string
+  /** Nome do template WABA aprovado, quando houver. */
+  templateName?: string
+  templateLang?: string
+  /** Componentes do template (parâmetros) já montados, quando aplicável. */
+  templateComponents?: unknown[]
+}
+
+export interface SendMessageResult {
+  providerMessageId: string
+  status: 'SENT' | 'FAILED'
+  errorMessage?: string
+  /** true quando nada foi realmente enviado (modo simulado). */
+  simulated: boolean
+}
+
+export interface WhatsAppCampaignProvider {
+  readonly name: string
+  send(input: SendMessageInput): Promise<SendMessageResult>
+}
+
+/** Provider simulado — padrão do MVP. Nunca envia mensagem real. */
+export class SimulatedProvider implements WhatsAppCampaignProvider {
+  readonly name = 'simulated'
+
+  async send(input: SendMessageInput): Promise<SendMessageResult> {
+    // Determinístico e sem I/O externo: gera um id fake baseado no destino.
+    const stamp = Buffer.from(`${input.to}:${input.body.length}`).toString('base64url').slice(0, 16)
+    return {
+      providerMessageId: `sim_${stamp}`,
+      status: 'SENT',
+      simulated: true,
+    }
+  }
+}
+
+/**
+ * Provider real (Meta WhatsApp Cloud API). Reutiliza o `whatsappService`
+ * existente e as credenciais por tenant (`getIntegrationConfig`). Só é usado
+ * quando explicitamente ligado — jamais no MVP.
+ */
+export class CloudApiProvider implements WhatsAppCampaignProvider {
+  readonly name = 'cloud_api'
+
+  constructor(private readonly cfg: { token?: string; phoneId?: string }) {}
+
+  async send(input: SendMessageInput): Promise<SendMessageResult> {
+    try {
+      // Envio em massa/utility DEVE usar template aprovado (política da Meta).
+      const res: any = input.templateName
+        ? await whatsappService.sendTemplate(
+            input.to,
+            input.templateName,
+            input.templateLang ?? 'pt_BR',
+            (input.templateComponents as unknown[]) ?? [],
+            this.cfg,
+          )
+        : await whatsappService.sendText(input.to, input.body, this.cfg)
+
+      const id = res?.messages?.[0]?.id ?? `wa_${Date.now()}`
+      return { providerMessageId: id, status: 'SENT', simulated: false }
+    } catch (err: any) {
+      return {
+        providerMessageId: '',
+        status: 'FAILED',
+        errorMessage: err?.message ?? 'Falha no envio',
+        simulated: false,
+      }
+    }
+  }
+}
+
+/**
+ * Fábrica de provider. Retorna o simulado a menos que:
+ *   1. `WA_CAMPAIGNS_LIVE=true`, e
+ *   2. haja credenciais WhatsApp (do tenant ou do ambiente).
+ *
+ * Isso garante que o MVP nunca dispare mensagens reais mesmo com credenciais
+ * presentes, até que o operador ligue a flag conscientemente.
+ */
+export async function getWaProvider(
+  prisma: PrismaClient,
+  companyId: string | null | undefined,
+): Promise<WhatsAppCampaignProvider> {
+  if (env.WA_CAMPAIGNS_LIVE !== 'true') {
+    return new SimulatedProvider()
+  }
+  const cfg = await getIntegrationConfig(prisma, companyId, 'whatsapp').catch(() => ({}) as Record<string, string>)
+  const token = cfg.token || env.WHATSAPP_TOKEN
+  const phoneId = cfg.phoneId || env.WHATSAPP_PHONE_ID
+  if (!token || !phoneId) {
+    return new SimulatedProvider()
+  }
+  return new CloudApiProvider({ token, phoneId })
+}
+
+/** Renderiza {{chave}} no corpo da mensagem a partir das variáveis. */
+export function renderMessage(body: string, variables: Record<string, unknown>): string {
+  return (body || '').replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_m, key: string) => {
+    const v = variables?.[key]
+    return v == null ? '' : String(v)
+  })
+}

--- a/apps/api/src/services/wa-campaigns/wa-risk.service.ts
+++ b/apps/api/src/services/wa-campaigns/wa-risk.service.ts
@@ -1,0 +1,119 @@
+/**
+ * Cálculo de risco de campanha.
+ *
+ * O objetivo é evitar spam, proteger a reputação do número do usuário e forçar
+ * revisão humana quando a campanha tem sinais de risco (lista grande, muitos
+ * inválidos, base LGPD frágil, ausência de template aprovado etc.).
+ *
+ * Função pura → fácil de testar e reutilizar na UI (preview de risco).
+ */
+
+export interface RiskInput {
+  totalValid: number
+  totalInvalid: number
+  totalBlockedOptOut: number
+  /** Distribuição de destinatários por base LGPD (consentBasis → contagem). */
+  consentBasisCounts: Record<string, number>
+  hasApprovedTemplate: boolean
+  messageBody: string
+  /** Fração de contatos vindos do agente de prospecção (0..1). */
+  prospectFraction?: number
+}
+
+export interface RiskFactor {
+  code: string
+  label: string
+  weight: number
+}
+
+export type RiskLevel = 'low' | 'medium' | 'high'
+
+export interface RiskResult {
+  score: number // 0-100
+  level: RiskLevel
+  requiresApproval: boolean
+  factors: RiskFactor[]
+}
+
+/** Bases LGPD consideradas "fortes" (relação prévia com o titular). */
+const STRONG_CONSENT = new Set(['consent', 'contract', 'existing_customer'])
+
+const LINK_REGEX = /(https?:\/\/|wa\.me\/|bit\.ly|\b\w+\.(com|br|net|io)\b)/i
+
+export function computeCampaignRisk(input: RiskInput): RiskResult {
+  const factors: RiskFactor[] = []
+  let score = 0
+
+  const totalRecipients = input.totalValid
+  const totalContacts =
+    input.totalValid + input.totalInvalid + input.totalBlockedOptOut
+
+  // 1) Tamanho da lista — quanto maior, maior o risco de ser tratado como spam.
+  if (totalRecipients > 500) {
+    factors.push({ code: 'large_list', label: 'Lista muito grande (>500)', weight: 30 })
+    score += 30
+  } else if (totalRecipients > 200) {
+    factors.push({ code: 'large_list', label: 'Lista grande (>200)', weight: 18 })
+    score += 18
+  } else if (totalRecipients > 50) {
+    factors.push({ code: 'medium_list', label: 'Lista média (>50)', weight: 8 })
+    score += 8
+  }
+
+  // 2) Qualidade da lista — muitos números inválidos indicam base "comprada"/suja.
+  if (totalContacts > 0) {
+    const invalidFraction = input.totalInvalid / totalContacts
+    if (invalidFraction > 0.3) {
+      factors.push({ code: 'dirty_list', label: 'Muitos telefones inválidos (>30%)', weight: 20 })
+      score += 20
+    } else if (invalidFraction > 0.1) {
+      factors.push({ code: 'some_invalid', label: 'Telefones inválidos (>10%)', weight: 8 })
+      score += 8
+    }
+  }
+
+  // 3) Base LGPD — proporção sem base forte de uso do contato.
+  const weakConsent = Object.entries(input.consentBasisCounts).reduce(
+    (sum, [basis, count]) => (STRONG_CONSENT.has(basis) ? sum : sum + count),
+    0,
+  )
+  if (totalRecipients > 0) {
+    const weakFraction = weakConsent / totalRecipients
+    if (weakFraction > 0.5) {
+      factors.push({ code: 'weak_lgpd', label: 'Maioria sem base forte de consentimento (LGPD)', weight: 25 })
+      score += 25
+    } else if (weakFraction > 0.2) {
+      factors.push({ code: 'partial_lgpd', label: 'Parte da lista sem consentimento explícito', weight: 12 })
+      score += 12
+    }
+  }
+
+  // 4) Origem de prospecção — contatos comerciais pesquisados exigem mais cautela.
+  if (input.prospectFraction && input.prospectFraction > 0.3) {
+    factors.push({ code: 'prospected', label: 'Muitos contatos de prospecção pública', weight: 15 })
+    score += 15
+  }
+
+  // 5) Template aprovado — sem template WABA aprovado o envio em massa é arriscado.
+  if (!input.hasApprovedTemplate) {
+    factors.push({ code: 'no_template', label: 'Sem modelo (template) aprovado', weight: 15 })
+    score += 15
+  }
+
+  // 6) Mensagem com link — links elevam bloqueio/spam e devem ser revisados.
+  if (LINK_REGEX.test(input.messageBody || '')) {
+    factors.push({ code: 'contains_link', label: 'Mensagem contém link', weight: 6 })
+    score += 6
+  }
+
+  score = Math.min(100, score)
+
+  let level: RiskLevel = 'low'
+  if (score >= 60) level = 'high'
+  else if (score >= 25) level = 'medium'
+
+  // Aprovação humana obrigatória para risco médio/alto.
+  const requiresApproval = level !== 'low'
+
+  return { score, level, requiresApproval, factors }
+}

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -44,6 +44,15 @@ const envSchema = z.object({
   WHATSAPP_VERIFY_TOKEN: z.string().optional().default('lemoschat_verify'),
   WHATSAPP_BUSINESS_ID: z.string().optional(),
 
+  // WhatsApp Campaigns module
+  // Provider de envio das campanhas: simulated (MVP) | cloud_api | provider
+  WA_CAMPAIGNS_PROVIDER: z.string().optional().default('simulated'),
+  // Trava de segurança: só envia mensagem REAL quando explicitamente "true".
+  // Enquanto "false" (padrão), tudo roda em modo simulado.
+  WA_CAMPAIGNS_LIVE: z.string().optional().default('false'),
+  // Namespace/idioma padrão dos templates aprovados na Meta (WABA).
+  WHATSAPP_TEMPLATE_NAMESPACE: z.string().optional(),
+
   // Storage
   AWS_REGION: z.string().default('us-east-1'),
   AWS_ACCESS_KEY_ID: z.string().optional(),

--- a/apps/api/src/workers/wa-campaign.worker.ts
+++ b/apps/api/src/workers/wa-campaign.worker.ts
@@ -1,0 +1,21 @@
+/**
+ * Worker da fila 'wa-campaigns' — processa um destinatário por job.
+ *
+ * Cada job envia (via provider — simulado no MVP) para um destinatário e,
+ * ao terminar, tenta finalizar a campanha se não houver mais pendentes.
+ */
+import type { PrismaClient } from '@prisma/client'
+import type { Job } from 'bullmq'
+import { processRecipient, finalizeCampaignIfDone } from '../services/wa-campaigns/wa-campaigns.service.js'
+
+export interface WaCampaignJobData {
+  recipientId: string
+  campaignId: string
+  companyId: string
+}
+
+export async function processWaCampaignJob(job: Job, prisma: PrismaClient): Promise<void> {
+  const { recipientId, campaignId } = job.data as WaCampaignJobData
+  await processRecipient(prisma, recipientId)
+  await finalizeCampaignIfDone(prisma, campaignId)
+}

--- a/apps/api/test/wa-campaign.test.ts
+++ b/apps/api/test/wa-campaign.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createCampaign,
+  addRecipients,
+} from '../src/services/wa-campaigns/wa-campaigns.service.js'
+import { addOptOut } from '../src/services/wa-campaigns/wa-optout.service.js'
+import { computeCampaignRisk } from '../src/services/wa-campaigns/wa-risk.service.js'
+import { makeMockPrisma } from './wa-mock-prisma.js'
+
+test('createCampaign persiste em DRAFT com base na empresa', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'Aurora', messageBody: 'Olá {{nome}}' })
+  assert.equal(c.status, 'DRAFT')
+  assert.equal(c.companyId, 'c1')
+  assert.equal(prisma.__db.waCampaign.length, 1)
+})
+
+test('addRecipients normaliza, deduplica, ignora inválidos e bloqueia opt-out', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'Aurora', messageBody: 'Olá' })
+
+  // Um número já descadastrado deve ser bloqueado no envio.
+  await addOptOut(prisma, { companyId: 'c1', phoneE164: '+5521987654321' })
+
+  const report = await addRecipients(prisma, {
+    campaignId: c.id,
+    companyId: 'c1',
+    entries: [
+      { raw: '11912345678', source: 'import', consentBasis: 'consent' },
+      { raw: '(11) 91234-5678', source: 'import', consentBasis: 'consent' }, // duplicado
+      { raw: '11 3234-5678', source: 'import', consentBasis: 'consent' },     // fixo → inválido
+      { raw: '21987654321', source: 'import', consentBasis: 'consent' },      // opt-out
+      { raw: 'abc', source: 'import', consentBasis: 'consent' },              // inválido
+    ],
+  })
+
+  assert.equal(report.added, 1, 'apenas 1 destinatário novo válido e liberado')
+  assert.equal(report.duplicatesInBatch, 1)
+  assert.equal(report.invalid, 2)
+  assert.equal(report.blockedOptOut, 1)
+
+  // Segundo lote com o mesmo número já existente → duplicado existente.
+  const report2 = await addRecipients(prisma, {
+    campaignId: c.id,
+    companyId: 'c1',
+    entries: [{ raw: '11912345678', source: 'import', consentBasis: 'consent' }],
+  })
+  assert.equal(report2.duplicatesExisting, 1)
+  assert.equal(report2.added, 0)
+})
+
+test('computeCampaignRisk: lista pequena com consentimento → baixo, sem aprovação', () => {
+  const r = computeCampaignRisk({
+    totalValid: 10, totalInvalid: 0, totalBlockedOptOut: 0,
+    consentBasisCounts: { consent: 10 }, hasApprovedTemplate: true, messageBody: 'Olá',
+  })
+  assert.equal(r.level, 'low')
+  assert.equal(r.requiresApproval, false)
+})
+
+test('computeCampaignRisk: lista grande + sem template + base fraca → alto, exige aprovação', () => {
+  const r = computeCampaignRisk({
+    totalValid: 600, totalInvalid: 200, totalBlockedOptOut: 0,
+    consentBasisCounts: { legitimate_interest: 600 }, hasApprovedTemplate: false,
+    messageBody: 'Confira https://exemplo.com',
+  })
+  assert.equal(r.level, 'high')
+  assert.equal(r.requiresApproval, true)
+  assert.ok(r.score >= 60)
+})

--- a/apps/api/test/wa-mock-prisma.ts
+++ b/apps/api/test/wa-mock-prisma.ts
@@ -1,0 +1,112 @@
+/**
+ * Mock de Prisma em memória para os testes do módulo de campanhas WhatsApp.
+ * Cobre apenas os modelos/métodos exercitados pelos serviços testados.
+ * (Não é um arquivo *.test.ts → não é executado como suíte.)
+ */
+
+let seq = 0
+const nextId = (p: string) => `${p}_${++seq}`
+
+/** Casa um registro contra um `where` com suporte a operadores comuns. */
+function matchWhere(row: any, where: any): boolean {
+  if (!where) return true
+  for (const [key, cond] of Object.entries<any>(where)) {
+    // Chave composta unique (companyId_phoneE164 / campaignId_phoneE164)
+    if (key.includes('_') && cond && typeof cond === 'object' && !('in' in cond) && !('not' in cond)) {
+      for (const [k, v] of Object.entries(cond)) {
+        if (row[k] !== v) return false
+      }
+      continue
+    }
+    if (cond && typeof cond === 'object') {
+      if ('in' in cond) { if (!cond.in.includes(row[key])) return false; continue }
+      if ('not' in cond) { if (row[key] === cond.not) return false; continue }
+    } else if (row[key] !== cond) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Aplica um `data` de update, resolvendo { increment: n }. */
+function applyData(row: any, data: any) {
+  for (const [k, v] of Object.entries<any>(data)) {
+    if (v && typeof v === 'object' && 'increment' in v) row[k] = (row[k] ?? 0) + v.increment
+    else row[k] = v
+  }
+}
+
+function makeModel(store: any[], defaults: (d: any) => any) {
+  return {
+    async create({ data }: any) {
+      const row = { id: nextId('r'), createdAt: new Date(), updatedAt: new Date(), ...defaults(data), ...data }
+      store.push(row)
+      return { ...row }
+    },
+    async createMany({ data }: any) {
+      const rows = Array.isArray(data) ? data : [data]
+      for (const d of rows) store.push({ id: nextId('r'), createdAt: new Date(), updatedAt: new Date(), ...defaults(d), ...d })
+      return { count: rows.length }
+    },
+    async findUnique({ where }: any) {
+      return store.find((r) => matchWhere(r, where)) ?? null
+    },
+    async findFirst({ where }: any) {
+      return store.find((r) => matchWhere(r, where)) ?? null
+    },
+    async findMany({ where }: any) {
+      return store.filter((r) => matchWhere(r, where)).map((r) => ({ ...r }))
+    },
+    async count({ where }: any) {
+      return store.filter((r) => matchWhere(r, where)).length
+    },
+    async update({ where, data }: any) {
+      const row = store.find((r) => matchWhere(r, where))
+      if (row) applyData(row, data)
+      return row
+    },
+    async updateMany({ where, data }: any) {
+      const rows = store.filter((r) => matchWhere(r, where))
+      rows.forEach((r) => applyData(r, data))
+      return { count: rows.length }
+    },
+    async upsert({ where, create, update }: any) {
+      const row = store.find((r) => matchWhere(r, where))
+      if (row) { applyData(row, update); return row }
+      const created = { id: nextId('r'), createdAt: new Date(), ...create }
+      store.push(created)
+      return created
+    },
+    async deleteMany({ where }: any) {
+      let count = 0
+      for (let i = store.length - 1; i >= 0; i--) {
+        if (matchWhere(store[i], where)) { store.splice(i, 1); count++ }
+      }
+      return { count }
+    },
+  }
+}
+
+export function makeMockPrisma() {
+  const db = {
+    waCampaign: [] as any[],
+    waCampaignRecipient: [] as any[],
+    waOptOut: [] as any[],
+    waProspectResult: [] as any[],
+    lead: [] as any[],
+  }
+
+  const prisma: any = {
+    __db: db,
+    waCampaign: makeModel(db.waCampaign, () => ({
+      status: 'DRAFT', riskScore: 0, riskLevel: 'low', riskFactors: [], requiresApproval: false,
+      totalRecipients: 0, totalSent: 0, totalDelivered: 0, totalReplied: 0, totalFailed: 0, totalOptOut: 0,
+      templateName: null, templateLang: 'pt_BR', variables: {},
+    })),
+    waCampaignRecipient: makeModel(db.waCampaignRecipient, () => ({ status: 'PENDING', valid: false, variables: {} })),
+    waOptOut: makeModel(db.waOptOut, () => ({ reason: 'keyword' })),
+    waProspectResult: makeModel(db.waProspectResult, () => ({ status: 'PENDING_REVIEW' })),
+    lead: makeModel(db.lead, () => ({ status: 'NEW' })),
+  }
+  return prisma
+}

--- a/apps/api/test/wa-optout.test.ts
+++ b/apps/api/test/wa-optout.test.ts
@@ -1,0 +1,62 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isOptOutMessage,
+  isOptedOut,
+  addOptOut,
+  getOptedOutSet,
+  handleInboundReply,
+} from '../src/services/wa-campaigns/wa-optout.service.js'
+import { makeMockPrisma } from './wa-mock-prisma.js'
+
+test('detecta palavras-chave de descadastro', () => {
+  assert.equal(isOptOutMessage('SAIR'), true)
+  assert.equal(isOptOutMessage('parar'), true)
+  assert.equal(isOptOutMessage('Quero cancelar por favor'), true)
+  assert.equal(isOptOutMessage('STOP'), true)
+})
+
+test('não trata mensagem comum como descadastro', () => {
+  assert.equal(isOptOutMessage('Tenho interesse no imóvel'), false)
+  assert.equal(isOptOutMessage('quando posso visitar?'), false)
+})
+
+test('addOptOut + isOptedOut são idempotentes e consultáveis', async () => {
+  const prisma = makeMockPrisma()
+  await addOptOut(prisma, { companyId: 'c1', phoneE164: '+5511912345678', reason: 'manual' })
+  await addOptOut(prisma, { companyId: 'c1', phoneE164: '+5511912345678' }) // idempotente
+  assert.equal(prisma.__db.waOptOut.length, 1)
+  assert.equal(await isOptedOut(prisma, 'c1', '+5511912345678'), true)
+  assert.equal(await isOptedOut(prisma, 'c1', '+5511900000000'), false)
+  const set = await getOptedOutSet(prisma, 'c1', ['+5511912345678', '+5511900000000'])
+  assert.deepEqual([...set], ['+5511912345678'])
+})
+
+test('handleInboundReply com SAIR registra opt-out e marca UNSUBSCRIBED', async () => {
+  const prisma = makeMockPrisma()
+  await prisma.waCampaign.create({ data: { id: 'camp1', companyId: 'c1', name: 'X', messageBody: 'oi', createdById: 'u1' } })
+  await prisma.waCampaignRecipient.create({
+    data: { id: 'rec1', campaignId: 'camp1', companyId: 'c1', rawPhone: '11912345678', phoneE164: '+5511912345678', valid: true, status: 'DELIVERED' },
+  })
+
+  const res = await handleInboundReply(prisma, { companyId: 'c1', phone: '11912345678', text: 'SAIR' })
+  assert.equal(res.optedOut, true)
+  assert.equal(prisma.__db.waOptOut.length, 1)
+  const rec = prisma.__db.waCampaignRecipient.find((r: any) => r.id === 'rec1')
+  assert.equal(rec.status, 'UNSUBSCRIBED')
+})
+
+test('handleInboundReply com resposta comum abre atendimento (Lead) e marca REPLIED', async () => {
+  const prisma = makeMockPrisma()
+  await prisma.waCampaign.create({ data: { id: 'camp2', companyId: 'c1', name: 'X', messageBody: 'oi', createdById: 'u1' } })
+  await prisma.waCampaignRecipient.create({
+    data: { id: 'rec2', campaignId: 'camp2', companyId: 'c1', name: 'Ana', rawPhone: '11912345678', phoneE164: '+5511912345678', valid: true, status: 'DELIVERED' },
+  })
+
+  const res = await handleInboundReply(prisma, { companyId: 'c1', phone: '11912345678', text: 'Tenho interesse!' })
+  assert.equal(res.optedOut, false)
+  assert.ok(res.leadId, 'deve criar/achar um lead')
+  assert.equal(prisma.__db.lead.length, 1)
+  const rec = prisma.__db.waCampaignRecipient.find((r: any) => r.id === 'rec2')
+  assert.equal(rec.status, 'REPLIED')
+})

--- a/apps/api/test/wa-phone.test.ts
+++ b/apps/api/test/wa-phone.test.ts
@@ -1,0 +1,56 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  normalizePhoneBR,
+  parsePhoneList,
+  normalizeAndDedupe,
+} from '../src/services/wa-campaigns/phone.util.js'
+
+test('normaliza celular com DDD e máscara para E.164', () => {
+  assert.equal(normalizePhoneBR('(11) 91234-5678').e164, '+5511912345678')
+  assert.equal(normalizePhoneBR('11912345678').e164, '+5511912345678')
+  assert.equal(normalizePhoneBR('+55 11 91234-5678').e164, '+5511912345678')
+  assert.equal(normalizePhoneBR('5511912345678').e164, '+5511912345678')
+  assert.equal(normalizePhoneBR('011 91234-5678').e164, '+5511912345678')
+})
+
+test('insere o nono dígito em celular antigo de 8 dígitos', () => {
+  const n = normalizePhoneBR('11 8123-4567') // 8 dígitos → recebe o nono
+  assert.equal(n.valid, true)
+  assert.equal(n.e164, '+5511981234567')
+})
+
+test('rejeita telefone fixo (não entregável no WhatsApp)', () => {
+  const n = normalizePhoneBR('11 3234-5678')
+  assert.equal(n.valid, false)
+  assert.equal(n.reason, 'landline_not_whatsapp')
+})
+
+test('rejeita DDD inválido', () => {
+  const n = normalizePhoneBR('10 91234-5678')
+  assert.equal(n.valid, false)
+  assert.equal(n.reason, 'invalid_ddd')
+})
+
+test('rejeita muito curto e vazio', () => {
+  assert.equal(normalizePhoneBR('12345').reason, 'too_short')
+  assert.equal(normalizePhoneBR('').reason, 'empty')
+})
+
+test('parsePhoneList separa por linha, vírgula e ponto e vírgula', () => {
+  const list = parsePhoneList('11912345678\n11987654321, 21912345678; 11955554444')
+  assert.equal(list.length, 4)
+})
+
+test('normalizeAndDedupe remove duplicados e separa inválidos', () => {
+  const report = normalizeAndDedupe([
+    '11912345678',
+    '(11) 91234-5678', // duplicado do primeiro
+    '11 3234-5678',    // fixo → inválido
+    '21987654321',
+    'lixo',            // inválido
+  ])
+  assert.equal(report.valid.length, 2)
+  assert.equal(report.duplicates.length, 1)
+  assert.equal(report.invalid.length, 2)
+})

--- a/apps/api/test/wa-queue.test.ts
+++ b/apps/api/test/wa-queue.test.ts
@@ -1,0 +1,88 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createCampaign,
+  addRecipients,
+  dispatchCampaign,
+  processRecipient,
+} from '../src/services/wa-campaigns/wa-campaigns.service.js'
+import { makeMockPrisma } from './wa-mock-prisma.js'
+
+/** Fila fake que apenas coleta os jobs adicionados. */
+function makeMockQueue() {
+  const jobs: any[] = []
+  return { jobs, add: async (name: string, data: any) => { jobs.push({ name, data }); return { id: `j${jobs.length}` } } }
+}
+
+test('dispatch com fila enfileira um job por destinatário e marca QUEUED', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'X', messageBody: 'Olá {{nome}}' })
+  await addRecipients(prisma, {
+    campaignId: c.id, companyId: 'c1',
+    entries: [
+      { raw: '11912345678', name: 'Ana' },
+      { raw: '21987654321', name: 'Bia' },
+    ],
+  })
+
+  const queue = makeMockQueue()
+  const res = await dispatchCampaign(prisma, queue as any, { companyId: 'c1', campaignId: c.id })
+
+  assert.equal(res.mode, 'queue')
+  assert.equal(res.simulated, true, 'MVP: provider simulado')
+  assert.equal(res.enqueued, 2)
+  assert.equal(queue.jobs.length, 2)
+  const recs = prisma.__db.waCampaignRecipient.filter((r: any) => r.valid)
+  assert.ok(recs.every((r: any) => r.status === 'QUEUED'))
+})
+
+test('dispatch inline (sem fila) envia via provider simulado → DELIVERED e campanha SENT', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'X', messageBody: 'Olá {{nome}}' })
+  await addRecipients(prisma, {
+    campaignId: c.id, companyId: 'c1',
+    entries: [{ raw: '11912345678', name: 'Ana' }, { raw: '21987654321', name: 'Bia' }],
+  })
+
+  const res = await dispatchCampaign(prisma, null, { companyId: 'c1', campaignId: c.id })
+  assert.equal(res.mode, 'inline')
+  assert.equal(res.enqueued, 2)
+
+  const recs = prisma.__db.waCampaignRecipient.filter((r: any) => r.valid)
+  assert.ok(recs.every((r: any) => r.status === 'DELIVERED'), 'todos entregues (simulado)')
+  assert.ok(recs.every((r: any) => r.providerMessageId?.startsWith('sim_')), 'id simulado')
+
+  const camp = prisma.__db.waCampaign.find((x: any) => x.id === c.id)
+  assert.equal(camp.status, 'SENT')
+  assert.equal(camp.totalSent, 2)
+  assert.equal(camp.totalDelivered, 2)
+})
+
+test('exige aprovação humana antes de disparar quando risco pede', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'X', messageBody: 'Olá' })
+  // Força a flag de aprovação (simula risco médio/alto já calculado).
+  await prisma.waCampaign.update({ where: { id: c.id }, data: { requiresApproval: true } })
+  await addRecipients(prisma, { campaignId: c.id, companyId: 'c1', entries: [{ raw: '11912345678' }] })
+  // addRecipients recomputa risco; garante de novo a trava para o teste.
+  await prisma.waCampaign.update({ where: { id: c.id }, data: { requiresApproval: true } })
+
+  await assert.rejects(
+    () => dispatchCampaign(prisma, null, { companyId: 'c1', campaignId: c.id }),
+    /APPROVAL_REQUIRED/,
+  )
+})
+
+test('processRecipient bloqueia envio se o número virou opt-out após a fila', async () => {
+  const prisma = makeMockPrisma()
+  const c = await createCampaign(prisma, { companyId: 'c1', createdById: 'u1', name: 'X', messageBody: 'Olá' })
+  await addRecipients(prisma, { campaignId: c.id, companyId: 'c1', entries: [{ raw: '11912345678', name: 'Ana' }] })
+  const rec = prisma.__db.waCampaignRecipient.find((r: any) => r.valid)
+
+  // Opt-out chega depois de enfileirar.
+  await prisma.waOptOut.create({ data: { companyId: 'c1', phoneE164: '+5511912345678' } })
+  await processRecipient(prisma, rec.id)
+
+  const after = prisma.__db.waCampaignRecipient.find((r: any) => r.id === rec.id)
+  assert.equal(after.status, 'UNSUBSCRIBED')
+})

--- a/apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/[id]/page.tsx
@@ -1,0 +1,295 @@
+'use client'
+
+import { useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/auth.store'
+import { waCampaignsApi } from '@/lib/api'
+import {
+  ArrowLeft, Users, Send, Shield, AlertTriangle, CheckCircle, XCircle,
+  Loader2, Upload, Search, Trash2, Ban,
+} from 'lucide-react'
+
+const RISK_CFG: Record<string, { label: string; cls: string }> = {
+  low:    { label: 'Baixo', cls: 'text-green-700 bg-green-50 border-green-200' },
+  medium: { label: 'Médio', cls: 'text-amber-700 bg-amber-50 border-amber-200' },
+  high:   { label: 'Alto',  cls: 'text-red-700 bg-red-50 border-red-200' },
+}
+
+const STATUS_CFG: Record<string, string> = {
+  PENDING: 'bg-gray-100 text-gray-600', QUEUED: 'bg-indigo-100 text-indigo-700',
+  SENT: 'bg-blue-100 text-blue-700', DELIVERED: 'bg-green-100 text-green-700',
+  READ: 'bg-green-100 text-green-700', REPLIED: 'bg-emerald-100 text-emerald-700',
+  FAILED: 'bg-red-100 text-red-700', UNSUBSCRIBED: 'bg-orange-100 text-orange-700',
+  SKIPPED: 'bg-gray-100 text-gray-400',
+}
+
+const CONSENT_LABEL: Record<string, string> = {
+  consent: 'Consentimento', legitimate_interest: 'Legítimo interesse',
+  contract: 'Contrato', existing_customer: 'Cliente existente',
+}
+
+export default function WaCampaignDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const token = useAuthStore((s) => s.accessToken)
+  const qc = useQueryClient()
+
+  const [rawList, setRawList] = useState('')
+  const [source, setSource] = useState('import')
+  const [consentBasis, setConsentBasis] = useState('consent')
+  const [sourceRef, setSourceRef] = useState('')
+  const [researchQuery, setResearchQuery] = useState('')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['wa-campaign', id],
+    queryFn: () => waCampaignsApi.get(token!, id),
+    enabled: !!token && !!id,
+  })
+
+  const { data: prospectsData } = useQuery({
+    queryKey: ['wa-prospects', id],
+    queryFn: () => waCampaignsApi.listProspects(token!, id),
+    enabled: !!token && !!id,
+  })
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['wa-campaign', id] })
+    qc.invalidateQueries({ queryKey: ['wa-prospects', id] })
+  }
+
+  const addMutation = useMutation({
+    mutationFn: () => waCampaignsApi.addRecipients(token!, id, { rawList, source, consentBasis, sourceRef: sourceRef || undefined }),
+    onSuccess: (res) => { setRawList(''); setLastReport(res.data.report); invalidate() },
+  })
+  const [lastReport, setLastReport] = useState<any>(null)
+
+  const approveMutation = useMutation({ mutationFn: () => waCampaignsApi.approve(token!, id), onSuccess: invalidate })
+  const dispatchMutation = useMutation({ mutationFn: () => waCampaignsApi.dispatch(token!, id), onSuccess: invalidate })
+  const riskMutation = useMutation({ mutationFn: () => waCampaignsApi.recomputeRisk(token!, id), onSuccess: invalidate })
+  const removeMutation = useMutation({ mutationFn: (rid: string) => waCampaignsApi.removeRecipient(token!, id, rid), onSuccess: invalidate })
+  const researchMutation = useMutation({
+    mutationFn: () => waCampaignsApi.research(token!, id, { query: researchQuery }),
+    onSuccess: () => { setResearchQuery(''); invalidate() },
+  })
+  const reviewMutation = useMutation({
+    mutationFn: (args: { pid: string; action: 'approve' | 'reject'; phone?: string }) =>
+      waCampaignsApi.reviewProspect(token!, args.pid, { action: args.action, phone: args.phone }),
+    onSuccess: invalidate,
+  })
+  const importMutation = useMutation({ mutationFn: () => waCampaignsApi.importProspects(token!, id), onSuccess: invalidate })
+
+  if (isLoading || !data?.data) {
+    return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-gray-400" /></div>
+  }
+
+  const c = data.data
+  const risk = RISK_CFG[c.riskLevel] ?? RISK_CFG.low
+  const recipients: any[] = c.recipients ?? []
+  const prospects: any[] = prospectsData?.data ?? []
+  const canDispatch = !['SENT', 'SENDING', 'QUEUED', 'CANCELLED'].includes(c.status)
+  const blockedByApproval = c.requiresApproval && c.status !== 'APPROVED'
+
+  return (
+    <div className="p-4 sm:p-6 space-y-5 max-w-5xl">
+      <Link href="/dashboard/marketing/wa-campanhas" className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700">
+        <ArrowLeft className="h-4 w-4" /> Campanhas
+      </Link>
+
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{c.name}</h1>
+          <p className="text-sm text-gray-500">{c.empreendimento || 'Sem empreendimento vinculado'} · Status: <strong>{c.status}</strong></p>
+        </div>
+        <div className="flex gap-2">
+          {blockedByApproval && (
+            <button onClick={() => approveMutation.mutate()} disabled={approveMutation.isPending}
+              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+              <Shield className="h-4 w-4" /> Aprovar
+            </button>
+          )}
+          <button onClick={() => dispatchMutation.mutate()} disabled={!canDispatch || blockedByApproval || dispatchMutation.isPending}
+            className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50">
+            {dispatchMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            Disparar (simulado)
+          </button>
+        </div>
+      </div>
+
+      {dispatchMutation.data && (
+        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+          Disparo enfileirado: {dispatchMutation.data.data.enqueued} destinatário(s), modo <strong>{dispatchMutation.data.data.mode}</strong>
+          {dispatchMutation.data.data.simulated ? ' — SIMULADO (nenhuma mensagem real enviada).' : '.'}
+        </div>
+      )}
+
+      {/* Métricas + risco */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Metric label="Destinatários" value={c.totalRecipients} icon={Users} />
+        <Metric label="Enviados" value={c.totalSent} icon={Send} />
+        <Metric label="Entregues" value={c.totalDelivered} icon={CheckCircle} />
+        <Metric label="Descadastros" value={c.totalOptOut} icon={Ban} />
+      </div>
+
+      <div className={`rounded-xl border p-4 ${risk.cls}`}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 font-semibold">
+            <AlertTriangle className="h-4 w-4" /> Risco {risk.label} · score {c.riskScore}/100
+            {c.requiresApproval && <span className="text-xs font-normal">(requer aprovação humana)</span>}
+          </div>
+          <button onClick={() => riskMutation.mutate()} className="text-xs underline">recalcular</button>
+        </div>
+        {Array.isArray(c.riskFactors) && c.riskFactors.length > 0 && (
+          <ul className="mt-2 space-y-1 text-xs">
+            {c.riskFactors.map((f: any, i: number) => (
+              <li key={i}>• {f.label} (+{f.weight})</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Adicionar destinatários */}
+      <section className="rounded-xl border border-gray-200 bg-white p-4">
+        <h2 className="font-semibold text-gray-900 flex items-center gap-2 mb-3"><Upload className="h-4 w-4" /> Adicionar contatos</h2>
+        <textarea
+          value={rawList}
+          onChange={(e) => setRawList(e.target.value)}
+          rows={4}
+          placeholder="Cole os telefones — um por linha ou separados por vírgula. Ex.: (11) 91234-5678"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-base"
+        />
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <label className="text-sm">
+            <span className="text-gray-600">Origem do contato</span>
+            <input value={source} onChange={(e) => setSource(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base" placeholder="manual / import / crm" />
+          </label>
+          <label className="text-sm">
+            <span className="text-gray-600">Base de uso (LGPD)</span>
+            <select value={consentBasis} onChange={(e) => setConsentBasis(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base">
+              <option value="consent">Consentimento</option>
+              <option value="legitimate_interest">Legítimo interesse</option>
+              <option value="contract">Contrato</option>
+              <option value="existing_customer">Cliente existente</option>
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="text-gray-600">Fonte / referência</span>
+            <input value={sourceRef} onChange={(e) => setSourceRef(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base" placeholder="planilha, formulário, evento..." />
+          </label>
+        </div>
+        <button onClick={() => addMutation.mutate()} disabled={!rawList.trim() || addMutation.isPending}
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-black disabled:opacity-50">
+          {addMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+          Validar e adicionar
+        </button>
+
+        {lastReport && (
+          <div className="mt-3 rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-700">
+            <strong>{lastReport.added}</strong> adicionados ·{' '}
+            <strong>{lastReport.invalid}</strong> inválidos ·{' '}
+            <strong>{lastReport.duplicatesInBatch + lastReport.duplicatesExisting}</strong> duplicados ·{' '}
+            <strong>{lastReport.blockedOptOut}</strong> bloqueados por opt-out
+          </div>
+        )}
+      </section>
+
+      {/* Agente de prospecção */}
+      <section className="rounded-xl border border-gray-200 bg-white p-4">
+        <h2 className="font-semibold text-gray-900 flex items-center gap-2 mb-1"><Search className="h-4 w-4" /> Agente de prospecção (contatos comerciais públicos)</h2>
+        <p className="text-xs text-gray-500 mb-3">Resultados simulados. Toda lista exige fonte e aprovação humana antes de virar destinatário.</p>
+        <div className="flex gap-2">
+          <input value={researchQuery} onChange={(e) => setResearchQuery(e.target.value)}
+            placeholder="Ex.: construtoras em Curitiba"
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-base" />
+          <button onClick={() => researchMutation.mutate()} disabled={researchQuery.length < 2 || researchMutation.isPending}
+            className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-50">
+            {researchMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+            Pesquisar
+          </button>
+        </div>
+        {prospects.length > 0 && (
+          <div className="mt-3 space-y-2">
+            {prospects.map((p) => (
+              <div key={p.id} className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <div className="min-w-0">
+                  <div className="font-medium text-gray-800">{p.name} <span className="text-xs text-gray-400">· {p.status}</span></div>
+                  <div className="text-xs text-gray-500 truncate">{p.phone || 'sem telefone'} · fonte: {p.sourceRef}</div>
+                </div>
+                {p.status === 'PENDING_REVIEW' && (
+                  <div className="flex items-center gap-2 shrink-0">
+                    <input placeholder="telefone" id={`ph-${p.id}`} className="w-32 rounded border border-gray-300 px-2 py-1 text-xs" />
+                    <button
+                      onClick={() => {
+                        const el = document.getElementById(`ph-${p.id}`) as HTMLInputElement
+                        reviewMutation.mutate({ pid: p.id, action: 'approve', phone: el?.value || undefined })
+                      }}
+                      className="rounded bg-green-600 px-2 py-1 text-xs text-white">Aprovar</button>
+                    <button onClick={() => reviewMutation.mutate({ pid: p.id, action: 'reject' })}
+                      className="rounded bg-gray-200 px-2 py-1 text-xs">Rejeitar</button>
+                  </div>
+                )}
+              </div>
+            ))}
+            <button onClick={() => importMutation.mutate()} disabled={importMutation.isPending}
+              className="mt-1 inline-flex items-center gap-2 rounded-lg border border-purple-300 px-3 py-1.5 text-xs font-medium text-purple-700 hover:bg-purple-50">
+              Importar aprovados para a campanha
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Lista de destinatários */}
+      <section className="rounded-xl border border-gray-200 bg-white p-4">
+        <h2 className="font-semibold text-gray-900 mb-3">Destinatários ({recipients.length})</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-400 border-b">
+                <th className="py-2 pr-2">Telefone</th>
+                <th className="py-2 pr-2">Nome</th>
+                <th className="py-2 pr-2">Origem</th>
+                <th className="py-2 pr-2">Base LGPD</th>
+                <th className="py-2 pr-2">Status</th>
+                <th className="py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {recipients.map((r) => (
+                <tr key={r.id} className="border-b last:border-0">
+                  <td className="py-2 pr-2 font-mono text-xs">{r.phoneE164 || <span className="text-red-500">{r.rawPhone} ✕</span>}</td>
+                  <td className="py-2 pr-2">{r.name || '—'}</td>
+                  <td className="py-2 pr-2 text-xs">{r.source}</td>
+                  <td className="py-2 pr-2 text-xs">{CONSENT_LABEL[r.consentBasis] ?? r.consentBasis}</td>
+                  <td className="py-2 pr-2">
+                    <span className={`text-xs px-2 py-0.5 rounded-full ${STATUS_CFG[r.status] ?? 'bg-gray-100'}`}>{r.status}</span>
+                    {r.invalidReason && <span className="ml-1 text-xs text-red-400">{r.invalidReason}</span>}
+                  </td>
+                  <td className="py-2 text-right">
+                    <button onClick={() => removeMutation.mutate(r.id)} className="text-gray-300 hover:text-red-500">
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {recipients.length === 0 && (
+                <tr><td colSpan={6} className="py-6 text-center text-gray-400">Nenhum destinatário ainda.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: number; icon: any }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="flex items-center gap-1.5 text-xs text-gray-400"><Icon className="h-3.5 w-3.5" /> {label}</div>
+      <div className="mt-1 text-2xl font-bold text-gray-900">{value ?? 0}</div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/page.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/auth.store'
+import { waCampaignsApi } from '@/lib/api'
+import {
+  MessageCircle, Plus, X, Shield, AlertTriangle, CheckCircle,
+  Send, Users, Loader2, ChevronRight,
+} from 'lucide-react'
+
+const STATUS_LABEL: Record<string, { label: string; cls: string }> = {
+  DRAFT:            { label: 'Rascunho',        cls: 'bg-gray-100 text-gray-600' },
+  PENDING_APPROVAL: { label: 'Aguard. aprovação', cls: 'bg-amber-100 text-amber-700' },
+  APPROVED:         { label: 'Aprovada',        cls: 'bg-blue-100 text-blue-700' },
+  QUEUED:           { label: 'Na fila',         cls: 'bg-indigo-100 text-indigo-700' },
+  SENDING:          { label: 'Enviando',        cls: 'bg-indigo-100 text-indigo-700' },
+  SENT:             { label: 'Concluída',       cls: 'bg-green-100 text-green-700' },
+  CANCELLED:        { label: 'Cancelada',       cls: 'bg-gray-100 text-gray-500' },
+  FAILED:           { label: 'Falhou',          cls: 'bg-red-100 text-red-700' },
+}
+
+const RISK_CFG: Record<string, { label: string; cls: string }> = {
+  low:    { label: 'Baixo',  cls: 'text-green-700 bg-green-100' },
+  medium: { label: 'Médio',  cls: 'text-amber-700 bg-amber-100' },
+  high:   { label: 'Alto',   cls: 'text-red-700 bg-red-100' },
+}
+
+export default function WaCampaignsPage() {
+  const token = useAuthStore((s) => s.accessToken)
+  const qc = useQueryClient()
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState({ name: '', empreendimento: '', templateName: '', messageBody: '' })
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['wa-campaigns'],
+    queryFn: () => waCampaignsApi.list(token!),
+    enabled: !!token,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: () => waCampaignsApi.create(token!, {
+      name: form.name,
+      empreendimento: form.empreendimento || undefined,
+      templateName: form.templateName || undefined,
+      messageBody: form.messageBody,
+    }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['wa-campaigns'] })
+      setShowForm(false)
+      setForm({ name: '', empreendimento: '', templateName: '', messageBody: '' })
+    },
+  })
+
+  const campaigns = data?.data ?? []
+
+  return (
+    <div className="p-4 sm:p-6 space-y-5">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <MessageCircle className="h-6 w-6 text-green-600" />
+            Campanhas WhatsApp
+          </h1>
+          <p className="text-sm text-gray-500">
+            Disparo profissional de imóveis e lançamentos — com validação, LGPD, opt-out e aprovação humana.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+        >
+          <Plus className="h-4 w-4" /> Nova campanha
+        </button>
+      </div>
+
+      {/* Banner MVP */}
+      <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+        <Shield className="h-4 w-4 mt-0.5 shrink-0" />
+        <span>
+          <strong>Modo simulado (MVP):</strong> nenhuma mensagem real é enviada. A integração com o
+          WhatsApp Business Platform está isolada e só é ativada com <code>WA_CAMPAIGNS_LIVE=true</code>.
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12"><Loader2 className="h-6 w-6 animate-spin text-gray-400" /></div>
+      ) : campaigns.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 py-12 text-center text-gray-500">
+          Nenhuma campanha ainda. Crie a primeira.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {campaigns.map((c: any) => {
+            const st = STATUS_LABEL[c.status] ?? STATUS_LABEL.DRAFT
+            const risk = RISK_CFG[c.riskLevel] ?? RISK_CFG.low
+            return (
+              <Link
+                key={c.id}
+                href={`/dashboard/marketing/wa-campanhas/${c.id}`}
+                className="flex items-center justify-between rounded-xl border border-gray-200 bg-white p-4 hover:border-green-300 hover:shadow-sm transition"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-gray-900 truncate">{c.name}</span>
+                    <span className={`text-xs px-2 py-0.5 rounded-full ${st.cls}`}>{st.label}</span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                    <span className="inline-flex items-center gap-1"><Users className="h-3 w-3" /> {c.totalRecipients} destinatários</span>
+                    <span className="inline-flex items-center gap-1"><Send className="h-3 w-3" /> {c.totalSent} enviados</span>
+                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full ${risk.cls}`}>
+                      <AlertTriangle className="h-3 w-3" /> Risco {risk.label} ({c.riskScore})
+                    </span>
+                    {c.requiresApproval && c.status !== 'SENT' && (
+                      <span className="inline-flex items-center gap-1 text-amber-700">
+                        <Shield className="h-3 w-3" /> Requer aprovação
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <ChevronRight className="h-5 w-5 text-gray-300 shrink-0" />
+              </Link>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Modal de criação */}
+      {showForm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Nova campanha</h2>
+              <button onClick={() => setShowForm(false)}><X className="h-5 w-5 text-gray-400" /></button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label className="text-sm font-medium text-gray-700">Nome da campanha</label>
+                <input
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base"
+                  placeholder="Ex.: Lançamento Residencial Aurora"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-700">Imóvel / Empreendimento</label>
+                <input
+                  value={form.empreendimento}
+                  onChange={(e) => setForm({ ...form, empreendimento: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base"
+                  placeholder="Ex.: Residencial Aurora - Torre 1"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-700">Template aprovado (opcional)</label>
+                <input
+                  value={form.templateName}
+                  onChange={(e) => setForm({ ...form, templateName: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base"
+                  placeholder="nome_do_template_waba"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-700">Mensagem</label>
+                <textarea
+                  value={form.messageBody}
+                  onChange={(e) => setForm({ ...form, messageBody: e.target.value })}
+                  rows={4}
+                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-base"
+                  placeholder="Olá {{nome}}, temos uma oportunidade no {{imovel}}..."
+                />
+                <p className="mt-1 text-xs text-gray-400">Use {'{{nome}}'} e outras variáveis para personalizar.</p>
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button onClick={() => setShowForm(false)} className="rounded-lg px-4 py-2 text-sm text-gray-600 hover:bg-gray-100">Cancelar</button>
+              <button
+                onClick={() => createMutation.mutate()}
+                disabled={!form.name || !form.messageBody || createMutation.isPending}
+                className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+              >
+                {createMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
+                Criar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -85,6 +85,7 @@ const midNavItems = [
   { href: '/dashboard/api-keys',            icon: KeyRound,         label: 'Open API',      highlight: false },
   { href: '/dashboard/automations',         icon: Zap,              label: 'Automações',    highlight: false },
   { href: '/dashboard/marketing/campanhas', icon: Megaphone,        label: 'Campanhas',     highlight: false },
+  { href: '/dashboard/marketing/wa-campanhas', icon: MessageCircle, label: 'Campanhas WhatsApp', highlight: true },
   { href: '/dashboard/fiscal',              icon: FileText,         label: 'Notas Fiscais', highlight: false },
   { href: '/dashboard/crm/renovacoes',      icon: AlertTriangle,    label: 'Renovações',    highlight: false },
   { href: '/dashboard/blog',                icon: BookOpen,         label: 'Blog',          highlight: false },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1543,3 +1543,60 @@ export const outboundApi = {
   ingest: (token: string, data: { name: string; phone?: string; email?: string; source?: string; campaign?: string }) =>
     request<{ success: boolean; data: any }>('/api/v1/outbound/ingest', { method: 'POST', body: JSON.stringify(data), token }),
 }
+
+// ── WhatsApp Campaigns ────────────────────────────────────────────────────
+export const waCampaignsApi = {
+  list: (token: string, params?: { status?: string }) =>
+    request<{ success: boolean; data: any[] }>(`/api/v1/wa-campaigns?${toQS(params)}`, { token }),
+
+  get: (token: string, id: string) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/${id}`, { token }),
+
+  create: (token: string, body: {
+    name: string; propertyId?: string; empreendimento?: string;
+    templateName?: string; templateLang?: string; messageBody: string;
+    variables?: Record<string, unknown>; scheduledAt?: string;
+  }) =>
+    request<{ success: boolean; data: any }>('/api/v1/wa-campaigns', { method: 'POST', token, body: JSON.stringify(body) }),
+
+  addRecipients: (token: string, id: string, body: {
+    rawList?: string;
+    contacts?: { phone: string; name?: string; variables?: Record<string, unknown> }[];
+    source?: string; consentBasis?: string; sourceRef?: string;
+  }) =>
+    request<{ success: boolean; data: { report: any; campaign: any } }>(
+      `/api/v1/wa-campaigns/${id}/recipients`, { method: 'POST', token, body: JSON.stringify(body) }),
+
+  removeRecipient: (token: string, id: string, rid: string) =>
+    request<{ success: boolean }>(`/api/v1/wa-campaigns/${id}/recipients/${rid}`, { method: 'DELETE', token }),
+
+  recomputeRisk: (token: string, id: string) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/${id}/risk`, { method: 'POST', token }),
+
+  approve: (token: string, id: string) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/${id}/approve`, { method: 'POST', token }),
+
+  dispatch: (token: string, id: string) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/${id}/dispatch`, { method: 'POST', token }),
+
+  cancel: (token: string, id: string) =>
+    request<{ success: boolean }>(`/api/v1/wa-campaigns/${id}/cancel`, { method: 'POST', token }),
+
+  listOptOut: (token: string) =>
+    request<{ success: boolean; data: any[] }>('/api/v1/wa-campaigns/optout', { token }),
+
+  addOptOut: (token: string, phone: string, reason?: string) =>
+    request<{ success: boolean; data: any }>('/api/v1/wa-campaigns/optout', { method: 'POST', token, body: JSON.stringify({ phone, reason }) }),
+
+  research: (token: string, id: string, body: { query: string; city?: string; category?: string; limit?: number }) =>
+    request<{ success: boolean; data: any[]; notice: string }>(`/api/v1/wa-campaigns/${id}/prospect/research`, { method: 'POST', token, body: JSON.stringify(body) }),
+
+  listProspects: (token: string, id: string, params?: { status?: string }) =>
+    request<{ success: boolean; data: any[] }>(`/api/v1/wa-campaigns/${id}/prospect?${toQS(params)}`, { token }),
+
+  reviewProspect: (token: string, pid: string, body: { action: 'approve' | 'reject'; phone?: string; sourceRef?: string; notes?: string }) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/prospect/${pid}/review`, { method: 'POST', token, body: JSON.stringify(body) }),
+
+  importProspects: (token: string, id: string) =>
+    request<{ success: boolean; data: any }>(`/api/v1/wa-campaigns/${id}/prospect/import`, { method: 'POST', token }),
+}

--- a/docs/WHATSAPP_CAMPANHAS.md
+++ b/docs/WHATSAPP_CAMPANHAS.md
@@ -1,0 +1,117 @@
+# Módulo de Campanhas por WhatsApp (MVP)
+
+Disparo profissional de campanhas de imóveis, lançamentos e oportunidades para
+listas de contatos, com validação de telefone, controle LGPD, opt-out, cálculo
+de risco, aprovação humana e fila de envio.
+
+> **MVP = envio SIMULADO.** Nenhuma mensagem real é enviada. A integração com o
+> WhatsApp Business Platform está isolada atrás de um _provider_ e só é ativada
+> conscientemente via variável de ambiente. **Não há automação de navegador /
+> WhatsApp Web** — apenas API oficial ou provedor autorizado.
+
+---
+
+## Onde o módulo vive
+
+Multi-tenant, escopo por `companyId` (mesmo padrão de `OutboundMessage`/`SalesFunnel`).
+
+| Camada | Arquivos |
+|--------|----------|
+| Schema | `packages/database/prisma/schema.prisma` → `WaCampaign`, `WaCampaignRecipient`, `WaOptOut`, `WaProspectResult` |
+| Serviços | `apps/api/src/services/wa-campaigns/` (`phone.util`, `wa-optout.service`, `wa-risk.service`, `wa-provider`, `wa-campaigns.service`, `wa-prospect.service`) |
+| Worker/Fila | `apps/api/src/workers/wa-campaign.worker.ts` + fila `wa-campaigns` em `apps/api/src/plugins/automation.ts` |
+| Rotas | `apps/api/src/routes/wa-campaigns/index.ts` → prefixo `/api/v1/wa-campaigns` |
+| Web | `apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/` (lista + detalhe) + `waCampaignsApi` em `apps/web/src/lib/api.ts` |
+| Testes | `apps/api/test/wa-*.test.ts` |
+
+---
+
+## Fluxo
+
+1. **Criar campanha** → `POST /api/v1/wa-campaigns` (nome, imóvel/empreendimento, mensagem, template opcional).
+2. **Colar/importar lista** → `POST /:id/recipients`. O serviço:
+   - normaliza telefones para E.164 (`+55DDDNUMERO`), corrige celular antigo de 8 dígitos;
+   - rejeita fixos, DDD inválido, formatos ruins;
+   - remove **duplicados** (no lote e contra a campanha);
+   - **bloqueia opt-out** (registro por empresa);
+   - grava **origem** (`source`) e **base LGPD** (`consentBasis`) por contato.
+3. **Risco** é recalculado automaticamente (`POST /:id/risk` para forçar). Fatores: tamanho da lista, % de inválidos, fragilidade LGPD, prospecção, ausência de template, links.
+4. **Aprovação humana** (`POST /:id/approve`, perfil gestor/admin) é **obrigatória** quando o risco é médio/alto (`requiresApproval`).
+5. **Disparo** → `POST /:id/dispatch`. Enfileira um job por destinatário na fila `wa-campaigns` (ou processa inline sem Redis). No MVP o _provider_ é **simulado**.
+6. **Status por destinatário**: `PENDING → QUEUED → SENT → DELIVERED → READ → REPLIED`, além de `FAILED`, `UNSUBSCRIBED`, `SKIPPED`.
+7. **Respostas** → `POST /:id/../webhook/inbound` (`/api/v1/wa-campaigns/webhook/inbound`): detecta **SAIR/PARAR** (registra opt-out + `UNSUBSCRIBED`) ou abre **atendimento no CRM** (cria/atualiza `Lead`).
+8. **Agente de prospecção** → `POST /:id/prospect/research`: gera candidatos comerciais públicos **SIMULADOS**, sempre em `PENDING_REVIEW`. Exige **fonte** e **revisão humana** (`POST /prospect/:pid/review`) antes de `POST /:id/prospect/import`.
+
+---
+
+## O que ficou simulado (MVP)
+
+- **Envio**: `SimulatedProvider` (`wa-provider.ts`) — retorna id `sim_...` e marca `DELIVERED`, sem chamar a Meta.
+- **Webhook de entrega/leitura real**: no simulado, `DELIVERED` é setado direto; `READ` viria do webhook real.
+- **Agente de prospecção**: `runResearch()` devolve exemplos determinísticos **sem inventar telefones**; a fonte real (ex.: Google Places, diretórios públicos de CNPJ) é plugada substituindo essa função.
+
+Tudo o mais é real: modelo de dados, validação, dedupe, opt-out, risco, aprovação, fila e status.
+
+---
+
+## Variáveis de ambiente
+
+Já existentes (reaproveitadas para o envio real):
+
+| Var | Uso |
+|-----|-----|
+| `WHATSAPP_TOKEN` | Token da WhatsApp Cloud API |
+| `WHATSAPP_PHONE_ID` | Phone Number ID (WABA) |
+| `WHATSAPP_VERIFY_TOKEN` | Verificação do webhook de inbound |
+| `WHATSAPP_BUSINESS_ID` | ID da conta WhatsApp Business |
+| `REDIS_URL` | Fila `wa-campaigns` (BullMQ). Sem Redis → processamento inline |
+
+Novas (introduzidas por este módulo, em `apps/api/src/utils/env.ts`):
+
+| Var | Default | Uso |
+|-----|---------|-----|
+| `WA_CAMPAIGNS_PROVIDER` | `simulated` | `simulated` \| `cloud_api` \| `provider` |
+| `WA_CAMPAIGNS_LIVE` | `false` | **Trava de segurança.** Só envia mensagem REAL quando `true`. Enquanto `false`, tudo é simulado mesmo com credenciais presentes |
+| `WHATSAPP_TEMPLATE_NAMESPACE` | — | Namespace dos templates aprovados na Meta |
+
+Credenciais por tenant também são resolvidas via `getIntegrationConfig(prisma, companyId, 'whatsapp')` (tabela `IntegrationCredential`), com fallback para as env vars.
+
+---
+
+## Como testar
+
+```bash
+# Testes unitários do módulo (telefone, opt-out, criação de campanha, fila)
+pnpm --filter @agoraencontrei/api exec tsx --test \
+  test/wa-phone.test.ts test/wa-optout.test.ts test/wa-campaign.test.ts test/wa-queue.test.ts
+```
+
+Manual (API rodando, com JWT de usuário staff):
+
+```bash
+# 1) criar campanha
+curl -X POST localhost:3100/api/v1/wa-campaigns -H "Authorization: Bearer $T" -H 'Content-Type: application/json' \
+  -d '{"name":"Lançamento Aurora","empreendimento":"Res. Aurora","messageBody":"Olá {{nome}}!"}'
+
+# 2) colar lista
+curl -X POST localhost:3100/api/v1/wa-campaigns/$ID/recipients -H "Authorization: Bearer $T" -H 'Content-Type: application/json' \
+  -d '{"rawList":"11912345678\n(11) 91234-5678\n11 3234-5678","source":"import","consentBasis":"consent"}'
+
+# 3) aprovar (se risco exigir) e disparar (SIMULADO)
+curl -X POST localhost:3100/api/v1/wa-campaigns/$ID/approve  -H "Authorization: Bearer $T"
+curl -X POST localhost:3100/api/v1/wa-campaigns/$ID/dispatch -H "Authorization: Bearer $T"
+```
+
+No painel: **Marketing → Campanhas WhatsApp**.
+
+---
+
+## Próximos passos para ligar o WhatsApp Business API
+
+1. **Aplicar a migração** do schema em produção: `pnpm db:migrate` (dev) ou `prisma migrate deploy` (as tabelas `wa_*` foram adicionadas). Em dev rápido, `pnpm db:push`.
+2. **Credenciais**: configurar `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID` (ou por tenant em Integrações).
+3. **Templates**: cadastrar e aprovar os _message templates_ na Meta e usar `templateName` na campanha (envio em massa exige template aprovado — política da Meta).
+4. **Ligar o provider real**: `WA_CAMPAIGNS_LIVE=true`. O `getWaProvider()` passa a devolver `CloudApiProvider`, que já reutiliza `whatsappService.sendTemplate/sendText`.
+5. **Webhook de status/inbound**: apontar o webhook da Meta para o handler de inbound e mapear os _delivery/read receipts_ para atualizar `sentAt/deliveredAt/readAt` e status dos `WaCampaignRecipient`.
+6. **Rate limiting real**: reaproveitar a lógica de janela horária/rotação de `outbound-queue.service.ts` para respeitar os limites de tier da conta WABA.
+7. **Provedor parceiro** (alternativa à Meta direta): implementar uma nova classe `WhatsAppCampaignProvider` e selecioná-la por `WA_CAMPAIGNS_PROVIDER`.

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3904,3 +3904,157 @@ model PropertyVisit {
   @@index([status])
   @@map("property_visits")
 }
+
+// =============================================================================
+// WHATSAPP CAMPAIGNS MODULE (MVP)
+// Disparo profissional de campanhas de imóveis/empreendimentos para listas de
+// contatos, com validação de telefone, controle LGPD, opt-out, cálculo de
+// risco, aprovação humana e fila de envio via WhatsApp Business Platform.
+//
+// Regras: nenhum envio real no MVP (provider "simulated"); toda a integração
+// oficial fica isolada atrás de WhatsAppCampaignProvider. Todo contato carrega
+// origem (source) e base de uso (consentBasis, LGPD). Todo disparo respeita o
+// registro de opt-out (SAIR/PARAR). Escopo multi-tenant por companyId (scalar
+// indexado, sem back-relation — mesmo padrão de OutboundMessage/SalesFunnel).
+// =============================================================================
+
+/// Campanha de WhatsApp — agrupa lista de destinatários, modelo de mensagem,
+/// risco calculado e estado de aprovação/envio.
+model WaCampaign {
+  id            String   @id @default(cuid())
+  companyId     String
+  createdById   String
+  name          String
+  /// Imóvel divulgado (scalar, sem relation para manter o módulo isolado)
+  propertyId    String?
+  /// Empreendimento/lançamento em texto livre, quando não há imóvel cadastrado
+  empreendimento String?
+  /// Modelo de mensagem aprovado (nome do template WABA) — obrigatório em produção
+  templateName  String?
+  templateLang  String   @default("pt_BR")
+  /// Corpo da mensagem com placeholders {{nome}}, {{imovel}}, {{link}} etc.
+  messageBody   String   @db.Text
+  /// Variáveis padrão da campanha (ex.: link, preco) aplicadas a todos
+  variables     Json     @default("{}")
+  /// DRAFT | PENDING_APPROVAL | APPROVED | QUEUED | SENDING | SENT | CANCELLED | FAILED
+  status        String   @default("DRAFT")
+  /// simulated | cloud_api | provider
+  provider      String   @default("simulated")
+  /// 0-100 — quanto maior, mais arriscada (spam/LGPD)
+  riskScore     Int      @default(0)
+  /// low | medium | high
+  riskLevel     String   @default("low")
+  riskFactors   Json     @default("[]")
+  /// Aprovação humana obrigatória quando risco medium/high
+  requiresApproval Boolean @default(false)
+  approvedById  String?
+  approvedAt    DateTime?
+  scheduledAt   DateTime?
+  startedAt     DateTime?
+  completedAt   DateTime?
+  totalRecipients Int    @default(0)
+  totalSent     Int      @default(0)
+  totalDelivered Int     @default(0)
+  totalReplied  Int      @default(0)
+  totalFailed   Int      @default(0)
+  totalOptOut   Int      @default(0)
+  metadata      Json     @default("{}")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  recipients    WaCampaignRecipient[]
+
+  @@index([companyId])
+  @@index([status])
+  @@index([createdAt])
+  @@map("wa_campaigns")
+}
+
+/// Destinatário individual de uma campanha. Guarda telefone normalizado (E.164),
+/// origem e base LGPD, status de envio e ids do provedor.
+model WaCampaignRecipient {
+  id            String     @id @default(cuid())
+  campaignId    String
+  campaign      WaCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  companyId     String
+  name          String?
+  /// Telefone como foi colado/importado (auditoria)
+  rawPhone      String
+  /// Telefone normalizado E.164 (+55DDDNUMERO). null se inválido.
+  phoneE164     String?
+  valid         Boolean    @default(false)
+  invalidReason String?
+  /// Origem do contato: manual | import | crm | prospect_agent | portal ...
+  source        String     @default("import")
+  /// Base de uso LGPD: consent | legitimate_interest | contract | existing_customer
+  consentBasis  String     @default("consent")
+  /// Referência da fonte (URL/planilha/descrição) — obrigatório p/ prospecção
+  sourceRef     String?
+  /// PENDING | QUEUED | SENT | DELIVERED | READ | REPLIED | FAILED | UNSUBSCRIBED | SKIPPED
+  status        String     @default("PENDING")
+  variables     Json       @default("{}")
+  providerMessageId String?
+  errorMessage  String?
+  queuedAt      DateTime?
+  sentAt        DateTime?
+  deliveredAt   DateTime?
+  repliedAt     DateTime?
+  metadata      Json       @default("{}")
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+
+  @@unique([campaignId, phoneE164])
+  @@index([campaignId])
+  @@index([companyId])
+  @@index([phoneE164])
+  @@index([status])
+  @@map("wa_campaign_recipients")
+}
+
+/// Registro de opt-out por empresa. Bloqueia qualquer disparo futuro para o
+/// número. Alimentado por palavras-chave (SAIR/PARAR), reclamação ou ação manual.
+model WaOptOut {
+  id         String   @id @default(cuid())
+  companyId  String
+  phoneE164  String
+  /// keyword | manual | complaint | bounce
+  reason     String   @default("keyword")
+  source     String?
+  createdAt  DateTime @default(now())
+
+  @@unique([companyId, phoneE164])
+  @@index([companyId])
+  @@index([phoneE164])
+  @@map("wa_optouts")
+}
+
+/// Resultado do agente de pesquisa de empresas/contatos comerciais públicos.
+/// SEMPRE entra como PENDING_REVIEW: exige revisão humana e uma fonte antes de
+/// poder ser adicionado a uma campanha. Não coleta dados pessoais sensíveis.
+model WaProspectResult {
+  id           String   @id @default(cuid())
+  companyId    String
+  campaignId   String?
+  /// Nome comercial/empresa (dado público)
+  name         String
+  phone        String?
+  phoneE164    String?
+  category     String?
+  city         String?
+  /// Fonte pública obrigatória (URL/descrição de onde veio)
+  sourceRef    String
+  sourceUrl    String?
+  /// PENDING_REVIEW | APPROVED | REJECTED | IMPORTED
+  status       String   @default("PENDING_REVIEW")
+  reviewedById String?
+  reviewedAt   DateTime?
+  notes        String?
+  metadata     Json     @default("{}")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([companyId])
+  @@index([campaignId])
+  @@index([status])
+  @@map("wa_prospect_results")
+}


### PR DESCRIPTION
## Resumo

Novo módulo **tenant-facing** (escopo por `companyId`) para disparo profissional de campanhas de imóveis, lançamentos e oportunidades para listas de contatos — com validação de telefone, controle LGPD, opt-out, cálculo de risco, aprovação humana e fila de envio.

> **MVP = envio SIMULADO.** Nenhuma mensagem real é enviada. A integração com o WhatsApp Business Platform está isolada atrás de um _provider_ e só é ativada com `WA_CAMPAIGNS_LIVE=true`. **Não há automação de navegador / WhatsApp Web** — apenas API oficial ou provedor autorizado.

## Funcionalidades

- Criar campanha (imóvel/empreendimento, mensagem, template opcional)
- Colar/importar lista → **normaliza para E.164**, corrige 9º dígito, rejeita fixo/DDD inválido
- **Remove duplicados** (no lote e contra a campanha)
- **Bloqueia opt-out** (registro por empresa)
- Registra **origem** (`source`) e **base LGPD** (`consentBasis`) por contato
- **Cálculo de risco** (tamanho, % inválidos, fragilidade LGPD, prospecção, template, links)
- **Aprovação humana obrigatória** quando risco médio/alto
- **Fila de envio** dedicada (`wa-campaigns`, BullMQ) com fallback inline sem Redis
- Status por destinatário: `PENDING → QUEUED → SENT → DELIVERED → READ → REPLIED`, além de `FAILED`, `UNSUBSCRIBED`, `SKIPPED`
- **Captura de respostas**: SAIR/PARAR → opt-out; resposta comum → abre atendimento (Lead) no CRM
- **Agente de prospecção** de contatos comerciais públicos, sempre com **fonte + revisão humana** antes do envio

## Arquivos principais

| Camada | Arquivos |
|--------|----------|
| Schema | `packages/database/prisma/schema.prisma` → `WaCampaign`, `WaCampaignRecipient`, `WaOptOut`, `WaProspectResult` |
| Serviços | `apps/api/src/services/wa-campaigns/` (`phone.util`, `wa-optout.service`, `wa-risk.service`, `wa-provider`, `wa-campaigns.service`, `wa-prospect.service`) |
| Fila/worker | `apps/api/src/workers/wa-campaign.worker.ts` + fila em `apps/api/src/plugins/automation.ts` |
| Rotas | `apps/api/src/routes/wa-campaigns/index.ts` → `/api/v1/wa-campaigns` (registrada em `server.ts`) |
| Web | `apps/web/src/app/(dashboard)/dashboard/marketing/wa-campanhas/` + `waCampaignsApi` em `lib/api.ts` + item na sidebar |
| Env | `apps/api/src/utils/env.ts`: `WA_CAMPAIGNS_PROVIDER`, `WA_CAMPAIGNS_LIVE`, `WHATSAPP_TEMPLATE_NAMESPACE` |
| Docs | `docs/WHATSAPP_CAMPANHAS.md` |

## Como testar

```bash
pnpm --filter @agoraencontrei/api exec tsx --test test/wa-*.test.ts
# 20 tests passed, 0 failed
```

Cobre: validação de telefone, opt-out, criação de campanha e fila de envio.

No painel: **Marketing → Campanhas WhatsApp**.

## O que ficou simulado

- **Envio**: `SimulatedProvider` retorna id `sim_...` e marca `DELIVERED`, sem chamar a Meta
- **Agente de prospecção**: gera exemplos determinísticos **sem inventar telefones** (fonte real é plugável)

Tudo o mais é real: modelo de dados, validação, dedupe, opt-out, risco, aprovação, fila e status.

## Próximos passos para ligar o WhatsApp Business API

1. Aplicar a migração/schema em produção (`prisma migrate deploy` ou `pnpm db:push`) — as tabelas `wa_*` já foram criadas no banco
2. Configurar `WHATSAPP_TOKEN` + `WHATSAPP_PHONE_ID` (ou por tenant em Integrações)
3. Cadastrar e aprovar _message templates_ na Meta e usar `templateName`
4. `WA_CAMPAIGNS_LIVE=true` → `getWaProvider()` passa a usar `CloudApiProvider`
5. Apontar o webhook da Meta para o handler de inbound (delivery/read receipts + SAIR)
6. Aplicar rate-limiting real reaproveitando `outbound-queue.service.ts`

## Notas

- Typecheck da API: os únicos erros são **pré-existentes** (padrão `new Queue(..., { connection })` do bullmq e módulo `tomas-knowledge`) — zero nos arquivos novos.
- Telefones **fixos** são marcados como inválidos (WhatsApp só entrega para móveis); ajuste simples em `phone.util.ts` caso queira aceitá-los.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CibiNZP3HsFBcFgpT7T1JK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CibiNZP3HsFBcFgpT7T1JK)_