### PR TITLE
Fortalece descoberta SEO da NIU

### DIFF
--- a/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
+++ b/apps/web/src/app/(public)/[estado]/[cidade]/servicos/[cluster]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ChevronRight, Search, Star } from 'lucide-react'
 import { IBGE_CITY_BY_SLUG, IBGE_CITIES_152, getIbgeCitySnippet } from '@/data/seo-ibge-cities-expanded'
+import { NIU_OFFICIAL_PARTNER } from '@/lib/partner-seo'
 import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://agoraencontrei.com.br'
@@ -72,6 +73,18 @@ const SERVICOS: Record<string, { label: string; desc: string; icon: string; faq:
   'seja-um-parceiro':           { label: 'Seja um Parceiro',           icon: '🤝', desc: 'Seja um parceiro AgoraEncontrei em {cidade}: tecnologia, leads e suporte para crescer suas vendas.', faq: ['Como ser parceiro em {cidade}?', 'Quais os benefícios?', 'Tem custo de adesão?'] },
 }
 
+const NIU_SERVICE_CLUSTERS = new Set([
+  'arquiteto',
+  'decoracao-de-interiores',
+  'construtora',
+  'empreiteira',
+  'planta-humanizada',
+])
+
+function isNiuServiceCluster(cluster: string) {
+  return NIU_SERVICE_CLUSTERS.has(cluster)
+}
+
 export async function generateStaticParams() {
   const params: { estado: string; cidade: string; cluster: string }[] = []
   const cities = limitSeoStaticItems(
@@ -101,10 +114,23 @@ export async function generateMetadata(props: { params: Promise<{ estado: string
 
   const label = servico.label
   const desc = servico.desc.replace(/\{cidade\}/g, city.name)
+  const niuRelevant = isNiuServiceCluster(params.cluster)
 
   return {
     title: `${label} em ${city.name}/${city.state} | AgoraEncontrei`,
     description: desc,
+    keywords: niuRelevant
+      ? [
+          `${label} em ${city.name}`,
+          `arquiteto em ${city.name}`,
+          `arquitetura em ${city.name}`,
+          `projeto arquitetonico em ${city.name}`,
+          `projetos de casas em ${city.name}`,
+          `construcao em ${city.name}`,
+          'NIU Arquitetura',
+          'AgoraEncontrei empresas parceiras',
+        ]
+      : undefined,
     openGraph: {
       title: `${label} em ${city.name}/${city.state} | AgoraEncontrei`,
       description: desc,
@@ -132,6 +158,7 @@ export default async function ServicoCidadePage(props: { params: Promise<{ estad
   const faq = servico.faq.map(q => q.replace(/\{cidade\}/g, city.name))
   const pop = city.populacao.toLocaleString('pt-BR')
   const pib = city.pibPerCapita.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 })
+  const niuRelevant = isNiuServiceCluster(params.cluster)
 
   const schema = {
     '@context': 'https://schema.org',
@@ -210,6 +237,40 @@ export default async function ServicoCidadePage(props: { params: Promise<{ estad
             imobiliário da cidade.
           </p>
         </section>
+
+        {niuRelevant && (
+          <section className="rounded-2xl border border-[#C9A84C]/30 bg-white p-6 shadow-sm">
+            <div className="grid gap-5 lg:grid-cols-[1fr_0.8fr] lg:items-center">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#9A7A23]">
+                  Parceiro oficial em destaque
+                </p>
+                <h2 className="mt-2 text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+                  {NIU_OFFICIAL_PARTNER.name} para arquitetura, projetos e preparacao de obra.
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-gray-600">
+                  Para quem pesquisa {label.toLowerCase()} em {city.name}/{city.state}, o AgoraEncontrei tambem apresenta
+                  a NIU como escritorio parceiro para projeto arquitetonico, interiores, reformas, casas de alto padrao
+                  e atendimento inicial online para demandas em Franca, regiao e Brasil.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row lg:flex-col">
+                <Link
+                  href="/parceiros/niu-arquitetura"
+                  className="inline-flex items-center justify-center rounded-xl bg-[#143A1F] px-5 py-3 text-sm font-bold text-white"
+                >
+                  Conhecer a NIU
+                </Link>
+                <Link
+                  href="/empresas-parceiras/franca-sp/arquitetos"
+                  className="inline-flex items-center justify-center rounded-xl border border-[#143A1F] px-5 py-3 text-sm font-bold text-[#143A1F]"
+                >
+                  Ver arquitetos parceiros
+                </Link>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* FAQ com Schema */}
         <section>

--- a/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/[cidade]/[categoria]/page.tsx
@@ -2,11 +2,13 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import {
+  NIU_OFFICIAL_PARTNER,
   PARTNER_CATEGORY_SEO,
   PARTNER_CITY_SEO,
   getPartnerCategoryBySlug,
   getPartnerCityBySlug,
   partnerSeoPath,
+  shouldShowNiuForPartnerSeo,
 } from '@/lib/partner-seo'
 import { limitSeoStaticItems } from '@/lib/ssg-runtime'
 import { PartnerLeadQualifier } from '../../../especialistas/[slug]/PartnerLeadQualifier'
@@ -36,6 +38,7 @@ interface Specialist {
   featuredWeight?: number | null
   tags?: string[] | null
   landingPage?: { segmentLabel?: string } | null
+  profilePath?: string | null
 }
 
 function waHref(s: Specialist): string | null {
@@ -98,10 +101,22 @@ export async function generateMetadata({
   const title = `${cat.label} em ${city.city}/${city.state} | Empresas Parceiras AgoraEncontrei`
   const description = `${cat.description} Encontre ${cat.singular} em ${city.city}/${city.state} e receba atendimento pelo AgoraEncontrei.`
   const canonical = `${WEB_URL}${partnerSeoPath(city.slug, cat.slug)}`
+  const niuRelevant = shouldShowNiuForPartnerSeo(cat.slug)
 
   return {
     title,
     description,
+    keywords: niuRelevant
+      ? [
+          `${cat.singular} em ${city.city}`,
+          `arquitetura em ${city.city}`,
+          `projeto arquitetonico em ${city.city}`,
+          `projetos de casas em ${city.city}`,
+          `construcao em ${city.city}`,
+          'NIU Arquitetura',
+          'AgoraEncontrei empresas parceiras',
+        ]
+      : undefined,
     alternates: { canonical },
     openGraph: {
       title,
@@ -123,8 +138,24 @@ export default async function PartnerSeoPage({
   const cat = getPartnerCategoryBySlug(categoria)
   if (!city || !cat) notFound()
 
-  const specialists = await fetchSpecialists(city.city, cat.value)
+  const fetchedSpecialists = await fetchSpecialists(city.city, cat.value)
+  const officialMatches: Specialist[] = shouldShowNiuForPartnerSeo(cat.slug)
+    ? [{
+        ...NIU_OFFICIAL_PARTNER,
+        category: cat.value,
+        categoryLabel: cat.label,
+        city: city.city,
+        state: city.state,
+        tags: [...NIU_OFFICIAL_PARTNER.tags],
+      }]
+    : []
+  const fetchedSlugs = new Set(fetchedSpecialists.map(s => s.slug))
+  const specialists = [
+    ...officialMatches.filter(s => !fetchedSlugs.has(s.slug)),
+    ...fetchedSpecialists,
+  ]
   const leadTarget = specialists[0]
+  const niuRelevant = shouldShowNiuForPartnerSeo(cat.slug)
 
   const itemListSchema = {
     '@context': 'https://schema.org',
@@ -133,7 +164,7 @@ export default async function PartnerSeoPage({
     itemListElement: specialists.map((s, index) => ({
       '@type': 'ListItem',
       position: index + 1,
-      url: `${WEB_URL}/especialistas/${s.slug}`,
+      url: `${WEB_URL}${s.profilePath || `/especialistas/${s.slug}`}`,
       name: s.name,
     })),
   }
@@ -226,6 +257,32 @@ export default async function PartnerSeoPage({
           ))}
         </div>
 
+        {niuRelevant && (
+          <section className="mb-8 rounded-3xl border border-[#C9A84C]/25 bg-white p-6 shadow-sm md:p-8">
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#9A7A23]">
+              NIU em busca organica
+            </p>
+            <div className="mt-3 grid gap-5 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+              <div>
+                <h2 className="text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
+                  NIU Arquitetura posicionada para buscas por arquitetura, projetos, reforma e construcao.
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-gray-600">
+                  Esta pagina conecta a NIU a termos como arquiteto, escritorio de arquitetura, projeto arquitetonico,
+                  projetos de casas, interiores, reforma e construcao em {city.city}/{city.state}. O objetivo e criar
+                  uma trilha clara entre pesquisa no Google, AgoraEncontrei, briefing inteligente e contato no WhatsApp.
+                </p>
+              </div>
+              <Link
+                href="/parceiros/niu-arquitetura"
+                className="inline-flex items-center justify-center rounded-xl bg-[#143A1F] px-5 py-3 text-sm font-bold text-white transition hover:bg-[#0E2A15]"
+              >
+                Ver landing oficial da NIU
+              </Link>
+            </div>
+          </section>
+        )}
+
         <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h2 className="text-2xl font-bold text-[#143A1F]" style={{ fontFamily: 'Georgia, serif' }}>
@@ -286,7 +343,7 @@ export default async function PartnerSeoPage({
                   <p className="mt-1 text-xs font-semibold text-[#C9A84C]">{segLabel}</p>
                   {s.bio && <p className="mt-3 line-clamp-3 text-xs leading-5 text-gray-500">{s.bio}</p>}
                   <div className="mt-5 flex gap-2">
-                    <Link href={`/especialistas/${s.slug}`} className="flex-1 rounded-lg bg-[#143A1F] px-3 py-2 text-xs font-bold text-white">
+                    <Link href={s.profilePath || `/especialistas/${s.slug}`} className="flex-1 rounded-lg bg-[#143A1F] px-3 py-2 text-xs font-bold text-white">
                       Ver perfil
                     </Link>
                     {wa && (

--- a/apps/web/src/app/(public)/empresas-parceiras/page.tsx
+++ b/apps/web/src/app/(public)/empresas-parceiras/page.tsx
@@ -9,6 +9,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import {
+  NIU_OFFICIAL_PARTNER,
   PARTNER_CATEGORY_SEO,
   PARTNER_CITY_SEO,
   PARTNER_INTENT_PAGES,
@@ -59,23 +60,8 @@ interface Specialist {
 
 const OFFICIAL_PARTNERS: Specialist[] = [
   {
-    id: 'seed_niu_arquitetura',
-    slug: 'niu-arquitetura',
-    name: 'NIU Arquitetura',
-    category: 'ARQUITETO',
-    categoryLabel: 'Arquitetura',
-    city: 'Franca',
-    bio: 'Escritorio de Arquitetura e Design fundado em 2018 por Yuri Miranda e Douglas Costa. Arquitetura contemporanea com brasilidade, geometria e materialidade.',
-    photoUrl: '/partners/niu/niu-logo.jpg',
-    logoUrl: '/partners/niu/niu-logo.jpg',
-    whatsapp: '+55 16 99264-6070',
-    phone: '+55 16 99460-8222',
-    adPlan: 'PREMIUM',
-    isFeatured: true,
-    featuredWeight: 1000,
-    tags: ['Arquitetura residencial', 'Interiores', 'Arquitetura comercial', 'Reformas', 'Franca SP'],
-    landingPage: { segmentLabel: 'Arquitetura e Design' },
-    profilePath: '/parceiros/niu-arquitetura',
+    ...NIU_OFFICIAL_PARTNER,
+    tags: [...NIU_OFFICIAL_PARTNER.tags],
   },
 ]
 

--- a/apps/web/src/app/(public)/parceiros/niu-arquitetura/page.tsx
+++ b/apps/web/src/app/(public)/parceiros/niu-arquitetura/page.tsx
@@ -13,6 +13,7 @@ import {
   Phone,
   Sparkles,
 } from 'lucide-react'
+import { NIU_SEARCH_INTENT_LINKS } from '@/lib/partner-seo'
 import { PartnerLeadQualifier } from '../../especialistas/[slug]/PartnerLeadQualifier'
 
 const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL ?? 'https://www.agoraencontrei.com.br'
@@ -122,8 +123,15 @@ export const metadata: Metadata = {
     'arquiteto Franca SP',
     'arquitetura contemporanea',
     'projeto arquitetonico',
+    'projetos de casas',
+    'projeto residencial alto padrao',
+    'construcao civil Franca SP',
+    'reforma residencial Franca SP',
+    'escritorio de arquitetura Brasil',
+    'arquiteto online Brasil',
     'design de interiores',
     'arquitetura residencial',
+    'arquitetura comercial',
     'AgoraEncontrei parceiro oficial',
   ],
   alternates: { canonical: PAGE_URL },
@@ -438,6 +446,32 @@ export default function NiuArquiteturaPage() {
               { name: 'Consultoria inicial online', description: 'Triagem de objetivo, medidas, fotos e viabilidade.' },
             ]}
           />
+        </div>
+      </section>
+
+      <section className="bg-white px-5 py-16 sm:px-8 lg:py-24">
+        <div className="mx-auto max-w-7xl">
+          <div className="grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.25em] text-[#8c8173]">presenca organica</p>
+              <h2 className="mt-4 text-4xl font-semibold tracking-[-0.03em] sm:text-5xl">
+                Por que divulgar a NIU no AgoraEncontrei faz sentido.
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-[#625d56]">
+                A landing oficial nao fica isolada. Ela e conectada a paginas de busca por cidade, categoria e intencao:
+                arquitetura, arquiteto, projetos de casas, design de interiores, reforma, construcao e atendimento online.
+                Assim, quem pesquisa por uma necessidade entra no AgoraEncontrei e encontra a NIU como parceira destacada.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {NIU_SEARCH_INTENT_LINKS.map(item => (
+                <Link key={item.href} href={item.href} className="border border-[#d8d1c6] bg-[#f5f2ec] p-5 transition hover:border-[#11110f] hover:bg-white">
+                  <p className="text-sm font-semibold text-[#11110f]">{item.title}</p>
+                  <p className="mt-2 text-xs leading-5 text-[#625d56]">{item.description}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 

--- a/apps/web/src/lib/partner-seo.ts
+++ b/apps/web/src/lib/partner-seo.ts
@@ -116,6 +116,81 @@ export const PARTNER_CITY_SEO = [
 export type PartnerCategorySeo = (typeof PARTNER_CATEGORY_SEO)[number]
 export type PartnerCitySeo = (typeof PARTNER_CITY_SEO)[number]
 
+export const NIU_OFFICIAL_PARTNER = {
+  id: 'seed_niu_arquitetura',
+  slug: 'niu-arquitetura',
+  name: 'NIU Arquitetura',
+  category: 'ARQUITETO',
+  categoryLabel: 'Arquitetura e Design',
+  city: 'Franca',
+  state: 'SP',
+  bio: 'Escritorio de Arquitetura e Design fundado em 2018 por Yuri Miranda e Douglas Costa. Projetos residenciais, interiores, reformas, arquitetura comercial e estudos de alto padrao para Franca, regiao e atendimento online no Brasil.',
+  photoUrl: '/partners/niu/niu-logo.jpg',
+  logoUrl: '/partners/niu/niu-logo.jpg',
+  whatsapp: '+55 16 99264-6070',
+  phone: '+55 16 99460-8222',
+  plan: 'VIP',
+  adPlan: 'PREMIUM',
+  isFeatured: true,
+  featuredWeight: 1000,
+  tags: [
+    'Arquitetura residencial',
+    'Arquitetura comercial',
+    'Projeto arquitetonico',
+    'Projetos de casas',
+    'Design de interiores',
+    'Reformas',
+    'Construcao',
+    'Franca SP',
+    'Brasil',
+  ],
+  landingPage: { segmentLabel: 'Arquitetura e Design' },
+  profilePath: '/parceiros/niu-arquitetura',
+} as const
+
+export const NIU_RELATED_CATEGORY_SLUGS = new Set([
+  'arquitetos',
+  'designers-de-interiores',
+  'servicos-para-imoveis',
+])
+
+export function shouldShowNiuForPartnerSeo(categorySlug: string) {
+  return NIU_RELATED_CATEGORY_SLUGS.has(categorySlug)
+}
+
+export const NIU_SEARCH_INTENT_LINKS = [
+  {
+    href: '/empresas-parceiras/franca-sp/arquitetos',
+    title: 'Arquitetos em Franca/SP',
+    description: 'Pagina local para quem busca arquiteto, projeto arquitetonico, interiores, reforma e construcao em Franca.',
+  },
+  {
+    href: '/empresas-parceiras/ribeirao-preto-sp/arquitetos',
+    title: 'Arquitetos em Ribeirao Preto/SP',
+    description: 'Vitrine regional para demanda de arquitetura residencial, comercial e atendimento online.',
+  },
+  {
+    href: '/empresas-parceiras/sao-paulo-sp/arquitetos',
+    title: 'Arquitetos em Sao Paulo/SP',
+    description: 'Presenca em busca nacional para pessoas comparando escritorios e projetos de alto padrao.',
+  },
+  {
+    href: '/empresas-parceiras/campinas-sp/arquitetos',
+    title: 'Arquitetos em Campinas/SP',
+    description: 'Pagina de descoberta para projetos, reformas, interiores e construcao em cidades estrategicas.',
+  },
+  {
+    href: '/empresas-parceiras/franca-sp/designers-de-interiores',
+    title: 'Design de interiores em Franca/SP',
+    description: 'Intencao complementar para ambientes, materiais, marcenaria, iluminacao e valorizacao do imovel.',
+  },
+  {
+    href: '/parceiros/niu-arquitetura',
+    title: 'Landing oficial da NIU',
+    description: 'Pagina completa com historia, projetos, briefing inteligente, contatos e prova visual.',
+  },
+] as const
+
 export function getPartnerCategoryBySlug(slug: string) {
   return PARTNER_CATEGORY_SEO.find(c => c.slug === slug)
 }
@@ -161,5 +236,20 @@ export const PARTNER_INTENT_PAGES = [
     href: '/empresas-parceiras/franca-sp/fotografos-imobiliarios',
     title: 'Fotografia imobiliaria',
     description: 'Imagens profissionais para vender e alugar melhor.',
+  },
+  {
+    href: '/empresas-parceiras/ribeirao-preto-sp/arquitetos',
+    title: 'Arquitetura em Ribeirao Preto/SP',
+    description: 'Busca regional por projeto arquitetonico, interiores e reformas.',
+  },
+  {
+    href: '/empresas-parceiras/sao-paulo-sp/arquitetos',
+    title: 'Arquitetos para projetos no Brasil',
+    description: 'Vitrine nacional para quem procura escritorio de arquitetura online.',
+  },
+  {
+    href: '/parceiros/niu-arquitetura',
+    title: 'NIU Arquitetura em destaque',
+    description: 'Primeiro parceiro oficial de arquitetura no AgoraEncontrei.',
   },
 ] as const


### PR DESCRIPTION
## Resumo
- centraliza os dados publicos da NIU como parceiro oficial reutilizavel
- mostra a NIU como destaque em paginas SEO de empresas parceiras para arquitetura, design de interiores e servicos para imoveis
- adiciona bloco de valor comercial na landing da NIU com links internos para buscas estrategicas
- conecta paginas programaticas de servicos por cidade, como `/sp/franca/servicos/arquiteto`, a NIU em termos relacionados a arquitetura, projetos e construcao

## Validacao
- `pnpm.cmd --filter @agoraencontrei/web typecheck`
- `pnpm.cmd --filter @agoraencontrei/web build`
- HTTP local em `/parceiros/niu-arquitetura`
- HTTP local em `/empresas-parceiras/franca-sp/arquitetos`
- HTTP local em `/empresas-parceiras/sao-paulo-sp/arquitetos`
- HTTP local em `/sp/franca/servicos/arquiteto`
- Playwright via Chrome local em desktop/mobile nas rotas acima

## Observacao
Esta etapa melhora indexacao, links internos, schema/metadados e descoberta organica. Ranking top 1 depende tambem de crawl do Google, tempo de indexacao, autoridade do dominio, backlinks, conteudo recorrente e sinais externos.