### PR TITLE
[codex] add partner SEO and featured ranking

### DIFF
--- a/apps/api/src/routes/specialists/index.ts
+++ b/apps/api/src/routes/specialists/index.ts
@@ -21,7 +21,34 @@ const categoryLabels: Record<string, string> = {
   VIDEOMAKER: 'Videomaker',
   ADVOGADO_IMOBILIARIO: 'Advogado(a) Imobiliário',
   DESPACHANTE: 'Despachante',
+  IMOBILIARIA: 'Imobiliaria',
+  LOTEADORA: 'Loteadora',
   OUTRO: 'Outro',
+}
+
+function specialistVisibilityRank(s: any) {
+  const now = Date.now()
+  const featuredUntil = s.featuredUntil ? new Date(s.featuredUntil).getTime() : null
+  const activeFeatured = !!s.isFeatured && (!featuredUntil || featuredUntil >= now)
+  const planRank: Record<string, number> = { VIP: 0, PREMIUM: 1, PRIME: 2, PROFISSIONAL: 3, ESSENCIAL: 4, START: 5 }
+  const commercialPlan = s.adPlan || s.plan || ''
+  return [
+    activeFeatured ? 0 : 1,
+    -(Number(s.featuredWeight ?? 0)),
+    planRank[commercialPlan] ?? 6,
+    s.name || '',
+  ] as const
+}
+
+function sortSpecialistsForVisibility(list: any[]) {
+  return [...list].sort((a, b) => {
+    const ar = specialistVisibilityRank(a)
+    const br = specialistVisibilityRank(b)
+    if (ar[0] !== br[0]) return ar[0] - br[0]
+    if (ar[1] !== br[1]) return ar[1] - br[1]
+    if (ar[2] !== br[2]) return ar[2] - br[2]
+    return String(ar[3]).localeCompare(String(br[3]), 'pt-BR')
+  })
 }
 
 export default async function specialistsRoute(app: FastifyInstance) {
@@ -122,7 +149,7 @@ export default async function specialistsRoute(app: FastifyInstance) {
       ])
 
       return reply.send({
-        data: specialists.map((s: any) => ({
+        data: sortSpecialistsForVisibility(specialists).map((s: any) => ({
           ...s,
           categoryLabel: categoryLabels[s.category] || s.category,
           profileUrl: `https://www.agoraencontrei.com.br/especialistas/${s.slug}`,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -296,6 +296,11 @@ async function runMigrations(prisma: any) {
       crea TEXT, instagram TEXT, website TEXT, "photoUrl" TEXT,
       status TEXT NOT NULL DEFAULT 'PENDING',
       tags TEXT[] NOT NULL DEFAULT '{}',
+      "logoUrl" TEXT,
+      address TEXT,
+      "businessType" TEXT,
+      "landingPage" JSONB,
+      "adPlan" TEXT,
       "welcomeEmailSentAt" TIMESTAMPTZ,
       "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -319,12 +324,21 @@ async function runMigrations(prisma: any) {
       UNIQUE("specialistId", "buildingId")
     )`,
     `CREATE INDEX IF NOT EXISTS specialists_status_idx ON specialists(status)`,
+    // Campos do produto "Divulgue seu Negocio" (landing page editavel).
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "logoUrl" TEXT`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS address TEXT`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "businessType" TEXT`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "landingPage" JSONB`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "adPlan" TEXT`,
     // Campos de pagamento (idempotentes)
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS cpfcnpj TEXT`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'START'`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "planStatus" TEXT DEFAULT 'FREE'`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "planActivatedAt" TIMESTAMP`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "planExpiresAt" TIMESTAMP`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "isFeatured" BOOLEAN NOT NULL DEFAULT false`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "featuredUntil" TIMESTAMP`,
+    `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "featuredWeight" INTEGER NOT NULL DEFAULT 0`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "asaasCustomerId" TEXT`,
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "asaasSubscriptionId" TEXT`,
     // Magic-link de acesso ao painel do especialista (login sem senha).
@@ -332,6 +346,7 @@ async function runMigrations(prisma: any) {
     `ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "accessTokenSentAt" TIMESTAMP`,
     `CREATE UNIQUE INDEX IF NOT EXISTS specialists_access_token_key ON specialists("accessToken")`,
     `CREATE INDEX IF NOT EXISTS specialists_plan_idx ON specialists(plan)`,
+    `CREATE INDEX IF NOT EXISTS specialists_featured_idx ON specialists("isFeatured", "featuredUntil", "featuredWeight")`,
     `CREATE INDEX IF NOT EXISTS specialists_category_idx ON specialists(category)`,
     `CREATE INDEX IF NOT EXISTS buildings_city_idx ON buildings(city, state)`,
   ]

--- a/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
@@ -1,0 +1,324 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import {
+  PARTNER_CATEGORY_SEO,
+  PARTNER_CITY_SEO,
+  getPartnerCategoryBySlug,
+  getPartnerCityBySlug,
+  partnerSeoPath,
+} from '@/lib/partner-seo'
+
+export const revalidate = 300
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL ?? 'https://www.agoraencontrei.com.br'
+
+interface Specialist {
+  id: string
+  slug: string
+  name: string
+  category: string
+  categoryLabel?: string
+  city?: string | null
+  state?: string | null
+  bio?: string | null
+  photoUrl?: string | null
+  logoUrl?: string | null
+  whatsapp?: string | null
+  phone?: string | null
+  plan?: string | null
+  adPlan?: string | null
+  isFeatured?: boolean | null
+  featuredUntil?: string | null
+  featuredWeight?: number | null
+  tags?: string[] | null
+  landingPage?: { segmentLabel?: string } | null
+}
+
+function waHref(s: Specialist): string | null {
+  const raw = s.whatsapp || s.phone
+  if (!raw) return null
+  const d = raw.replace(/\D/g, '')
+  if (d.length < 10) return null
+  return `https://wa.me/${d.startsWith('55') ? d : '55' + d}?text=${encodeURIComponent(`Ola ${s.name}, encontrei seu perfil no AgoraEncontrei e gostaria de atendimento.`)}`
+}
+
+async function fetchSpecialists(city: string, category: string): Promise<Specialist[]> {
+  try {
+    const qs = new URLSearchParams({ limit: '80', city, category })
+    const res = await fetch(`${API_URL}/api/v1/specialists?${qs.toString()}`, { next: { revalidate: 300 } })
+    if (!res.ok) return []
+    const json = await res.json()
+    const list: Specialist[] = Array.isArray(json?.data) ? json.data : []
+    const rank: Record<string, number> = { VIP: 0, PREMIUM: 1, PRIME: 2, PROFISSIONAL: 3, ESSENCIAL: 4, START: 5 }
+    const now = Date.now()
+    return list.sort((a, b) => {
+      const aUntil = a.featuredUntil ? new Date(a.featuredUntil).getTime() : null
+      const bUntil = b.featuredUntil ? new Date(b.featuredUntil).getTime() : null
+      const aFeatured = !!a.isFeatured && (!aUntil || aUntil >= now)
+      const bFeatured = !!b.isFeatured && (!bUntil || bUntil >= now)
+      if (aFeatured !== bFeatured) return aFeatured ? -1 : 1
+      const featuredWeight = Number(b.featuredWeight ?? 0) - Number(a.featuredWeight ?? 0)
+      if (featuredWeight !== 0) return featuredWeight
+      const aPlan = a.adPlan || a.plan || ''
+      const bPlan = b.adPlan || b.plan || ''
+      const planRank = (rank[aPlan] ?? 6) - (rank[bPlan] ?? 6)
+      if (planRank !== 0) return planRank
+      return a.name.localeCompare(b.name, 'pt-BR')
+    })
+  } catch {
+    return []
+  }
+}
+
+export function generateStaticParams() {
+  return PARTNER_CITY_SEO.slice(0, 6).flatMap(city =>
+    PARTNER_CATEGORY_SEO.slice(0, 8).map(category => ({
+      cidade: city.slug,
+      categoria: category.slug,
+    }))
+  )
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ cidade: string; categoria: string }>
+}): Promise<Metadata> {
+  const { cidade, categoria } = await params
+  const city = getPartnerCityBySlug(cidade)
+  const cat = getPartnerCategoryBySlug(categoria)
+  if (!city || !cat) return { title: 'Empresas parceiras | AgoraEncontrei' }
+
+  const title = `${cat.label} em ${city.city}/${city.state} | Empresas Parceiras AgoraEncontrei`
+  const description = `${cat.description} Encontre ${cat.singular} em ${city.city}/${city.state} e receba atendimento pelo AgoraEncontrei.`
+  const canonical = `${WEB_URL}${partnerSeoPath(city.slug, cat.slug)}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'website',
+      siteName: 'AgoraEncontrei',
+    },
+  }
+}
+
+export default async function PartnerSeoPage({
+  params,
+}: {
+  params: Promise<{ cidade: string; categoria: string }>
+}) {
+  const { cidade, categoria } = await params
+  const city = getPartnerCityBySlug(cidade)
+  const cat = getPartnerCategoryBySlug(categoria)
+  if (!city || !cat) notFound()
+
+  const specialists = await fetchSpecialists(city.city, cat.value)
+
+  const itemListSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `${cat.label} em ${city.city}/${city.state}`,
+    itemListElement: specialists.map((s, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${WEB_URL}/especialistas/${s.slug}`,
+      name: s.name,
+    })),
+  }
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: `Como encontrar ${cat.singular} em ${city.city}/${city.state}?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: `Use o AgoraEncontrei para comparar empresas parceiras, ver especialidades e falar pelo WhatsApp com profissionais de ${cat.service} em ${city.city}/${city.state}.`,
+        },
+      },
+      {
+        '@type': 'Question',
+        name: `O AgoraEncontrei indica profissionais verificados?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'O diretorio destaca parceiros cadastrados, planos de divulgacao e perfis completos. Antes de contratar, confirme escopo, prazo, documentacao e referencias diretamente com o profissional.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: `Posso pedir atendimento online?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Sim. Muitas demandas podem comecar por briefing online, envio de fotos, medidas, documentos e conversa pelo WhatsApp.',
+        },
+      },
+    ],
+  }
+
+  return (
+    <main className="min-h-screen bg-[#f8f6f1]">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <section className="px-4 py-16 text-white" style={{ background: 'linear-gradient(135deg, #143A1F 0%, #0E2A15 100%)' }}>
+        <div className="mx-auto max-w-5xl">
+          <nav className="mb-6 flex flex-wrap items-center gap-2 text-xs text-white/60">
+            <Link href="/" className="hover:text-white">Inicio</Link>
+            <span>/</span>
+            <Link href="/empresas-parceiras" className="hover:text-white">Empresas parceiras</Link>
+            <span>/</span>
+            <span>{city.city}</span>
+            <span>/</span>
+            <span>{cat.label}</span>
+          </nav>
+          <p className="mb-3 text-xs font-bold uppercase tracking-[0.22em]" style={{ color: '#C9A84C' }}>
+            Profissionais parceiros em {city.region}
+          </p>
+          <h1 className="max-w-4xl text-4xl font-bold leading-tight md:text-5xl" style={{ fontFamily: 'Georgia, serif' }}>
+            {cat.label} em {city.city}/{city.state}
+          </h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-white/75">
+            Encontre empresas e profissionais para {cat.intent}. O AgoraEncontrei organiza parceiros,
+            contexto imobiliario e atendimento inteligente para conectar voce ao servico certo.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a
+              href={`https://wa.me/5516981010004?text=${encodeURIComponent(`Ola! Preciso de ${cat.service} em ${city.city}/${city.state}. Vim pelo AgoraEncontrei.`)}`}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-xl px-6 py-3 text-center text-sm font-bold text-[#143A1F]"
+              style={{ backgroundColor: '#C9A84C' }}
+            >
+              Pedir indicacao agora
+            </a>
+            <Link href="/parceiros/cadastro" className="rounded-xl border border-white/25 px-6 py-3 text-center text-sm font-bold text-white hover:bg-white/10">
+              Divulgar minha empresa
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6">
+        <div className="mb-8 grid gap-4 md:grid-cols-3">
+          {[
+            ['Busca com intencao', `Filtramos quem procura ${cat.service} por cidade, servico e momento de decisao.`],
+            ['Parceiros em destaque', 'Planos profissionais e destaques ativos aparecem com mais forca, sem esconder a lista completa.'],
+            ['Atendimento rastreavel', 'Links de WhatsApp e perfis ajudam a medir origem, demanda e conversao.'],
+          ].map(([title, text]) => (
+            <div key={title} className="rounded-2xl border border-[#C9A84C]/20 bg-white p-5">
+              <h2 className="text-sm font-bold text-[#143A1F]">{title}</h2>
+              <p className="mt-2 text-sm leading-6 text-gray-600">{text}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+              Empresas encontradas
+            </h2>
+            <p className="mt-1 text-sm text-gray-500">
+              {specialists.length} resultado{specialists.length === 1 ? '' : 's'} para {cat.service} em {city.city}/{city.state}
+            </p>
+          </div>
+          <Link href={`/empresas-parceiras?city=${encodeURIComponent(city.city)}&category=${cat.value}`} className="text-sm font-bold text-[#143A1F] hover:underline">
+            Abrir filtros avancados
+          </Link>
+        </div>
+
+        {specialists.length > 0 ? (
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {specialists.map(s => {
+              const wa = waHref(s)
+              const until = s.featuredUntil ? new Date(s.featuredUntil).getTime() : null
+              const activeFeatured = !!s.isFeatured && (!until || until >= Date.now())
+              const isFeatured = activeFeatured || s.plan === 'VIP' || s.plan === 'PRIME' || s.adPlan === 'PROFISSIONAL' || s.adPlan === 'PREMIUM'
+              const thumb = s.photoUrl || s.logoUrl || null
+              const segLabel = s.landingPage?.segmentLabel || s.categoryLabel || cat.label
+              return (
+                <article key={s.id} className={`rounded-2xl border bg-white p-6 text-center transition hover:shadow-lg ${isFeatured ? 'border-[#C9A84C] ring-1 ring-[#C9A84C]/30' : 'border-gray-100'}`}>
+                  {isFeatured && (
+                    <span className="mb-3 inline-flex rounded-full bg-[#C9A84C]/15 px-3 py-1 text-[10px] font-bold uppercase tracking-wide text-[#9A7A23]">
+                      Destaque {s.adPlan || s.plan || ''}
+                    </span>
+                  )}
+                  <div className="mx-auto mb-4 h-24 w-24 overflow-hidden rounded-full ring-2 ring-[#C9A84C]/30">
+                    {thumb ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={thumb} alt={s.name} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-[#143A1F]/5 text-2xl font-bold text-[#143A1F]">
+                        {(s.name || '?').slice(0, 2).toUpperCase()}
+                      </div>
+                    )}
+                  </div>
+                  <h3 className="text-base font-bold text-[#143A1F]">{s.name}</h3>
+                  <p className="mt-1 text-xs font-semibold text-[#C9A84C]">{segLabel}</p>
+                  {s.bio && <p className="mt-3 line-clamp-3 text-xs leading-5 text-gray-500">{s.bio}</p>}
+                  <div className="mt-5 flex gap-2">
+                    <Link href={`/especialistas/${s.slug}`} className="flex-1 rounded-lg bg-[#143A1F] px-3 py-2 text-xs font-bold text-white">
+                      Ver perfil
+                    </Link>
+                    {wa && (
+                      <a href={wa} target="_blank" rel="noreferrer" className="flex-1 rounded-lg bg-[#25D366] px-3 py-2 text-xs font-bold text-white">
+                        WhatsApp
+                      </a>
+                    )}
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="rounded-3xl border border-dashed border-[#C9A84C] bg-white p-10 text-center">
+            <h2 className="text-xl font-bold text-[#143A1F]">Seja o primeiro destaque nesta busca</h2>
+            <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
+              Ainda nao ha parceiros ativos para {cat.service} em {city.city}/{city.state}. O AgoraEncontrei ja deixou a pagina preparada
+              para capturar demanda organica e receber profissionais dessa categoria.
+            </p>
+            <Link href="/parceiros/cadastro" className="mt-6 inline-flex rounded-xl px-6 py-3 text-sm font-bold text-[#143A1F]" style={{ backgroundColor: '#C9A84C' }}>
+              Cadastrar minha empresa
+            </Link>
+          </div>
+        )}
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 pb-14 sm:px-6">
+        <div className="rounded-3xl bg-white p-8">
+          <h2 className="text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+            Mais buscas de empresas parceiras
+          </h2>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {PARTNER_CATEGORY_SEO.slice(0, 10).map(item => (
+              <Link
+                key={item.slug}
+                href={partnerSeoPath(city.slug, item.slug)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${item.slug === cat.slug ? 'border-[#143A1F] bg-[#143A1F] text-white' : 'border-gray-200 text-gray-700 hover:border-[#C9A84C]'}`}
+              >
+                {item.label} em {city.city}
+              </Link>
+            ))}
+            {PARTNER_CITY_SEO.slice(0, 6).map(item => (
+              <Link
+                key={item.slug}
+                href={partnerSeoPath(item.slug, cat.slug)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${item.slug === city.slug ? 'border-[#143A1F] bg-[#143A1F] text-white' : 'border-gray-200 text-gray-700 hover:border-[#C9A84C]'}`}
+              >
+                {cat.label} em {item.city}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/web/src/app/(public)/empresas-parceiras/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/page.tsx
@@ -8,6 +8,12 @@
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import {
+  PARTNER_CATEGORY_SEO,
+  PARTNER_CITY_SEO,
+  PARTNER_INTENT_PAGES,
+  partnerSeoPath,
+} from '@/lib/partner-seo'
 
 export const revalidate = 300
 
@@ -42,6 +48,9 @@ interface Specialist {
   phone?: string | null
   plan?: string | null
   adPlan?: string | null
+  isFeatured?: boolean | null
+  featuredUntil?: string | null
+  featuredWeight?: number | null
   tags?: string[] | null
   landingPage?: { segmentLabel?: string } | null
 }
@@ -56,9 +65,22 @@ async function fetchSpecialists(sp: Record<string, string>): Promise<Specialist[
     if (!res.ok) return []
     const json = await res.json()
     const list: Specialist[] = Array.isArray(json?.data) ? json.data : []
-    // Destaque primeiro: VIP > PRIME > START, e depois por nome.
-    const rank: Record<string, number> = { VIP: 0, PRIME: 1, START: 2 }
-    return list.sort((a, b) => (rank[a.plan ?? ''] ?? 3) - (rank[b.plan ?? ''] ?? 3))
+    const rank: Record<string, number> = { VIP: 0, PREMIUM: 1, PRIME: 2, PROFISSIONAL: 3, ESSENCIAL: 4, START: 5 }
+    const now = Date.now()
+    return list.sort((a, b) => {
+      const aUntil = a.featuredUntil ? new Date(a.featuredUntil).getTime() : null
+      const bUntil = b.featuredUntil ? new Date(b.featuredUntil).getTime() : null
+      const aFeatured = !!a.isFeatured && (!aUntil || aUntil >= now)
+      const bFeatured = !!b.isFeatured && (!bUntil || bUntil >= now)
+      if (aFeatured !== bFeatured) return aFeatured ? -1 : 1
+      const weight = Number(b.featuredWeight ?? 0) - Number(a.featuredWeight ?? 0)
+      if (weight !== 0) return weight
+      const aPlan = a.adPlan || a.plan || ''
+      const bPlan = b.adPlan || b.plan || ''
+      const plan = (rank[aPlan] ?? 6) - (rank[bPlan] ?? 6)
+      if (plan !== 0) return plan
+      return a.name.localeCompare(b.name, 'pt-BR')
+    })
   } catch {
     return []
   }
@@ -102,9 +124,26 @@ export default async function EmpresasParceirasPage({
 
   const specialists = await fetchSpecialists(sp)
   const activeCat = CATEGORIES.find(c => c.value === sp.category)
+  const directorySchema = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Empresas Parceiras do AgoraEncontrei',
+    description: 'Diretorio de profissionais e empresas parceiras para imoveis, arquitetura, engenharia, reformas, documentacao e marketing imobiliario.',
+    url: 'https://www.agoraencontrei.com.br/empresas-parceiras',
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: specialists.slice(0, 20).map((s, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: s.name,
+        url: `https://www.agoraencontrei.com.br/especialistas/${s.slug}`,
+      })),
+    },
+  }
 
   return (
     <main style={{ backgroundColor: '#f8f6f1' }} className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(directorySchema) }} />
       {/* Hero premium */}
       <section className="py-16 px-4 text-center text-white" style={{ background: 'linear-gradient(135deg, #143A1F 0%, #0E2A15 60%, #143A1F 100%)' }}>
         <div className="max-w-3xl mx-auto">
@@ -172,6 +211,44 @@ export default async function EmpresasParceirasPage({
           })}
         </div>
 
+        <section className="mb-10 grid gap-5 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-3xl bg-white p-6 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.2em]" style={{ color: '#C9A84C' }}>
+              Buscas mais fortes
+            </p>
+            <h2 className="mt-2 text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+              Encontre profissionais por cidade e profissao
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-gray-600">
+              O AgoraEncontrei organiza paginas locais para que arquitetos, engenheiros,
+              designers, avaliadores, imobiliarias e outras empresas parceiras aparecam
+              mais nas buscas e recebam clientes com intencao real.
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              {PARTNER_INTENT_PAGES.map(item => (
+                <Link key={item.href} href={item.href} className="rounded-2xl border border-gray-100 p-4 transition hover:border-[#C9A84C] hover:shadow-sm">
+                  <p className="text-sm font-bold text-[#143A1F]">{item.title}</p>
+                  <p className="mt-1 text-xs leading-5 text-gray-500">{item.description}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-3xl border border-[#C9A84C]/25 bg-[#143A1F] p-6 text-white shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.2em]" style={{ color: '#C9A84C' }}>
+              Vitrine inteligente
+            </p>
+            <h2 className="mt-2 text-2xl font-bold" style={{ fontFamily: 'Georgia, serif' }}>
+              Mais visibilidade para cada parceiro
+            </h2>
+            <ul className="mt-5 space-y-3 text-sm leading-6 text-white/75">
+              <li>Ranking com planos em destaque primeiro.</li>
+              <li>URLs limpas por cidade e categoria para SEO.</li>
+              <li>Perfis individuais com WhatsApp, tags e prova de especialidade.</li>
+              <li>Base pronta para Tomas IA qualificar demanda antes do contato.</li>
+            </ul>
+          </div>
+        </section>
+
         <p className="text-sm text-gray-500 mb-6">
           {specialists.length} empresa{specialists.length === 1 ? '' : 's'} parceira{specialists.length === 1 ? '' : 's'}
           {activeCat ? ` em ${activeCat.label}` : ''}{sp.city ? ` · ${sp.city}` : ''}
@@ -181,7 +258,9 @@ export default async function EmpresasParceirasPage({
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
             {specialists.map(s => {
               const wa = waHref(s)
-              const isFeatured = s.plan === 'VIP' || s.plan === 'PRIME' || s.adPlan === 'PROFISSIONAL' || s.adPlan === 'PREMIUM'
+              const until = s.featuredUntil ? new Date(s.featuredUntil).getTime() : null
+              const activeFeatured = !!s.isFeatured && (!until || until >= Date.now())
+              const isFeatured = activeFeatured || s.plan === 'VIP' || s.plan === 'PRIME' || s.adPlan === 'PROFISSIONAL' || s.adPlan === 'PREMIUM'
               const thumb = s.photoUrl || s.logoUrl || null
               const segLabel = s.landingPage?.segmentLabel || s.categoryLabel || s.category
               return (
@@ -251,6 +330,30 @@ export default async function EmpresasParceirasPage({
         )}
 
         {/* CTA final — anuncie sua empresa */}
+        <section className="mt-14 rounded-3xl bg-white p-6">
+          <h2 className="text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+            Paginas por cidade e categoria
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
+            Atalhos preparados para disputar buscas locais de alto valor, como arquiteto em Franca,
+            engenheiro em Ribeirao Preto, avaliador de imoveis e empresas para construir,
+            reformar, vender ou alugar melhor.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {PARTNER_CITY_SEO.slice(0, 6).flatMap(city =>
+              PARTNER_CATEGORY_SEO.slice(0, 4).map(category => (
+                <Link
+                  key={`${city.slug}-${category.slug}`}
+                  href={partnerSeoPath(city.slug, category.slug)}
+                  className="rounded-full border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:border-[#C9A84C] hover:text-[#143A1F]"
+                >
+                  {category.label} em {city.city}
+                </Link>
+              ))
+            )}
+          </div>
+        </section>
+
         <div className="mt-14 rounded-3xl p-8 sm:p-10 text-center" style={{ background: 'linear-gradient(135deg, #143A1F, #0E2A15)' }}>
           <h2 className="text-2xl font-bold text-white mb-2" style={{ fontFamily: 'Georgia, serif' }}>
             Sua empresa no maior marketplace imobiliário da região

--- a/apps/web/src/lib/partner-seo.ts
+++ b/apps/web/src/lib/partner-seo.ts
@@ -1,0 +1,165 @@
+export const PARTNER_CATEGORY_SEO = [
+  {
+    value: 'ARQUITETO',
+    slug: 'arquitetos',
+    singular: 'arquiteto',
+    label: 'Arquitetos',
+    service: 'arquitetura',
+    intent: 'projetar, construir, reformar e valorizar imoveis',
+    description: 'Arquitetos parceiros para projetos residenciais, interiores, reformas, fachadas e valorizacao imobiliaria.',
+  },
+  {
+    value: 'ENGENHEIRO',
+    slug: 'engenheiros',
+    singular: 'engenheiro civil',
+    label: 'Engenheiros',
+    service: 'engenharia civil',
+    intent: 'laudos, obras, regularizacao, calculos e execucao tecnica',
+    description: 'Engenheiros parceiros para obra, regularizacao, laudos, reformas, vistoria e construcao.',
+  },
+  {
+    value: 'DESIGNER_INTERIORES',
+    slug: 'designers-de-interiores',
+    singular: 'designer de interiores',
+    label: 'Designers de Interiores',
+    service: 'design de interiores',
+    intent: 'decorar, mobiliar, reformar ambientes e melhorar o uso dos espacos',
+    description: 'Designers de interiores para apartamentos, casas, areas gourmet, lojas e ambientes comerciais.',
+  },
+  {
+    value: 'AVALIADOR',
+    slug: 'avaliadores-de-imoveis',
+    singular: 'avaliador de imoveis',
+    label: 'Avaliadores de Imoveis',
+    service: 'avaliacao imobiliaria',
+    intent: 'precificar, vender, comprar, financiar ou negociar com seguranca',
+    description: 'Avaliadores para estimar valor de mercado, venda, locacao, inventario, financiamento e negociacao.',
+  },
+  {
+    value: 'ADVOGADO_IMOBILIARIO',
+    slug: 'advogados-imobiliarios',
+    singular: 'advogado imobiliario',
+    label: 'Advogados Imobiliarios',
+    service: 'direito imobiliario',
+    intent: 'contratos, regularizacao, compra, venda, locacao e seguranca juridica',
+    description: 'Advogados imobiliarios para contratos, due diligence, locacao, compra e venda, usucapiao e regularizacao.',
+  },
+  {
+    value: 'DESPACHANTE',
+    slug: 'despachantes-imobiliarios',
+    singular: 'despachante imobiliario',
+    label: 'Despachantes Imobiliarios',
+    service: 'documentacao imobiliaria',
+    intent: 'resolver documentos, certidoes, registros e regularizacoes',
+    description: 'Despachantes para documentacao, cartorio, certidoes, prefeitura, registro e regularizacao de imoveis.',
+  },
+  {
+    value: 'FOTOGRAFO',
+    slug: 'fotografos-imobiliarios',
+    singular: 'fotografo imobiliario',
+    label: 'Fotografos Imobiliarios',
+    service: 'fotografia imobiliaria',
+    intent: 'fotografar, anunciar e vender imoveis com mais impacto',
+    description: 'Fotografos para ensaios imobiliarios, fotos profissionais, tour visual e material para anuncios.',
+  },
+  {
+    value: 'VIDEOMAKER',
+    slug: 'videomakers-imobiliarios',
+    singular: 'videomaker imobiliario',
+    label: 'Videomakers Imobiliarios',
+    service: 'video imobiliario',
+    intent: 'criar videos, reels, tours e campanhas para imoveis',
+    description: 'Videomakers para videos de imoveis, reels, drone, tours, lancamentos e campanhas imobiliarias.',
+  },
+  {
+    value: 'IMOBILIARIA',
+    slug: 'imobiliarias',
+    singular: 'imobiliaria',
+    label: 'Imobiliarias',
+    service: 'intermediacao imobiliaria',
+    intent: 'comprar, vender, alugar, administrar ou anunciar imoveis',
+    description: 'Imobiliarias parceiras para compra, venda, locacao, administracao e captacao de imoveis.',
+  },
+  {
+    value: 'LOTEADORA',
+    slug: 'loteadoras',
+    singular: 'loteadora',
+    label: 'Loteadoras',
+    service: 'loteamentos e terrenos',
+    intent: 'encontrar terrenos, loteamentos, areas e oportunidades de desenvolvimento',
+    description: 'Loteadoras e empresas de terrenos para quem busca areas, lotes, lancamentos e oportunidades.',
+  },
+  {
+    value: 'OUTRO',
+    slug: 'servicos-para-imoveis',
+    singular: 'profissional para imoveis',
+    label: 'Servicos para Imoveis',
+    service: 'servicos imobiliarios',
+    intent: 'resolver necessidades do imovel com empresas parceiras',
+    description: 'Profissionais e empresas para obras, reformas, manutencao, regularizacao e servicos ligados ao imovel.',
+  },
+] as const
+
+export const PARTNER_CITY_SEO = [
+  { slug: 'franca-sp', city: 'Franca', state: 'SP', region: 'Franca e regiao' },
+  { slug: 'ribeirao-preto-sp', city: 'Ribeirao Preto', state: 'SP', region: 'Ribeirao Preto e regiao' },
+  { slug: 'batatais-sp', city: 'Batatais', state: 'SP', region: 'Batatais e regiao' },
+  { slug: 'cristais-paulista-sp', city: 'Cristais Paulista', state: 'SP', region: 'Cristais Paulista e regiao' },
+  { slug: 'restinga-sp', city: 'Restinga', state: 'SP', region: 'Restinga e regiao' },
+  { slug: 'itirapua-sp', city: 'Itirapua', state: 'SP', region: 'Itirapua e regiao' },
+  { slug: 'sao-paulo-sp', city: 'Sao Paulo', state: 'SP', region: 'Sao Paulo' },
+  { slug: 'campinas-sp', city: 'Campinas', state: 'SP', region: 'Campinas e regiao' },
+  { slug: 'belo-horizonte-mg', city: 'Belo Horizonte', state: 'MG', region: 'Belo Horizonte e regiao' },
+  { slug: 'curitiba-pr', city: 'Curitiba', state: 'PR', region: 'Curitiba e regiao' },
+] as const
+
+export type PartnerCategorySeo = (typeof PARTNER_CATEGORY_SEO)[number]
+export type PartnerCitySeo = (typeof PARTNER_CITY_SEO)[number]
+
+export function getPartnerCategoryBySlug(slug: string) {
+  return PARTNER_CATEGORY_SEO.find(c => c.slug === slug)
+}
+
+export function getPartnerCityBySlug(slug: string) {
+  return PARTNER_CITY_SEO.find(c => c.slug === slug)
+}
+
+export function partnerSeoPath(citySlug: string, categorySlug: string) {
+  return `/empresas-parceiras/${citySlug}/${categorySlug}`
+}
+
+export function partnerCategoryQuery(category: PartnerCategorySeo) {
+  return `/empresas-parceiras?category=${category.value}`
+}
+
+export function partnerCityQuery(city: PartnerCitySeo) {
+  return `/empresas-parceiras?city=${encodeURIComponent(city.city)}`
+}
+
+export const PARTNER_INTENT_PAGES = [
+  {
+    href: '/empresas-parceiras/franca-sp/arquitetos',
+    title: 'Arquitetos em Franca/SP',
+    description: 'Projetos, interiores, reformas e valorizacao imobiliaria.',
+  },
+  {
+    href: '/empresas-parceiras/franca-sp/engenheiros',
+    title: 'Engenheiros em Franca/SP',
+    description: 'Obras, regularizacao, laudos e execucao tecnica.',
+  },
+  {
+    href: '/empresas-parceiras/franca-sp/designers-de-interiores',
+    title: 'Design de interiores em Franca/SP',
+    description: 'Ambientes mais bonitos, funcionais e valorizados.',
+  },
+  {
+    href: '/empresas-parceiras/franca-sp/avaliadores-de-imoveis',
+    title: 'Avaliadores de imoveis',
+    description: 'Preco real para vender, comprar, financiar ou negociar.',
+  },
+  {
+    href: '/empresas-parceiras/franca-sp/fotografos-imobiliarios',
+    title: 'Fotografia imobiliaria',
+    description: 'Imagens profissionais para vender e alugar melhor.',
+  },
+] as const

--- a/apps/web/src/lib/sitemap-entries.ts
+++ b/apps/web/src/lib/sitemap-entries.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next'
+import { PARTNER_CATEGORY_SEO, PARTNER_CITY_SEO, partnerSeoPath } from '@/lib/partner-seo'
 
 /**
  * Fonte única de verdade das URLs do sitemap principal.
@@ -218,6 +219,7 @@ export function buildStaticEntries(): MetadataRoute.Sitemap {
     { url: `${WEB_URL}/imoveis`, lastModified: now, changeFrequency: 'hourly', priority: 0.95 },
     { url: `${WEB_URL}/leiloes`, lastModified: now, changeFrequency: 'hourly', priority: 0.95 },
     { url: `${WEB_URL}/profissionais/franca`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${WEB_URL}/empresas-parceiras`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
     { url: `${WEB_URL}/parceiros/cadastro`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${WEB_URL}/parceiros/membro-fundador`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${WEB_URL}/anunciar-imovel`, lastModified: now, changeFrequency: 'monthly', priority: 0.85 },
@@ -246,6 +248,15 @@ export function buildStaticEntries(): MetadataRoute.Sitemap {
   const servicos = SERVICOS.map(p => ({
     url: `${WEB_URL}${p}`, lastModified: now, changeFrequency: 'monthly' as const, priority: 0.75,
   }))
+
+  const empresasParceiras = PARTNER_CITY_SEO.flatMap(city =>
+    PARTNER_CATEGORY_SEO.map(category => ({
+      url: `${WEB_URL}${partnerSeoPath(city.slug, category.slug)}`,
+      lastModified: now,
+      changeFrequency: 'weekly' as const,
+      priority: city.slug === 'franca-sp' ? 0.88 : 0.72,
+    }))
+  )
 
   const cidades = CIDADES_REGIONAIS.map(c => ({
     url: `${WEB_URL}/imoveis-${c}-sp`, lastModified: now, changeFrequency: 'daily' as const, priority: 0.85,
@@ -413,6 +424,7 @@ export function buildStaticEntries(): MetadataRoute.Sitemap {
     ...landings,
     ...leilaoBairros,
     ...servicos,
+    ...empresasParceiras,
     ...capitais,
     ...cidades,
     ...bairros,

--- a/packages/database/prisma/migrations/20260706223000_specialist_featured_fields/migration.sql
+++ b/packages/database/prisma/migrations/20260706223000_specialist_featured_fields/migration.sql
@@ -1,0 +1,10 @@
+-- Destaque temporario para especialistas/parceiros.
+-- Suporta Fase 4/5: planos de destaque e ranking por validade, sem billing.
+
+ALTER TABLE "specialists"
+  ADD COLUMN IF NOT EXISTS "isFeatured" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "featuredUntil" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "featuredWeight" INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS "specialists_featured_idx"
+  ON "specialists"("isFeatured", "featuredUntil", "featuredWeight");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2572,6 +2572,9 @@ model Specialist {
   planStatus         String?            @default("FREE")
   planActivatedAt    DateTime?
   planExpiresAt      DateTime?
+  isFeatured         Boolean            @default(false)
+  featuredUntil      DateTime?
+  featuredWeight     Int                @default(0)
   asaasCustomerId    String?
   asaasSubscriptionId String?
 
@@ -2582,6 +2585,7 @@ model Specialist {
   @@index([category])
   @@index([city, state])
   @@index([plan])
+  @@index([isFeatured, featuredUntil])
   @@map("specialists")
 }
 

--- a/scripts/seed-niu-arquitetura.sql
+++ b/scripts/seed-niu-arquitetura.sql
@@ -1,57 +1,117 @@
 -- ============================================================================
 -- Seed: NIU Arquitetura como primeira Empresa Parceira (Specialist) do
--- AgoraEncontrei — categoria ARQUITETO, em destaque (plano VIP).
+-- AgoraEncontrei.
 --
--- ⚠️  REVISE ANTES DE RODAR:
---   - Só usa DADOS PÚBLICOS. NÃO inclui fotos do Instagram (direito autoral).
---     photoUrl fica NULL → o card mostra as iniciais até você subir uma imagem
---     autorizada pela NIU.
---   - Ajuste email, phone, whatsapp, city/state e bio com os dados REAIS/oficiais
---     da NIU antes de executar (os valores abaixo são placeholders seguros).
+-- Dados publicos extraidos do Instagram em 2026-07-06:
+--   @niu_arquitetura
+--   Estudio de Arquitetura e Design.
+--   +55 16 99264-6070 | +55 16 99463-0822
+--   contato@niuarquitetura.com
 --
--- Como rodar: cole no SQL editor do Neon (mesmo banco de produção) e execute.
--- É idempotente (ON CONFLICT) — pode rodar de novo depois de ajustar os campos.
+-- Nao inclui fotos do Instagram. Use apenas imagem autorizada pela NIU em
+-- photoUrl depois que eles enviarem o arquivo oficial.
+--
+-- Como rodar: cole no SQL editor do Neon e execute.
+-- Idempotente: pode rodar novamente depois de ajustar campos.
 -- ============================================================================
+
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "isFeatured" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "featuredUntil" TIMESTAMP;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "featuredWeight" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "logoUrl" TEXT;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS address TEXT;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "businessType" TEXT;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "landingPage" JSONB;
+ALTER TABLE specialists ADD COLUMN IF NOT EXISTS "adPlan" TEXT;
 
 INSERT INTO specialists (
   id, slug, name, email, phone, whatsapp,
-  category, bio, city, state, instagram, website, "photoUrl",
+  category, bio, city, state, instagram, website, "photoUrl", "logoUrl", address,
+  "businessType", "landingPage", "adPlan",
   status, tags, plan, "planStatus", "planActivatedAt",
+  "isFeatured", "featuredUntil", "featuredWeight",
   "createdAt", "updatedAt"
 ) VALUES (
-  'seed_niu_arquitetura',                       -- id fixo (idempotência)
-  'niu-arquitetura',                            -- slug → /especialistas/niu-arquitetura
+  'seed_niu_arquitetura',
+  'niu-arquitetura',
   'NIU Arquitetura',
-  'contato@niuarquitetura.com.br',              -- ⚠️ ajuste para o e-mail real
-  NULL,                                         -- ⚠️ telefone real (opcional)
-  NULL,                                         -- ⚠️ whatsapp real (opcional)
+  'contato@niuarquitetura.com',
+  '+55 16 99463-0822',
+  '+55 16 99264-6070',
   'ARQUITETO',
-  'Escritório de arquitetura especializado em projetos residenciais e comerciais, interiores e reformas. Parceiro do AgoraEncontrei.',
-  'Franca',                                     -- ⚠️ confirme a cidade real
-  'SP',                                         -- ⚠️ confirme o estado real
-  'niu_arquitetura',                            -- handle público do Instagram
-  NULL,                                         -- site oficial (opcional)
-  NULL,                                         -- photoUrl: placeholder (sem foto do IG)
+  'Estudio de Arquitetura e Design. Projetos residenciais, interiores, reformas e arquitetura contemporanea para construir, transformar e valorizar imoveis.',
+  'Franca',
+  'SP',
+  'niu_arquitetura',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  'arquitetura',
+  '{
+    "segmentLabel": "Arquitetura e Design",
+    "adPlan": "PREMIUM",
+    "template": "vitrine",
+    "heroTitle": "Projetos de arquitetura contemporanea para construir, reformar e valorizar imoveis",
+    "heroSubtitle": "Atendimento para projetos residenciais, interiores, reformas e arquitetura sob medida em Franca/SP e para todo o Brasil.",
+    "services": [
+      { "name": "Projeto arquitetonico residencial", "description": "Briefing, conceito, estudos e desenvolvimento do projeto para obra nova ou reforma.", "price": null },
+      { "name": "Interiores e ambientacao", "description": "Planejamento de ambientes, materiais, marcenaria, iluminacao e composicao visual.", "price": null },
+      { "name": "Reforma e valorizacao de imoveis", "description": "Solucoes para atualizar, adequar e valorizar casas, apartamentos e areas de lazer.", "price": null },
+      { "name": "Consultoria inicial online", "description": "Triagem do objetivo, medidas, fotos, prazo e orcamento para indicar o caminho de projeto.", "price": null }
+    ],
+    "gallery": [],
+    "videos": [],
+    "faq": [
+      { "question": "A NIU atende clientes fora de Franca/SP?", "answer": "O atendimento pode comecar online. Confirme escopo, cidade, prazos e formato diretamente com a equipe." },
+      { "question": "Quais informacoes ajudam no primeiro contato?", "answer": "Cidade, tipo de imovel, objetivo do projeto, fotos, medidas aproximadas, prazo desejado e faixa de investimento." }
+    ],
+    "source": "Instagram publico @niu_arquitetura, consultado em 2026-07-06"
+  }'::jsonb,
+  'PREMIUM',
   'ACTIVE',
-  ARRAY['Projetos Residenciais','Interiores','Reformas','Comercial'],
-  'VIP',                                        -- destaque na home e no topo do diretório
+  ARRAY[
+    'Arquitetura residencial',
+    'Interiores',
+    'Reformas',
+    'Alto padrao',
+    'Design contemporaneo',
+    'Projeto online',
+    'Franca SP',
+    'Brasil'
+  ],
+  'VIP',
   'ACTIVE',
   NOW(),
+  true,
+  NOW() + INTERVAL '180 days',
+  100,
   NOW(),
   NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
-  name        = EXCLUDED.name,
-  category    = EXCLUDED.category,
-  bio         = EXCLUDED.bio,
-  city        = EXCLUDED.city,
-  state       = EXCLUDED.state,
-  instagram   = EXCLUDED.instagram,
-  status      = EXCLUDED.status,
-  tags        = EXCLUDED.tags,
-  plan        = EXCLUDED.plan,
-  "planStatus"= EXCLUDED."planStatus",
+  name = EXCLUDED.name,
+  email = EXCLUDED.email,
+  phone = EXCLUDED.phone,
+  whatsapp = EXCLUDED.whatsapp,
+  category = EXCLUDED.category,
+  bio = EXCLUDED.bio,
+  city = EXCLUDED.city,
+  state = EXCLUDED.state,
+  instagram = EXCLUDED.instagram,
+  "businessType" = EXCLUDED."businessType",
+  "landingPage" = EXCLUDED."landingPage",
+  "adPlan" = EXCLUDED."adPlan",
+  status = EXCLUDED.status,
+  tags = EXCLUDED.tags,
+  plan = EXCLUDED.plan,
+  "planStatus" = EXCLUDED."planStatus",
+  "isFeatured" = EXCLUDED."isFeatured",
+  "featuredUntil" = EXCLUDED."featuredUntil",
+  "featuredWeight" = EXCLUDED."featuredWeight",
   "updatedAt" = NOW();
 
 -- Verificar:
--- SELECT slug, name, category, city, status, plan FROM specialists WHERE slug = 'niu-arquitetura';
+-- SELECT slug, name, category, city, status, plan, "isFeatured", "featuredUntil"
+-- FROM specialists
+-- WHERE slug = 'niu-arquitetura';


### PR DESCRIPTION
## O que muda

- Adiciona rotas SEO `/empresas-parceiras/[cidade]/[categoria]` para buscas locais por profissão e cidade.
- Enriquece `/empresas-parceiras` com schema, links internos, atalhos de intenção e ranking consistente.
- Cria `partner-seo.ts` como catálogo de categorias/cidades para páginas e sitemap.
- Adiciona campos de destaque em `Specialist`: `isFeatured`, `featuredUntil`, `featuredWeight`.
- Alinha o ranking da API com os planos novos do Claude (`adPlan`: ESSENCIAL, PROFISSIONAL, PREMIUM) e os planos existentes (`START`, `PRIME`, `VIP`).
- Atualiza o seed da NIU com dados públicos confirmados, campos `landingPage`, `businessType`, `adPlan` e destaque temporário.

## Por que

O `main` já recebeu os PRs do Claude com o produto de divulgação, cadastro, landing individual e planos pagos. Este PR complementa essa base sem cruzar informações: usa os novos campos de anúncio e mantém o destaque/ranking em uma camada separada e idempotente.

## Validação

- `git diff --cached --check` passou antes do commit.
- Checagem de marcadores de conflito retornou limpa.
- Typecheck não executou até o código porque o ambiente não tem `typescript/tsc` disponível nos `node_modules` e o Node local está em v24.14.1 enquanto o projeto pede Node 22.x.

## Observação

O seed não inclui fotos do Instagram; mantém `photoUrl/logoUrl` nulos até a NIU autorizar imagens oficiais.