### PR TITLE
fix(header): logo/nome do site principal volta a ser AgoraEncontrei (+ upload, destaque, métricas)

### DIFF
--- a/apps/api/src/routes/specialists/index.ts
+++ b/apps/api/src/routes/specialists/index.ts
@@ -8,8 +8,10 @@
  */
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
+import { nanoid } from 'nanoid'
 import { slugify } from '../../utils/slugify.js'
 import { specialistTokenOrAdmin, generateSpecialistAccessToken } from './auth.js'
+import { s3Service } from '../../services/s3.service.js'
 
 const categoryLabels: Record<string, string> = {
   ARQUITETO: 'Arquiteto(a)',
@@ -53,6 +55,50 @@ function sortSpecialistsForVisibility(list: any[]) {
 
 export default async function specialistsRoute(app: FastifyInstance) {
   const prisma = (app as any).prisma
+
+  // ─── POST /upload — upload de imagem da landing (S3 ou base64 fallback) ───
+  // Público: o cadastro de "Divulgue seu Negócio" é anônimo (o parceiro ainda
+  // não tem conta) e o editor usa magic-link. Restrito a imagens, tamanho e
+  // rate-limit apertados para conter abuso. Retorna { url }.
+  const UPLOAD_MIMES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif'])
+  const UPLOAD_MAX = 8 * 1024 * 1024 // 8 MB
+  app.post('/upload', {
+    config: { rateLimit: { max: 40, timeWindow: '1 minute' } },
+  }, async (req: any, reply) => {
+    let data: any
+    try {
+      data = await req.file({ limits: { fileSize: UPLOAD_MAX } })
+    } catch {
+      return reply.status(400).send({ error: 'INVALID_UPLOAD' })
+    }
+    if (!data) return reply.status(400).send({ error: 'NO_FILE' })
+
+    const mimetype = data.mimetype || 'application/octet-stream'
+    if (!UPLOAD_MIMES.has(mimetype)) {
+      return reply.status(400).send({ error: 'INVALID_FILE_TYPE', message: 'Envie uma imagem (JPG, PNG, WEBP, AVIF ou GIF).' })
+    }
+
+    const chunks: Buffer[] = []
+    let total = 0
+    for await (const chunk of data.file) {
+      total += chunk.length
+      if (total > UPLOAD_MAX) return reply.status(413).send({ error: 'FILE_TOO_LARGE', message: 'Imagem acima de 8 MB.' })
+      chunks.push(chunk)
+    }
+    const buffer = Buffer.concat(chunks)
+
+    try {
+      if (s3Service.isConfigured()) {
+        const key = `specialists/${nanoid()}.${mimetype.split('/')[1] || 'jpg'}`
+        const url = await s3Service.upload(key, buffer, mimetype)
+        return reply.send({ url, key })
+      }
+    } catch (err: any) {
+      req.log?.error({ err }, '[specialists/upload] S3 falhou — usando base64')
+    }
+    // Fallback: data URL inline (sem S3 configurado)
+    return reply.send({ url: `data:${mimetype};base64,${buffer.toString('base64')}`, inline: true })
+  })
 
   // ─── GET /buildings — lista de edifícios para o formulário de cadastro ───
   app.get('/buildings', async (request, reply) => {
@@ -414,6 +460,55 @@ export default async function specialistsRoute(app: FastifyInstance) {
       return reply.send({ success: true, data: safe })
     } catch (err: any) {
       return reply.status(500).send({ error: 'Erro ao atualizar', details: err.message })
+    }
+  })
+
+  // ─── PATCH /:id/feature — destaque do parceiro (somente admin) ───────────
+  // Controle manual do "destaque" (isFeatured/featuredWeight/featuredUntil) que
+  // alimenta o ranqueamento do diretório e das buscas. Só ADMIN/SUPER_ADMIN.
+  app.patch('/:id/feature', {
+    preHandler: [(app as any).authenticate],
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const user = (request as any).user
+    if (!['ADMIN', 'SUPER_ADMIN', 'MANAGER'].includes(user?.role)) {
+      return reply.status(403).send({ error: 'Acesso negado' })
+    }
+
+    const parsed = z.object({
+      isFeatured: z.boolean().optional(),
+      featuredWeight: z.number().int().min(0).max(1000).optional(),
+      featuredDays: z.number().int().min(1).max(365).optional().nullable(),
+    }).safeParse(request.body)
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Dados inválidos', details: parsed.error.flatten() })
+    }
+
+    const data: any = {}
+    if (parsed.data.isFeatured !== undefined) data.isFeatured = parsed.data.isFeatured
+    if (parsed.data.featuredWeight !== undefined) data.featuredWeight = parsed.data.featuredWeight
+    if (parsed.data.featuredDays !== undefined) {
+      data.featuredUntil = parsed.data.featuredDays
+        ? new Date(Date.now() + parsed.data.featuredDays * 24 * 60 * 60 * 1000)
+        : null
+    }
+    // Ligar destaque sem prazo definido → mantém enquanto isFeatured for true.
+    if (parsed.data.isFeatured === false) data.featuredUntil = null
+
+    try {
+      const updated = await prisma.specialist.update({ where: { id }, data })
+      return reply.send({
+        success: true,
+        data: {
+          id: updated.id,
+          isFeatured: updated.isFeatured,
+          featuredWeight: updated.featuredWeight,
+          featuredUntil: updated.featuredUntil,
+        },
+      })
+    } catch (err: any) {
+      if (err.code === 'P2025') return reply.status(404).send({ error: 'Especialista não encontrado' })
+      return reply.status(500).send({ error: 'Erro ao atualizar destaque', details: err.message })
     }
   })
 

--- a/apps/web/src/app/(dashboard)/dashboard/parceiros/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/parceiros/page.tsx
@@ -53,6 +53,7 @@ interface SpecialistStats {
 
 interface Specialist {
   id: string
+  slug?: string
   name: string
   email: string
   phone?: string
@@ -64,6 +65,9 @@ interface Specialist {
   createdAt: string
   planActivatedAt?: string
   planExpiresAt?: string
+  isFeatured?: boolean
+  featuredWeight?: number
+  featuredUntil?: string | null
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -140,6 +144,22 @@ export default function ParceirosPage() {
       headers: { Authorization: `Bearer ${accessToken}` },
     })
     window.location.reload()
+  }
+
+  // Liga/desliga o destaque do parceiro (alimenta o ranking do diretório).
+  const [featBusy, setFeatBusy] = useState<string | null>(null)
+  const handleFeature = async (id: string, next: boolean) => {
+    setFeatBusy(id)
+    try {
+      await fetch(`${API_URL}/api/v1/specialists/${id}/feature`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ isFeatured: next, featuredWeight: next ? 100 : 0 }),
+      })
+      window.location.reload()
+    } finally {
+      setFeatBusy(null)
+    }
   }
 
   if (isLoading) {
@@ -369,8 +389,21 @@ export default function ParceirosPage() {
                               Aprovar
                             </button>
                           )}
+                          <button
+                            onClick={() => handleFeature(s.id, !s.isFeatured)}
+                            disabled={featBusy === s.id}
+                            title={s.isFeatured ? 'Remover destaque' : 'Destacar no diretório'}
+                            className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors inline-flex items-center gap-1 disabled:opacity-50 ${
+                              s.isFeatured
+                                ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                            }`}
+                          >
+                            <Star className={`w-3 h-3 ${s.isFeatured ? 'fill-amber-500 text-amber-500' : ''}`} />
+                            {s.isFeatured ? 'Em destaque' : 'Destacar'}
+                          </button>
                           <Link
-                            href={`/especialistas/${s.id}`}
+                            href={`/especialistas/${s.slug ?? s.id}`}
                             target="_blank"
                             className="px-3 py-1 rounded-lg text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors inline-flex items-center gap-1"
                           >

--- a/apps/web/src/app/(public)/meu-painel/page.tsx
+++ b/apps/web/src/app/(public)/meu-painel/page.tsx
@@ -6,7 +6,7 @@ import {
   User, Star, Crown, Zap, CheckCircle, ArrowRight, Building2,
   MessageCircle, TrendingUp, Eye, Edit3, Share2, AlertCircle,
   ExternalLink, Camera, FileText, MapPin, Award, Shield, Lock,
-  BarChart2, Phone, MousePointer
+  BarChart2, MousePointer
 } from 'lucide-react'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
@@ -17,6 +17,7 @@ interface Specialist {
   email: string
   slug: string
   plan: 'START' | 'PRIME' | 'VIP'
+  adPlan?: string | null
   planStatus: string
   planExpiresAt?: string
   category: string
@@ -119,7 +120,9 @@ export default function MeuPainelPage() {
     setLoadingAnalytics(true)
     const qs = token ? `?token=${encodeURIComponent(token)}` : ''
     Promise.all([
-      fetch(`${API_URL}/api/v1/public/partner-stats/${specialist.id}${qs}`).then(r => r.ok ? r.json() : null).catch(() => null),
+      // Métricas do parceiro pelo endpoint com magic-link (funciona para
+      // anunciantes de divulgação, que entram sem JWT).
+      fetch(`${API_URL}/api/v1/specialists/${specialist.id}/stats${qs}`).then(r => r.ok ? r.json() : null).catch(() => null),
       fetch(`${API_URL}/api/v1/public/territory/my/${specialist.id}`).then(r => r.ok ? r.json() : null).catch(() => null),
     ]).then(([analyticsData, territoryData]) => {
       if (analyticsData) setAnalytics(analyticsData)
@@ -407,8 +410,8 @@ export default function MeuPainelPage() {
               </div>
             </div>
 
-            {/* Analytics em tempo real */}
-            {specialist.plan !== 'START' && (
+            {/* Analytics em tempo real (planos pagos OU divulgação ativa) */}
+            {(specialist.plan !== 'START' || specialist.adPlan) && (
               <div className="bg-white rounded-2xl border p-6 shadow-sm">
                 <div className="flex items-center justify-between mb-4">
                   <h2 className="font-bold text-[#143A1F] flex items-center gap-2">
@@ -427,12 +430,12 @@ export default function MeuPainelPage() {
                       <div className="text-xs text-gray-500 mt-1 flex items-center justify-center gap-1"><MessageCircle className="w-3 h-3" /> WhatsApp</div>
                     </div>
                     <div className="bg-[#f8faff] rounded-xl p-3 text-center">
-                      <div className="text-2xl font-bold text-[#C9A84C]">{analytics.monthly?.condoImpressions ?? 0}</div>
-                      <div className="text-xs text-gray-500 mt-1 flex items-center justify-center gap-1"><Building2 className="w-3 h-3" /> Impressões</div>
+                      <div className="text-2xl font-bold text-[#C9A84C]">{analytics.monthly?.uniqueVisitors ?? 0}</div>
+                      <div className="text-xs text-gray-500 mt-1 flex items-center justify-center gap-1"><User className="w-3 h-3" /> Visitantes</div>
                     </div>
                     <div className="bg-[#f8faff] rounded-xl p-3 text-center">
-                      <div className="text-2xl font-bold text-purple-600">{analytics.monthly?.phoneClicks ?? 0}</div>
-                      <div className="text-xs text-gray-500 mt-1 flex items-center justify-center gap-1"><Phone className="w-3 h-3" /> Ligações</div>
+                      <div className="text-2xl font-bold text-purple-600">{analytics.monthly?.qualifiedLeads ?? 0}</div>
+                      <div className="text-xs text-gray-500 mt-1 flex items-center justify-center gap-1"><MousePointer className="w-3 h-3" /> Leads</div>
                     </div>
                   </div>
                 ) : (
@@ -440,14 +443,10 @@ export default function MeuPainelPage() {
                     {loadingAnalytics ? 'Carregando métricas...' : 'Nenhum dado disponível ainda'}
                   </div>
                 )}
-                {analytics?.monthly && (
+                {analytics?.allTime && (
                   <div className="mt-3 pt-3 border-t flex items-center justify-between text-xs text-gray-500">
-                    <span>Custo por lead: <strong className="text-[#143A1F]">
-                      {analytics.monthly.whatsappClicks > 0
-                        ? `R$ ${((analytics.partner?.planPrice || 0) / analytics.monthly.whatsappClicks).toFixed(0)}`
-                        : '—'}
-                    </strong></span>
-                    <span>Total histórico: <strong className="text-[#143A1F]">{analytics.allTime?.totalContacts ?? 0} contatos</strong></span>
+                    <span>Total de visualizações: <strong className="text-[#143A1F]">{analytics.allTime?.totalViews ?? 0}</strong></span>
+                    <span>Cliques no WhatsApp: <strong className="text-[#143A1F]">{analytics.allTime?.totalWhatsapp ?? 0}</strong></span>
                   </div>
                 )}
               </div>

--- a/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/cadastro/page.tsx
@@ -15,6 +15,7 @@ import {
   AD_PLAN_BY_ID, LANDING_TEMPLATES, getCategory, formatBRL,
   type AdPlan,
 } from '@/lib/divulgue-catalog'
+import { uploadSpecialistImage } from '@/lib/specialist-upload'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -65,33 +66,6 @@ function validateDocument(value: string): { valid: boolean; error: string } {
   if (d.length <= 11) return d.length < 11 ? { valid: true, error: '' } : (validateCPF(d) ? { valid: true, error: '' } : { valid: false, error: 'CPF inválido' })
   if (d.length < 14) return { valid: true, error: '' }
   return validateCNPJ(d) ? { valid: true, error: '' } : { valid: false, error: 'CNPJ inválido' }
-}
-
-// Reduz uma imagem para dataURL leve (máx ~1000px, JPEG 0.82).
-function fileToDataUrl(file: File, maxSize = 1000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const img = document.createElement('img')
-      img.onload = () => {
-        let { width, height } = img
-        if (width > maxSize || height > maxSize) {
-          if (width >= height) { height = Math.round((height * maxSize) / width); width = maxSize }
-          else { width = Math.round((width * maxSize) / height); height = maxSize }
-        }
-        const canvas = document.createElement('canvas')
-        canvas.width = width; canvas.height = height
-        const ctx = canvas.getContext('2d')
-        if (!ctx) { resolve(reader.result as string); return }
-        ctx.drawImage(img, 0, 0, width, height)
-        resolve(canvas.toDataURL('image/jpeg', 0.82))
-      }
-      img.onerror = reject
-      img.src = reader.result as string
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
 }
 
 const PRICE_TYPES = [
@@ -176,9 +150,10 @@ function CadastroContent() {
   }
   const onPhotoFiles = async (files: FileList | null) => {
     if (!files) return
+    let count = photos.length
     for (const file of Array.from(files)) {
-      if (photos.length >= plan.maxPhotos) { setError(`Seu plano permite até ${plan.maxPhotos} fotos.`); break }
-      try { const data = await fileToDataUrl(file); setPhotos(prev => [...prev, data]) } catch { /* ignora arquivo inválido */ }
+      if (count >= plan.maxPhotos) { setError(`Seu plano permite até ${plan.maxPhotos} fotos.`); break }
+      try { const url = await uploadSpecialistImage(file); setPhotos(prev => [...prev, url]); count++ } catch { /* ignora arquivo inválido */ }
     }
   }
   const removePhoto = (i: number) => setPhotos(prev => prev.filter((_, idx) => idx !== i))
@@ -193,7 +168,7 @@ function CadastroContent() {
 
   const onLogoFile = async (file: File | null) => {
     if (!file) return
-    try { setLogoUrl(await fileToDataUrl(file, 512)) } catch { /* ignora */ }
+    try { setLogoUrl(await uploadSpecialistImage(file, { maxSize: 512 })) } catch { /* ignora */ }
   }
 
   const fmtDoc = (v: string) => {

--- a/apps/web/src/app/(public)/parceiros/editar/[id]/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/editar/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   Eye, MessageCircle, Users, ClipboardCheck,
 } from 'lucide-react'
 import { LANDING_TEMPLATES, getCategory } from '@/lib/divulgue-catalog'
+import { uploadSpecialistImage } from '@/lib/specialist-upload'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
 
@@ -47,32 +48,6 @@ const PRICE_TYPES = [
   { value: 'hora', label: 'Por hora' },
   { value: 'consulta', label: 'Sob consulta' },
 ]
-
-function fileToDataUrl(file: File, maxSize = 1000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const img = document.createElement('img')
-      img.onload = () => {
-        let { width, height } = img
-        if (width > maxSize || height > maxSize) {
-          if (width >= height) { height = Math.round((height * maxSize) / width); width = maxSize }
-          else { width = Math.round((width * maxSize) / height); height = maxSize }
-        }
-        const canvas = document.createElement('canvas')
-        canvas.width = width; canvas.height = height
-        const ctx = canvas.getContext('2d')
-        if (!ctx) { resolve(reader.result as string); return }
-        ctx.drawImage(img, 0, 0, width, height)
-        resolve(canvas.toDataURL('image/jpeg', 0.82))
-      }
-      img.onerror = reject
-      img.src = reader.result as string
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
 
 export default function EditarParceiroPage() {
   const params = useParams<{ id: string }>()
@@ -153,10 +128,10 @@ export default function EditarParceiroPage() {
   }
   const updateService = (i: number, patch: Partial<ServiceItem>) => setServices(prev => prev.map((s, idx) => idx === i ? { ...s, ...patch } : s))
 
-  const onLogo = async (f: File | null) => { if (f) { try { setLogoUrl(await fileToDataUrl(f, 512)) } catch {} } }
+  const onLogo = async (f: File | null) => { if (f) { try { setLogoUrl(await uploadSpecialistImage(f, { maxSize: 512 })) } catch {} } }
   const onPhotos = async (files: FileList | null) => {
     if (!files) return
-    for (const f of Array.from(files)) { try { const d = await fileToDataUrl(f); setPhotos(p => [...p, d]) } catch {} }
+    for (const f of Array.from(files)) { try { const url = await uploadSpecialistImage(f); setPhotos(p => [...p, url]) } catch {} }
   }
 
   const save = async () => {

--- a/apps/web/src/components/dashboard/sidebar.tsx
+++ b/apps/web/src/components/dashboard/sidebar.tsx
@@ -215,15 +215,15 @@ function NavContent({ onClose }: { onClose?: () => void }) {
         ) : (
           <>
             <Image
-              src="/logo-lemos-v2.png"
-              alt="Imobiliária Lemos"
+              src="/brand/ae-icon-round.png"
+              alt="AgoraEncontrei"
               width={40}
               height={40}
               className="rounded-full flex-shrink-0 object-cover"
             />
             <div className="min-w-0">
-              <p className="font-bold text-sm leading-none text-white" style={{ fontFamily: 'Georgia, serif' }}>IMOBILIÁRIA</p>
-              <p className="text-xs font-bold leading-none mt-0.5 truncate" style={{ color: '#C9A84C', fontFamily: 'Georgia, serif' }}>LEMOS</p>
+              <p className="font-bold text-sm leading-none text-white" style={{ fontFamily: 'Georgia, serif' }}>AGORA</p>
+              <p className="text-xs font-bold leading-none mt-0.5 truncate" style={{ color: '#C9A84C', fontFamily: 'Georgia, serif' }}>ENCONTREI</p>
             </div>
           </>
         )}

--- a/apps/web/src/lib/site-settings.ts
+++ b/apps/web/src/lib/site-settings.ts
@@ -27,6 +27,24 @@ export const DEFAULT_ACCENT_COLOR = '#C9A84C'
 // evitando o header azul-marinho onde o logo/escrita AgoraEncontrei some.
 const STALE_PRIMARY_DEFAULTS = new Set(['#1b2b5b', '#011347'])
 
+// O site PRINCIPAL é o marketplace AgoraEncontrei. A Imobiliária Lemos é a
+// empresa operadora (aparece no rodapé/contato e na landing do parceiro), mas
+// NÃO deve ser a marca do cabeçalho. Provisionamentos antigos gravaram o
+// logo/nome da Lemos na config do site; tratamos esses valores como "não
+// configurado" para o cabeçalho voltar à marca AgoraEncontrei (mesma lógica do
+// STALE_PRIMARY_DEFAULTS). Logos/nomes custom que NÃO sejam da Lemos seguem
+// respeitados normalmente.
+function isStaleBrandLogo(v?: string | null): boolean {
+  if (!v || typeof v !== 'string') return false
+  const s = v.toLowerCase()
+  return s.includes('logo-lemos') || s.includes('imobiliaria-lemos/logo') || s.includes('imobiliaria-lemos%2flogo')
+}
+function isStaleBrandName(v?: string | null): boolean {
+  if (!v || typeof v !== 'string') return false
+  const n = v.normalize('NFKD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/\s+/g, ' ').trim()
+  return n === 'imobiliaria lemos' || n === 'imobiliaria lemos marketplace' || n === 'lemos'
+}
+
 export interface SiteSettings {
   logoUrl?: string | null
   logoIconUrl?: string | null
@@ -132,20 +150,21 @@ export function resolveSiteBrand(
 } {
   const settings = s ?? {}
   // Prioridade do ícone: logoIconUrl (campo dedicado) > logoUrl (legado) > fallback.
+  // Ignora logos legados da Imobiliária Lemos (o cabeçalho do marketplace é AE).
   const iconCandidate =
-    [settings.logoIconUrl, settings.logoUrl].find(v => typeof v === 'string' && v.trim() !== '')
+    [settings.logoIconUrl, settings.logoUrl].find(v => typeof v === 'string' && v.trim() !== '' && !isStaleBrandLogo(v))
   const custom = typeof iconCandidate === 'string'
-  const wordmarkCandidate = typeof settings.logoWordmarkUrl === 'string' && settings.logoWordmarkUrl.trim() !== ''
+  const wordmarkCandidate = typeof settings.logoWordmarkUrl === 'string' && settings.logoWordmarkUrl.trim() !== '' && !isStaleBrandLogo(settings.logoWordmarkUrl)
     ? settings.logoWordmarkUrl.trim()
     : null
-  const name = typeof settings.companyName === 'string' && settings.companyName.trim() !== ''
+  const name = typeof settings.companyName === 'string' && settings.companyName.trim() !== '' && !isStaleBrandName(settings.companyName)
     ? settings.companyName.trim()
     : null
   // Logo COMPLETO (emblema + escrita), como no login. Prioridade:
   //   1. logoFullUrl custom do admin (editável);
   //   2. sem ícone custom → o full padrão do AgoraEncontrei (tom claro);
   //   3. com ícone custom mas sem full → null (mantém ícone + wordmark).
-  const customFull = typeof settings.logoFullUrl === 'string' && settings.logoFullUrl.trim() !== ''
+  const customFull = typeof settings.logoFullUrl === 'string' && settings.logoFullUrl.trim() !== '' && !isStaleBrandLogo(settings.logoFullUrl)
     ? settings.logoFullUrl.trim()
     : null
   const fullLogoUrl = customFull || (custom ? null : DEFAULT_FULL_LOGO_URL)

--- a/apps/web/src/lib/specialist-upload.ts
+++ b/apps/web/src/lib/specialist-upload.ts
@@ -1,0 +1,79 @@
+/**
+ * Upload de imagens da landing page do parceiro ("Divulgue seu Negócio").
+ *
+ * Comprime no navegador (canvas → JPEG) e envia para
+ * POST /api/v1/specialists/upload, que grava no S3 quando configurado ou
+ * devolve um data URL base64 como fallback. Se o upload falhar por qualquer
+ * motivo, cai para o data URL local — a montagem da página nunca quebra.
+ */
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3100'
+
+function compressToBlob(file: File, maxSize: number, quality = 0.82): Promise<{ blob: Blob; dataUrl: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const img = document.createElement('img')
+      img.onload = () => {
+        let { width, height } = img
+        if (width > maxSize || height > maxSize) {
+          if (width >= height) { height = Math.round((height * maxSize) / width); width = maxSize }
+          else { width = Math.round((width * maxSize) / height); height = maxSize }
+        }
+        const canvas = document.createElement('canvas')
+        canvas.width = width; canvas.height = height
+        const ctx = canvas.getContext('2d')
+        if (!ctx) { reject(new Error('no-canvas')); return }
+        ctx.drawImage(img, 0, 0, width, height)
+        const dataUrl = canvas.toDataURL('image/jpeg', quality)
+        canvas.toBlob(
+          (blob) => blob ? resolve({ blob, dataUrl }) : resolve({ blob: dataURLtoBlob(dataUrl), dataUrl }),
+          'image/jpeg',
+          quality,
+        )
+      }
+      img.onerror = reject
+      img.src = reader.result as string
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
+function dataURLtoBlob(dataUrl: string): Blob {
+  const [head, body] = dataUrl.split(',')
+  const mime = head.match(/data:(.*?);/)?.[1] || 'image/jpeg'
+  const bin = atob(body)
+  const arr = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
+  return new Blob([arr], { type: mime })
+}
+
+/**
+ * Comprime e faz upload de uma imagem, retornando a URL final (S3 ou base64).
+ * Nunca lança: em falha, retorna o data URL local.
+ */
+export async function uploadSpecialistImage(file: File, opts?: { maxSize?: number }): Promise<string> {
+  const maxSize = opts?.maxSize ?? 1400
+  let dataUrlFallback = ''
+  try {
+    const { blob, dataUrl } = await compressToBlob(file, maxSize)
+    dataUrlFallback = dataUrl
+    const form = new FormData()
+    form.append('file', blob, 'imagem.jpg')
+    const res = await fetch(`${API_URL}/api/v1/specialists/upload`, { method: 'POST', body: form })
+    if (res.ok) {
+      const data = await res.json().catch(() => null)
+      if (data?.url) return data.url as string
+    }
+  } catch {
+    /* cai para o fallback abaixo */
+  }
+  if (dataUrlFallback) return dataUrlFallback
+  // Último recurso: lê o arquivo original como data URL.
+  return await new Promise<string>((resolve, reject) => {
+    const r = new FileReader()
+    r.onload = () => resolve(r.result as string)
+    r.onerror = reject
+    r.readAsDataURL(file)
+  })
+}


### PR DESCRIPTION
Continuação do #301 (mergeado). O #301 corrigiu o logo do **schema.org** (metadados, invisível), mas o **cabeçalho visível** ainda mostra **"Imobiliária Lemos" + logo da Lemos** — porque a config do site vem do banco (`Company.name = "Imobiliária Lemos"`, `logoUrl = /partners/imobiliaria-lemos/logo.jpg`). Este PR corrige isso, além de trazer as pendências que ficaram fora do #301.

## 1) Header visível → AgoraEncontrei (a correção que faltava)
`site-settings.ts`: o cabeçalho do **site principal** ignora o logo/nome legado da Imobiliária Lemos (mesma lógica que o código já usava para cores legadas) e volta à marca **AgoraEncontrei**. Marcas custom que não sejam da Lemos seguem respeitadas; a landing do parceiro, o card "Nossas Imobiliárias Parceiras" e o rodapé/contato da Lemos permanecem intactos.

**Testado contra a config REAL de produção** (busquei o `/api/v1/public/site-settings` ao vivo: `companyName: "Imobiliária Lemos"`, `logoUrl: "/partners/imobiliaria-lemos/logo.jpg"`) → `resolveSiteBrand` zera ambos e o header renderiza `ae-logo-full-light.png` (alt "AgoraEncontrei"). Também reproduzi num Postgres local + Chromium.

## 2) Métricas do painel (`/meu-painel`)
Passa a usar `GET /specialists/:id/stats` (magic-link) em vez do endpoint travado por JWT (que não funcionava para anunciantes). Card "Performance do Mês" aparece para quem tem `adPlan`.

## 3) Upload real de imagens (S3 + fallback base64)
`POST /api/v1/specialists/upload`; cadastro e editor deixam de embutir base64.

## 4) Destaque do parceiro (admin) + logo AE na sidebar do dashboard
`PATCH /api/v1/specialists/:id/feature` + botão no dashboard; sidebar usa a marca AE.

## Verificação
- Config real de produção → header AgoraEncontrei (unit test do `resolveSiteBrand`).
- E2E (Postgres 16 + API + Chromium): header AE; painel do anunciante com métricas; upload url/400; destaque liga/desliga (401 sem auth).
- `typecheck` limpo (só o erro pré-existente de `plugins/automation.ts`).

> Obs.: após o merge + deploy, o header pode levar ~1 min para atualizar (cache ISR/Redis do site-settings). O ideal a médio prazo é também trocar no admin o nome/logo do site principal para AgoraEncontrei — este PR já garante a marca correta independentemente disso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Byh14xDfsMs3oDqHajzciq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byh14xDfsMs3oDqHajzciq)_