### PR TITLE
Reduce programmatic SEO build pressure

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,10 +1,20 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = path.resolve(__dirname, '../..')
+const useStandaloneOutput = process.platform !== 'win32' || process.env.FORCE_NEXT_STANDALONE === '1'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   // Transpile workspace packages (TS sources imported via exports.ts)
   transpilePackages: ['@agoraencontrei/tomas-knowledge'],
-  // Standalone output for Docker/Railway deployment
-  output: 'standalone',
+  // Standalone output for Docker/Railway deployment. On Windows, Next tries to
+  // create package symlinks during trace copy and often fails without developer
+  // mode/admin privileges; production Linux builds keep standalone enabled.
+  output: useStandaloneOutput ? 'standalone' : undefined,
+  outputFileTracingRoot: workspaceRoot,
   // Compressão gzip/brotli automática
   compress: true,
   // swcMinify is the default on Next 15 and the key itself is deprecated —

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/[modificador]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/[modificador]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronRight, Home, Search } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 
@@ -45,12 +46,23 @@ function clusterLabel(cluster: string): string {
 }
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string; modificador: string }[] = []
-  // Gerar apenas para as top 20 cidades por população para não explodir o build
-  const topCidades = IBGE_CITIES_152.sort((a, b) => b.populacao - a.populacao).slice(0, 20)
-  const topClusters = VALID_CLUSTERS.slice(0, 10)
-  const topMods = Object.keys(MODIFICADORES).slice(0, 5)
+  // Pre-renderiza apenas combinacoes prioritarias; a cauda longa fica em ISR.
+  const topCidades = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_MODIFIER_CITY_LIMIT',
+    5
+  )
+  const topClusters = limitSeoStaticItems(
+    VALID_CLUSTERS,
+    'SEO_STATIC_MODIFIER_CLUSTER_LIMIT',
+    3
+  )
+  const topMods = limitSeoStaticItems(
+    Object.keys(MODIFICADORES),
+    'SEO_STATIC_MODIFIER_LIMIT',
+    2
+  )
   for (const city of topCidades) {
     for (const cluster of topClusters) {
       for (const mod of topMods) {

--- a/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/[cluster]/page.tsx
@@ -10,7 +10,7 @@ import { notFound } from 'next/navigation'
 import { MapPin, Home, Search, ChevronRight } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
 import { CitySeoContent } from '@/components/public/CitySeoContent'
-import { isBuildPhase } from '@/lib/ssg-runtime'
+import { isBuildPhase, limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api-production-669c.up.railway.app'
@@ -57,10 +57,19 @@ function resolveMeta(cluster: string, cityName: string, state: string) {
 }
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
-  for (const city of IBGE_CITIES_152) {
-    for (const cluster of Object.keys(CLUSTER_META)) {
+  const cities = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_CLUSTER_CITY_LIMIT',
+    10
+  )
+  const clusters = limitSeoStaticItems(
+    Object.keys(CLUSTER_META),
+    'SEO_STATIC_CLUSTER_LIMIT',
+    8
+  )
+  for (const city of cities) {
+    for (const cluster of clusters) {
       params.push({ estado: city.stateSlug, cidade: city.slug, cluster })
     }
   }

--- a/apps/web/src/app/(public)/[estado]/[cidade]/guia/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/guia/[cluster]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronRight, BookOpen } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 
@@ -27,10 +28,19 @@ const GUIAS: Record<string, { label: string; desc: string; icon: string }> = {
 }
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
-  for (const city of IBGE_CITIES_152) {
-    for (const cluster of Object.keys(GUIAS)) {
+  const cities = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_GUIDE_CITY_LIMIT',
+    10
+  )
+  const guides = limitSeoStaticItems(
+    Object.keys(GUIAS),
+    'SEO_STATIC_GUIDE_LIMIT',
+    4
+  )
+  for (const city of cities) {
+    for (const cluster of guides) {
       params.push({ estado: city.stateSlug, cidade: city.slug, cluster })
     }
   }

--- a/apps/web/src/app/(public)/[estado]/[cidade]/investimentos/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/investimentos/[cluster]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronRight, TrendingUp, Search } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 
@@ -25,10 +26,19 @@ const INVESTIMENTOS: Record<string, { label: string; desc: string; icon: string 
 }
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
-  for (const city of IBGE_CITIES_152) {
-    for (const cluster of Object.keys(INVESTIMENTOS)) {
+  const cities = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_INVESTMENT_CITY_LIMIT',
+    10
+  )
+  const investments = limitSeoStaticItems(
+    Object.keys(INVESTIMENTOS),
+    'SEO_STATIC_INVESTMENT_LIMIT',
+    3
+  )
+  for (const city of cities) {
+    for (const cluster of investments) {
       params.push({ estado: city.stateSlug, cidade: city.slug, cluster })
     }
   }

--- a/apps/web/src/app/(public)/[estado]/[cidade]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { MapPin, TrendingUp, Home, Building2, Gavel, Wrench, Search } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 
@@ -37,8 +38,12 @@ const SERVICE_CLUSTERS = [
 ]
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
-  return IBGE_CITIES_152.map(city => ({
+  const cities = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_CITY_LIMIT',
+    20
+  )
+  return cities.map(city => ({
     estado: city.stateSlug,
     cidade: city.slug,
   }))

--- a/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronRight, Search, Star } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
 
@@ -72,10 +73,19 @@ const SERVICOS: Record<string, { label: string; desc: string; icon: string; faq:
 }
 
 export async function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
   const params: { estado: string; cidade: string; cluster: string }[] = []
-  for (const city of IBGE_CITIES_152) {
-    for (const cluster of Object.keys(SERVICOS)) {
+  const cities = limitSeoStaticItems(
+    [...IBGE_CITIES_152].sort((a, b) => b.populacao - a.populacao),
+    'SEO_STATIC_SERVICE_CITY_LIMIT',
+    10
+  )
+  const services = limitSeoStaticItems(
+    Object.keys(SERVICOS),
+    'SEO_STATIC_SERVICE_LIMIT',
+    8
+  )
+  for (const city of cities) {
+    for (const cluster of services) {
       params.push({ estado: city.stateSlug, cidade: city.slug, cluster })
     }
   }

--- a/apps/web/src/app/(public)/comparar/[comparacao]/page.tsx
+++ b/apps/web/src/app/(public)/comparar/[comparacao]/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ArrowRight, TrendingUp, Users, BarChart3, MapPin, Home } from 'lucide-react'
 import { IBGE_CITIES_152, IBGE_CITY_BY_SLUG, type IbgeCityData } from '@/data/seo-ibge-cities-expanded'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 export const revalidate = 86400
 
@@ -22,12 +23,10 @@ const ALL_CITIES_SORTED = IBGE_CITIES_152
 type CompareParams = { comparacao: string }
 
 export function generateStaticParams() {
-  if (process.env.MINIMAL_SSG === '1') return []  // build offline (.exe) nao precisa das paginas SEO publicas
-  // Pré-gera as combinações entre as ~40 maiores cidades (40×39/2 = 780
-  // páginas). As demais combinações são geradas sob demanda via ISR
+  // Pre-gera combinacoes entre cidades prioritarias. As demais combinacoes sao geradas sob demanda via ISR
   // (dynamicParams = true por padrão) — mantém o build rápido sem perder
   // cobertura de SEO.
-  const TOP = ALL_CITIES_SORTED.slice(0, 40)
+  const TOP = limitSeoStaticItems(ALL_CITIES_SORTED, 'SEO_STATIC_COMPARE_CITY_LIMIT', 10)
   const params: { comparacao: string }[] = []
   for (let i = 0; i < TOP.length; i++) {
     for (let j = i + 1; j < TOP.length; j++) {

--- a/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
@@ -8,6 +8,7 @@ import {
   getPartnerCityBySlug,
   partnerSeoPath,
 } from '@/lib/partner-seo'
+import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 export const revalidate = 300
 
@@ -73,8 +74,10 @@ async function fetchSpecialists(city: string, category: string): Promise<Special
 }
 
 export function generateStaticParams() {
-  return PARTNER_CITY_SEO.slice(0, 6).flatMap(city =>
-    PARTNER_CATEGORY_SEO.slice(0, 8).map(category => ({
+  const cities = limitSeoStaticItems(PARTNER_CITY_SEO, 'SEO_STATIC_PARTNER_CITY_LIMIT', 3)
+  const categories = limitSeoStaticItems(PARTNER_CATEGORY_SEO, 'SEO_STATIC_PARTNER_CATEGORY_LIMIT', 4)
+  return cities.flatMap(city =>
+    categories.map(category => ({
       cidade: city.slug,
       categoria: category.slug,
     }))

--- a/apps/web/src/lib/ssg-runtime.ts
+++ b/apps/web/src/lib/ssg-runtime.ts
@@ -16,3 +16,22 @@ export function isBuildPhase(): boolean {
   return process.env.NEXT_PHASE === 'phase-production-build'
     || process.env.SSG_SKIP_FETCH === '1'
 }
+
+export function getSeoStaticLimit(envName: string, fallback: number): number {
+  if (process.env.MINIMAL_SSG === '1') return 0
+  if (process.env.SEO_FULL_SSG === '1') return Number.POSITIVE_INFINITY
+
+  const raw = process.env[envName]
+  if (!raw) return fallback
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return Math.floor(parsed)
+}
+
+export function limitSeoStaticItems<T>(items: T[], envName: string, fallback: number): T[] {
+  const limit = getSeoStaticLimit(envName, fallback)
+  if (limit === 0) return []
+  if (!Number.isFinite(limit)) return items
+  return items.slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- Adds shared SEO SSG limit helpers with `MINIMAL_SSG=1`, `SEO_FULL_SSG=1`, and route-specific limit env vars.
- Limits default pre-rendering for programmatic city/cluster/service/guide/investment/modifier/comparison/partner SEO routes while preserving on-demand ISR coverage.
- Pins `outputFileTracingRoot` to the monorepo root and disables standalone output only on Windows local builds unless `FORCE_NEXT_STANDALONE=1` is set.

## Validation
- `pnpm.cmd --filter './apps/web' build` passes.
- Static generation dropped from 15,368 pages before the fix to 957 pages with the new defaults.
- `git diff --check` passes.

## Notes
- Local environment still warns because Node is `v24.14.1` while the repo wants Node `22.x`.
- Linux/Vercel/Railway production builds keep `output: 'standalone'`; Windows local builds avoid symlink EPERM unless forced.