### PR TITLE
Ensure Tomas knowledge package builds before apps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
+    "prebuild": "pnpm --filter @agoraencontrei/tomas-knowledge build",
     "build": "tsc --project tsconfig.build.json || true",
     "verify:boot": "node scripts/verify-route-imports.mjs",
     "start": "node dist/server.js",
+    "pretypecheck": "pnpm --filter @agoraencontrei/tomas-knowledge build",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "lint": "eslint src --ext .ts"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,9 +5,11 @@
   "packageManager": "pnpm@10.6.0",
   "scripts": {
     "dev": "next dev -p 3000",
+    "prebuild": "pnpm --filter @agoraencontrei/tomas-knowledge build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "pretypecheck": "pnpm --filter @agoraencontrei/tomas-knowledge build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Builds `@agoraencontrei/tomas-knowledge` automatically before web build/typecheck.
- Builds the same package automatically before API build/typecheck.
- Keeps generated `dist` out of git and lets workspace scripts generate it when needed.

## Validation
- `pnpm.cmd --filter @agoraencontrei/tomas-knowledge build` passes.
- `pnpm.cmd --filter './apps/web' build` now compiles successfully past the previous missing-module point; local build later stops during static generation with `ENOSPC: no space left on device`.
- `git diff --check` passes.

## Notes
- Local environment is running Node `v24.14.1`, while the repo declares Node `22.x`.
- The remaining local build failure is disk/static-generation related, not the Tomas package import.