### PR TITLE
Add lead qualifier to partner directory pages

### DIFF
--- a/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
@@ -9,6 +9,7 @@ import {
   partnerSeoPath,
 } from '@/lib/partner-seo'
 import { limitSeoStaticItems } from '@/lib/ssg-runtime'
+import { PartnerLeadQualifier } from '../../../especialistas/[slug]/PartnerLeadQualifier'
 
 export const revalidate = 300
 
@@ -123,6 +124,7 @@ export default async function PartnerSeoPage({
   if (!city || !cat) notFound()
 
   const specialists = await fetchSpecialists(city.city, cat.value)
+  const leadTarget = specialists[0]
 
   const itemListSchema = {
     '@context': 'https://schema.org',
@@ -239,6 +241,22 @@ export default async function PartnerSeoPage({
         </div>
 
         {specialists.length > 0 ? (
+          <>
+            <div className="mb-8">
+              <PartnerLeadQualifier
+                specialistId={leadTarget.id}
+                specialistName={leadTarget.name}
+                categoryLabel={`${cat.label} em ${city.city}/${city.state}`}
+                whatsapp={leadTarget.whatsapp || leadTarget.phone}
+                services={[
+                  { name: cat.service },
+                  { name: 'Projeto ou orcamento' },
+                  { name: 'Comparar profissionais' },
+                  { name: 'Outro' },
+                ]}
+              />
+            </div>
+
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {specialists.map(s => {
               const wa = waHref(s)
@@ -281,6 +299,7 @@ export default async function PartnerSeoPage({
               )
             })}
           </div>
+          </>
         ) : (
           <div className="rounded-3xl border border-dashed border-[#C9A84C] bg-white p-10 text-center">
             <h2 className="text-xl font-bold text-[#143A1F]">Seja o primeiro destaque nesta busca</h2>

--- a/apps/web/src/app/(public)/empresas-parceiras/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/page.tsx
@@ -14,6 +14,7 @@ import {
   PARTNER_INTENT_PAGES,
   partnerSeoPath,
 } from '@/lib/partner-seo'
+import { PartnerLeadQualifier } from '../especialistas/[slug]/PartnerLeadQualifier'
 
 export const revalidate = 300
 
@@ -124,6 +125,8 @@ export default async function EmpresasParceirasPage({
 
   const specialists = await fetchSpecialists(sp)
   const activeCat = CATEGORIES.find(c => c.value === sp.category)
+  const leadTarget = specialists[0]
+  const leadCategoryLabel = activeCat?.label || leadTarget?.landingPage?.segmentLabel || leadTarget?.categoryLabel || 'Servicos para imoveis'
   const directorySchema = {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
@@ -255,6 +258,22 @@ export default async function EmpresasParceirasPage({
         </p>
 
         {specialists.length > 0 ? (
+          <>
+            <div className="mb-8">
+              <PartnerLeadQualifier
+                specialistId={leadTarget.id}
+                specialistName={leadTarget.name}
+                categoryLabel={leadCategoryLabel}
+                whatsapp={leadTarget.whatsapp || leadTarget.phone}
+                services={[
+                  { name: leadCategoryLabel },
+                  { name: 'Orcamento e diagnostico' },
+                  { name: 'Comparar profissionais' },
+                  { name: 'Outro' },
+                ]}
+              />
+            </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
             {specialists.map(s => {
               const wa = waHref(s)
@@ -311,6 +330,7 @@ export default async function EmpresasParceirasPage({
               )
             })}
           </div>
+          </>
         ) : (
           <div className="max-w-2xl mx-auto rounded-2xl border border-dashed p-10 text-center bg-white" style={{ borderColor: '#C9A84C' }}>
             <div className="text-5xl mb-3 opacity-30">🏢</div>


### PR DESCRIPTION
## Summary
- Adds the existing intelligent partner briefing form to `/empresas-parceiras` when results exist.
- Adds the same qualifier to `/empresas-parceiras/[cidade]/[categoria]` SEO landing pages.
- Routes the qualified lead to the first ranked partner in the current result set, preserving partner attribution, lead score, and dashboard visibility.

## Validation
- `pnpm.cmd --filter './apps/web' build` passes.
- `git diff --check` passes.

## Notes
- Local environment still warns because Node is `v24.14.1` while the repo wants Node `22.x`.