### PR TITLE
feat(auctions): arquivo histórico de leilões — ciclo de vida, snapshots, documentos (edital/matrícula) e desfecho

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,6 +46,7 @@
     "openai": "^6.42.0",
     "pino-pretty": "^13.0.0",
     "playwright-core": "^1.61.0",
+    "unpdf": "^1.6.2",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.5"
   },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -304,6 +304,10 @@ async function runMigrations(prisma: any) {
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "lastSeenAt" TIMESTAMPTZ`,
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "disappearedAt" TIMESTAMPTZ`,
     `CREATE INDEX IF NOT EXISTS auctions_disappeared_idx ON auctions("disappearedAt")`,
+    // ── Desfecho do leilão (arrematado por quanto / deserto) ──────────────────
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "soldDate" TIMESTAMPTZ`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "outcomeCapturedAt" TIMESTAMPTZ`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "outcomeAttempts" INTEGER NOT NULL DEFAULT 0`,
     // ── Snapshots temporais (histórico imutável de cada mudança observada) ────
     `CREATE TABLE IF NOT EXISTS auction_snapshots (
       id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -279,6 +279,46 @@ async function runMigrations(prisma: any) {
     `CREATE INDEX IF NOT EXISTS auctions_discount_idx ON auctions("discountPercent")`,
     `CREATE INDEX IF NOT EXISTS auctions_created_idx ON auctions("createdAt" DESC)`,
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "streetViewUrl" TEXT`,
+    // ── Reconciliação: colunas presentes no schema Prisma mas ausentes do
+    //    CREATE TABLE acima. O scraper já escreve algumas destas (registryNumber,
+    //    registryOffice, debtorName, documentsUrls, features) — sem estes ALTERs
+    //    uma base recriada do zero quebraria a ingestão. Idempotente.
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "auctioneerUrl" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "auctioneerCnpj" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "auctioneerJucesp" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "itbiEstimate" DECIMAL(12,2)`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "registryEstimate" DECIMAL(12,2)`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "lawyerEstimate" DECIMAL(12,2)`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "evictionEstimate" DECIMAL(12,2)`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS judge TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "registryNumber" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "registryOffice" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "debtorName" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "creditorName" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS restrictions TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "bankBranch" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "documentsUrls" TEXT[] NOT NULL DEFAULT '{}'`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS features TEXT[] NOT NULL DEFAULT '{}'`,
+    // ── Ciclo de vida / arquivo histórico ────────────────────────────────────
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "firstSeenAt" TIMESTAMPTZ`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "lastSeenAt" TIMESTAMPTZ`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "disappearedAt" TIMESTAMPTZ`,
+    `CREATE INDEX IF NOT EXISTS auctions_disappeared_idx ON auctions("disappearedAt")`,
+    // ── Snapshots temporais (histórico imutável de cada mudança observada) ────
+    `CREATE TABLE IF NOT EXISTS auction_snapshots (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "auctionId" TEXT NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+      "capturedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      "scrapedHash" TEXT,
+      status TEXT,
+      "appraisalValue" DECIMAL(14,2),
+      "minimumBid" DECIMAL(14,2),
+      "currentBid" DECIMAL(14,2),
+      "soldValue" DECIMAL(14,2),
+      "discountPercent" DOUBLE PRECISION,
+      raw JSONB NOT NULL DEFAULT '{}'
+    )`,
+    `CREATE INDEX IF NOT EXISTS auction_snapshots_auction_idx ON auction_snapshots("auctionId", "capturedAt")`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_source_idx ON scraper_runs(source)`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_started_idx ON scraper_runs("startedAt")`,
   ]

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -319,6 +319,23 @@ async function runMigrations(prisma: any) {
       raw JSONB NOT NULL DEFAULT '{}'
     )`,
     `CREATE INDEX IF NOT EXISTS auction_snapshots_auction_idx ON auction_snapshots("auctionId", "capturedAt")`,
+    // ── Documentos arquivados (edital, matrícula, laudo, ata) → S3 ────────────
+    `CREATE TABLE IF NOT EXISTS auction_documents (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "auctionId" TEXT NOT NULL REFERENCES auctions(id) ON DELETE CASCADE,
+      type TEXT NOT NULL DEFAULT 'OUTRO',
+      "sourceUrl" TEXT NOT NULL,
+      "s3Key" TEXT, "s3Url" TEXT,
+      sha256 TEXT NOT NULL,
+      "sizeBytes" INTEGER,
+      "mimeType" TEXT,
+      "extractedText" TEXT,
+      status TEXT NOT NULL DEFAULT 'ARCHIVED',
+      "capturedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS auction_documents_auction_sha_key ON auction_documents("auctionId", sha256)`,
+    `CREATE INDEX IF NOT EXISTS auction_documents_auction_idx ON auction_documents("auctionId")`,
+    `CREATE INDEX IF NOT EXISTS auction_documents_type_idx ON auction_documents(type)`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_source_idx ON scraper_runs(source)`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_started_idx ON scraper_runs("startedAt")`,
   ]

--- a/apps/api/src/services/auction-archive.service.ts
+++ b/apps/api/src/services/auction-archive.service.ts
@@ -51,8 +51,9 @@ export function extractRegistryInfo(text: string): {
   const out: { registryNumber?: string; registryOffice?: string; processNumber?: string } = {}
   if (!text) return out
 
-  // Matrícula: "matrícula nº 12.345", "matricula n. 12345", "matrícula 90123"
-  const mat = text.match(/matr[íi]cula\s*(?:imobili[áa]ria\s*)?(?:n[º°.]*\s*)?([\d][\d.]{2,})/i)
+  // Matrícula: "matrícula nº 12.345", "matricula no 12345", "matrícula n. 90123"
+  // n[º°o.]{0,3} tolera nº / no / n° / n. antes do número.
+  const mat = text.match(/matr[íi]cula\s*(?:imobili[áa]ria\s*)?(?:n[º°o.]{0,3}\s*)?([\d][\d.]{2,})/i)
   if (mat) {
     const num = mat[1].replace(/\./g, '').replace(/\D/g, '')
     if (num.length >= 3) out.registryNumber = num
@@ -69,6 +70,24 @@ export function extractRegistryInfo(text: string): {
   if (proc) out.processNumber = proc[0]
 
   return out
+}
+
+function isPdf(buf: Buffer, mime?: string | null): boolean {
+  if (mime && /pdf/.test(mime)) return true
+  return buf.length > 4 && buf.subarray(0, 5).toString('latin1') === '%PDF-'
+}
+
+/** Extrai texto de um PDF (unpdf, JS puro). Best-effort — null se falhar. */
+async function extractPdfText(buf: Buffer): Promise<string | null> {
+  try {
+    const { extractText, getDocumentProxy } = await import('unpdf')
+    const pdf = await getDocumentProxy(new Uint8Array(buf))
+    const { text } = await extractText(pdf, { mergePages: true })
+    const s = (Array.isArray(text) ? text.join('\n') : text || '').trim()
+    return s ? s.slice(0, MAX_TEXT_CHARS) : null
+  } catch {
+    return null
+  }
 }
 
 function extForMime(mime?: string): string {
@@ -138,6 +157,10 @@ export async function archiveAuctionDocuments(
       if (mimeType && /text\/(html|plain)/.test(mimeType)) {
         extractedText = buf.toString('utf-8').slice(0, MAX_TEXT_CHARS)
         collectedText.push(extractedText)
+      } else if (isPdf(buf, mimeType)) {
+        // Editais em geral são PDF — extrai o texto para achar a matrícula.
+        extractedText = await extractPdfText(buf)
+        if (extractedText) collectedText.push(extractedText)
       }
 
       let s3Key: string | null = null

--- a/apps/api/src/services/auction-archive.service.ts
+++ b/apps/api/src/services/auction-archive.service.ts
@@ -1,0 +1,212 @@
+/**
+ * Auction Archive Service — arquivamento durável de documentos públicos de leilão.
+ *
+ * Os links de edital/matrícula nos sites dos leiloeiros apodrecem assim que o
+ * leilão encerra. Aqui baixamos o binário da fonte enquanto ainda está no ar,
+ * calculamos o sha256 (dedup + versionamento), subimos para o S3 e registramos
+ * em auction_documents. Quando o documento é texto/HTML, extraímos nº de
+ * matrícula, cartório e processo e preenchemos o leilão se estiverem vazios.
+ *
+ * Best-effort e idempotente: mesmo conteúdo (sha256) nunca duplica; rodar de
+ * novo é seguro. Sem S3 configurado, ainda gravamos o registro + texto + hash
+ * com status PENDING para re-arquivar depois.
+ */
+
+import crypto from 'crypto'
+import type { PrismaClient } from '@prisma/client'
+import { s3Service } from './s3.service.js'
+
+export type AuctionDocType = 'EDITAL' | 'MATRICULA' | 'LAUDO' | 'ATA' | 'OUTRO'
+
+export interface ArchiveDeps {
+  fetchImpl?: typeof fetch
+  s3?: {
+    isConfigured: () => boolean
+    upload: (key: string, body: Buffer, contentType: string) => Promise<string>
+  }
+}
+
+const MAX_BYTES = 25 * 1024 * 1024 // 25MB — evita baixar arquivos gigantes
+const MAX_TEXT_CHARS = 200_000
+
+/** Classifica o tipo do documento pelo nome/URL. */
+export function classifyDocType(url: string): AuctionDocType {
+  const u = url.toLowerCase()
+  if (/matr[ií]cula|registro.?imovel|registro.?de.?im[óo]veis/.test(u)) return 'MATRICULA'
+  if (/edital/.test(u)) return 'EDITAL'
+  if (/laudo|avalia[çc][ãa]o/.test(u)) return 'LAUDO'
+  if (/\bata\b|auto.?(de)?.?arremat|arremata[çc][ãa]o/.test(u)) return 'ATA'
+  return 'OUTRO'
+}
+
+/**
+ * Extrai nº de matrícula, cartório e processo de um texto de edital.
+ * Determinístico (regex) — sem IA, testável offline.
+ */
+export function extractRegistryInfo(text: string): {
+  registryNumber?: string
+  registryOffice?: string
+  processNumber?: string
+} {
+  const out: { registryNumber?: string; registryOffice?: string; processNumber?: string } = {}
+  if (!text) return out
+
+  // Matrícula: "matrícula nº 12.345", "matricula n. 12345", "matrícula 90123"
+  const mat = text.match(/matr[íi]cula\s*(?:imobili[áa]ria\s*)?(?:n[º°.]*\s*)?([\d][\d.]{2,})/i)
+  if (mat) {
+    const num = mat[1].replace(/\./g, '').replace(/\D/g, '')
+    if (num.length >= 3) out.registryNumber = num
+  }
+
+  // Cartório / Oficial de Registro de Imóveis (frase curta)
+  const off = text.match(
+    /(\d+[ºoª]?\s*)?(?:cart[óo]rio|of[íi]cio|oficial)[^.\n,;]{0,50}registro\s+de\s+im[óo]veis(?:\s+d[aeo]\s+[^.\n,;]{0,40})?/i,
+  )
+  if (off) out.registryOffice = off[0].replace(/\s+/g, ' ').trim().slice(0, 120)
+
+  // Processo no padrão CNJ: NNNNNNN-DD.AAAA.J.TR.OOOO
+  const proc = text.match(/\d{7}-\d{2}\.\d{4}\.\d\.\d{2}\.\d{4}/)
+  if (proc) out.processNumber = proc[0]
+
+  return out
+}
+
+function extForMime(mime?: string): string {
+  if (!mime) return 'bin'
+  if (mime.includes('pdf')) return 'pdf'
+  if (mime.includes('html')) return 'html'
+  if (mime.includes('plain')) return 'txt'
+  if (mime.includes('jpeg')) return 'jpg'
+  if (mime.includes('png')) return 'png'
+  return 'bin'
+}
+
+/**
+ * Arquiva todos os documentos públicos de um leilão (editalUrl + documentsUrls).
+ * Retorna a contagem por resultado.
+ */
+export async function archiveAuctionDocuments(
+  prisma: PrismaClient,
+  auctionId: string,
+  deps: ArchiveDeps = {},
+): Promise<{ archived: number; skipped: number; failed: number }> {
+  const fetchImpl = deps.fetchImpl || fetch
+  const s3 = deps.s3 || s3Service
+
+  const auction = await prisma.auction.findUnique({
+    where: { id: auctionId },
+    select: {
+      id: true, editalUrl: true, documentsUrls: true,
+      registryNumber: true, registryOffice: true, processNumber: true,
+    },
+  })
+  if (!auction) return { archived: 0, skipped: 0, failed: 0 }
+
+  // URLs únicas: edital (sempre EDITAL) + documentos avulsos.
+  const urls = new Map<string, AuctionDocType>()
+  if (auction.editalUrl) urls.set(auction.editalUrl, 'EDITAL')
+  for (const u of auction.documentsUrls || []) {
+    if (u && !urls.has(u)) urls.set(u, classifyDocType(u))
+  }
+
+  let archived = 0, skipped = 0, failed = 0
+  const collectedText: string[] = []
+
+  for (const [url, type] of urls) {
+    try {
+      const res = await fetchImpl(url)
+      if (!res.ok) { failed++; continue }
+
+      const buf = Buffer.from(await res.arrayBuffer())
+      if (buf.length === 0 || buf.length > MAX_BYTES) { skipped++; continue }
+
+      const sha256 = crypto.createHash('sha256').update(buf).digest('hex')
+
+      // Dedup: mesmo conteúdo já arquivado para este leilão → pula.
+      const existing = await prisma.auctionDocument.findUnique({
+        where: { auctionId_sha256: { auctionId, sha256 } },
+      }).catch(() => null)
+      if (existing) {
+        if (existing.extractedText) collectedText.push(existing.extractedText)
+        skipped++
+        continue
+      }
+
+      const mimeType = (res.headers.get('content-type') || '').split(';')[0] || null
+
+      let extractedText: string | null = null
+      if (mimeType && /text\/(html|plain)/.test(mimeType)) {
+        extractedText = buf.toString('utf-8').slice(0, MAX_TEXT_CHARS)
+        collectedText.push(extractedText)
+      }
+
+      let s3Key: string | null = null
+      let s3Url: string | null = null
+      let status = 'PENDING'
+      if (s3.isConfigured()) {
+        s3Key = `auctions/${auctionId}/${type.toLowerCase()}-${sha256.slice(0, 12)}.${extForMime(mimeType || undefined)}`
+        try {
+          s3Url = await s3.upload(s3Key, buf, mimeType || 'application/octet-stream')
+          status = 'ARCHIVED'
+        } catch {
+          s3Key = null
+          status = 'FAILED'
+        }
+      }
+
+      await prisma.auctionDocument.create({
+        data: {
+          auctionId, type, sourceUrl: url,
+          s3Key, s3Url, sha256,
+          sizeBytes: buf.length, mimeType,
+          extractedText, status,
+        },
+      }).then(() => { archived++ }).catch(() => { skipped++ }) // corrida no unique → skip
+    } catch {
+      failed++
+    }
+  }
+
+  // Preenche matrícula/cartório/processo se o leilão estiver sem eles.
+  if ((!auction.registryNumber || !auction.registryOffice || !auction.processNumber) && collectedText.length) {
+    const info = extractRegistryInfo(collectedText.join('\n'))
+    const patch: Record<string, string> = {}
+    if (!auction.registryNumber && info.registryNumber) patch.registryNumber = info.registryNumber
+    if (!auction.registryOffice && info.registryOffice) patch.registryOffice = info.registryOffice
+    if (!auction.processNumber && info.processNumber) patch.processNumber = info.processNumber
+    if (Object.keys(patch).length) {
+      await prisma.auction.update({ where: { id: auctionId }, data: patch }).catch(() => {})
+    }
+  }
+
+  return { archived, skipped, failed }
+}
+
+/**
+ * Passe agendado: arquiva lotes de leilões que têm documentos mas ainda não
+ * foram arquivados. Sequencial e limitado — throttle natural (roda no cron).
+ */
+export async function runAuctionArchiveBatch(
+  prisma: PrismaClient,
+  limit = 20,
+  deps: ArchiveDeps = {},
+): Promise<{ processed: number; archived: number }> {
+  const pending = await prisma.auction.findMany({
+    where: {
+      AND: [
+        { OR: [{ editalUrl: { not: null } }, { documentsUrls: { isEmpty: false } }] },
+        { documents: { none: {} } },
+      ],
+    },
+    select: { id: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let archived = 0
+  for (const a of pending) {
+    const r = await archiveAuctionDocuments(prisma, a.id, deps)
+    archived += r.archived
+  }
+  return { processed: pending.length, archived }
+}

--- a/apps/api/src/services/auction-monitor.service.ts
+++ b/apps/api/src/services/auction-monitor.service.ts
@@ -79,7 +79,10 @@ export class AuctionMonitorService {
     if (staleAuctions.length > 0) {
       const result = await this.prisma.auction.updateMany({
         where: { id: { in: staleAuctions.map(a => a.id) } },
-        data: { status: 'SUSPENDED' },
+        // Saiu da fonte (sem sighting > 7 dias): marca deslistagem. O registro
+        // é preservado como histórico — nunca deletamos. disappearedAt é o
+        // gatilho da futura captura de desfecho (arrematado por quanto).
+        data: { status: 'SUSPENDED', disappearedAt: now },
       })
       suspended = result.count
       console.log(`[AuctionMonitor] ${suspended} leilões marcados como SUSPENDED (sem atualização > 7 dias)`)

--- a/apps/api/src/services/auction-outcome.service.ts
+++ b/apps/api/src/services/auction-outcome.service.ts
@@ -1,0 +1,169 @@
+/**
+ * Auction Outcome Service — captura do desfecho do leilão ("arrematado por quanto").
+ *
+ * Quando um leilão sai da listagem da fonte (disappearedAt) ou sua data passa, a
+ * página de detalhe do lote (sourceUrl) normalmente sobrevive mais tempo e passa
+ * a exibir o resultado: "ARREMATADO por R$ X", "VENDIDO", "DESERTO", "REVOGADO".
+ * Re-visitamos essa página e extraímos o desfecho — abordagem genérica que cobre
+ * a maioria dos leiloeiros sem scraper de listagem site-a-site.
+ *
+ * LGPD: capturamos apenas o VALOR do arremate (dado público). Nome/CPF do
+ * arrematante NÃO são persistidos.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+export type Outcome = 'SOLD' | 'DESERTED' | 'CANCELLED' | 'INCONCLUSIVE'
+
+export interface OutcomeDeps {
+  fetchImpl?: typeof fetch
+}
+
+const MAX_ATTEMPTS = 5
+
+/** Converte "250.000,00" / "R$ 1.250.000,50" em número. */
+export function parseBRCurrency(s: string): number | null {
+  const m = s.match(/([\d.]+,\d{2})/)
+  if (!m) return null
+  const n = Number(m[1].replace(/\./g, '').replace(',', '.'))
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Extrai o desfecho de um texto/HTML da página do lote. Determinístico e testável.
+ * Prioridade: arrematado > deserto > cancelado/revogado.
+ */
+export function parseOutcome(text: string): { status: Outcome; soldValue?: number } {
+  if (!text) return { status: 'INCONCLUSIVE' }
+  const t = text.replace(/\s+/g, ' ')
+
+  // Arrematado / vendido — tenta capturar o valor próximo do marcador.
+  if (/arrematad[oa]|arremata[çc][ãa]o\s+(?:realizada|conclu[íi]da)|lote\s+vendid[oa]|\bvendid[oa]\b/i.test(t)) {
+    // "arrematado por R$ 250.000,00" (valor após o marcador)
+    // Obs.: não usar [^R$] com a flag /i — ela também exclui o 'r' minúsculo
+    // (ex.: "por"), cortando o match antes do "R$". Usamos quantificador lazy.
+    let soldValue: number | null = null
+    const near = t.match(/(?:arrematad[oa]|vendid[oa]|arremata[çc][ãa]o)[\s\S]{0,60}?R\$\s*([\d.]+,\d{2})/i)
+    if (near) soldValue = parseBRCurrency(near[1])
+    // fallback: "valor da arrematação: R$ X" / "lance vencedor R$ X"
+    if (soldValue == null) {
+      const alt = t.match(/(?:valor\s+d[ae]\s+arremata[çc][ãa]o|lance\s+vencedor|valor\s+arrematad[oa])[\s\S]{0,30}?R\$\s*([\d.]+,\d{2})/i)
+      if (alt) soldValue = parseBRCurrency(alt[1])
+    }
+    return soldValue != null ? { status: 'SOLD', soldValue } : { status: 'SOLD' }
+  }
+
+  if (/\bdeserto\b|leil[ãa]o\s+negativo|sem\s+lances?|n[ãa]o\s+houve\s+lance/i.test(t)) {
+    return { status: 'DESERTED' }
+  }
+
+  if (/\brevogad[oa]\b|\bcancelad[oa]\b|leil[ãa]o\s+suspenso|\bsobrestad[oa]\b/i.test(t)) {
+    return { status: 'CANCELLED' }
+  }
+
+  return { status: 'INCONCLUSIVE' }
+}
+
+/**
+ * Re-visita o sourceUrl de um leilão e captura o desfecho. Best-effort:
+ * conclusivo → grava status/soldValue/soldDate + snapshot + lance vencedor;
+ * inconclusivo → incrementa outcomeAttempts (limite anti-hammer).
+ */
+export async function captureAuctionOutcome(
+  prisma: PrismaClient,
+  auctionId: string,
+  deps: OutcomeDeps = {},
+): Promise<{ outcome: Outcome; soldValue?: number }> {
+  const fetchImpl = deps.fetchImpl || fetch
+  const auction = await prisma.auction.findUnique({
+    where: { id: auctionId },
+    select: { id: true, sourceUrl: true, soldValue: true, currentBid: true, status: true },
+  })
+  if (!auction) return { outcome: 'INCONCLUSIVE' }
+
+  const bumpAttempt = () =>
+    prisma.auction.update({ where: { id: auctionId }, data: { outcomeAttempts: { increment: 1 } } }).catch(() => {})
+
+  if (!auction.sourceUrl) { await bumpAttempt(); return { outcome: 'INCONCLUSIVE' } }
+
+  let text = ''
+  try {
+    const res = await fetchImpl(auction.sourceUrl)
+    if (!res.ok) { await bumpAttempt(); return { outcome: 'INCONCLUSIVE' } }
+    text = await res.text()
+  } catch {
+    await bumpAttempt()
+    return { outcome: 'INCONCLUSIVE' }
+  }
+
+  const parsed = parseOutcome(text)
+  if (parsed.status === 'INCONCLUSIVE') { await bumpAttempt(); return { outcome: 'INCONCLUSIVE' } }
+
+  const now = new Date()
+  const fallbackValue = Number(auction.soldValue ?? auction.currentBid ?? 0) || undefined
+  const soldValue = parsed.status === 'SOLD' ? (parsed.soldValue ?? fallbackValue) : undefined
+
+  await prisma.auction.update({
+    where: { id: auctionId },
+    data: {
+      status: parsed.status as any,
+      outcomeCapturedAt: now,
+      outcomeAttempts: { increment: 1 },
+      ...(parsed.status === 'SOLD' && soldValue ? { soldValue, soldDate: now } : {}),
+    },
+  }).catch(() => {})
+
+  // Snapshot do desfecho na linha do tempo histórica (best-effort).
+  await prisma.auctionSnapshot.create({
+    data: {
+      auctionId,
+      status: parsed.status,
+      soldValue: parsed.status === 'SOLD' ? soldValue : undefined,
+      raw: { outcome: parsed.status, source: 'sourceUrl-refetch' },
+    },
+  }).catch(() => {})
+
+  // Lance vencedor (só o valor — sem dados pessoais do arrematante).
+  if (parsed.status === 'SOLD' && soldValue) {
+    const hasWinning = await prisma.auctionBid.findFirst({ where: { auctionId, isWinning: true } }).catch(() => null)
+    if (!hasWinning) {
+      await prisma.auctionBid.create({
+        data: { auctionId, round: 2, bidValue: soldValue, isWinning: true, bidDate: now, metadata: { source: 'outcome-capture' } },
+      }).catch(() => {})
+    }
+  }
+
+  return { outcome: parsed.status, soldValue }
+}
+
+/**
+ * Passe agendado: tenta capturar o desfecho de leilões que saíram da fonte ou
+ * cuja data passou e ainda não têm desfecho conclusivo. Limitado + sequencial.
+ */
+export async function runAuctionOutcomeBatch(
+  prisma: PrismaClient,
+  limit = 20,
+  deps: OutcomeDeps = {},
+): Promise<{ processed: number; sold: number; deserted: number }> {
+  const now = new Date()
+  const pending = await prisma.auction.findMany({
+    where: {
+      sourceUrl: { not: null },
+      outcomeCapturedAt: null,
+      outcomeAttempts: { lt: MAX_ATTEMPTS },
+      status: { notIn: ['SOLD', 'DESERTED', 'CANCELLED'] },
+      OR: [{ disappearedAt: { not: null } }, { auctionDate: { lt: now } }],
+    },
+    select: { id: true },
+    orderBy: { disappearedAt: 'desc' },
+    take: limit,
+  })
+
+  let sold = 0, deserted = 0
+  for (const a of pending) {
+    const r = await captureAuctionOutcome(prisma, a.id, deps)
+    if (r.outcome === 'SOLD') sold++
+    else if (r.outcome === 'DESERTED') deserted++
+  }
+  return { processed: pending.length, sold, deserted }
+}

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -926,6 +926,21 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] auction-archive failed')
   }
 
+  // ── 9d. Captura de desfecho de leilão (arrematado por quanto / deserto) ──
+  // Leilões que saíram da fonte (disappearedAt) ou cuja data passou têm o
+  // sourceUrl re-visitado para extrair o resultado (arrematado + valor, deserto,
+  // revogado). Limite de 20/rodada e anti-hammer (outcomeAttempts < 5). Só o
+  // valor do arremate é persistido — sem dados pessoais do arrematante (LGPD).
+  try {
+    const { runAuctionOutcomeBatch } = await import('./auction-outcome.service.js')
+    const r = await runAuctionOutcomeBatch(app.prisma, 20)
+    if (r.processed > 0 && (r.sold > 0 || r.deserted > 0)) {
+      app.log.info(`[scheduled] auction-outcome: ${r.sold} arrematados, ${r.deserted} desertos de ${r.processed} verificados`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] auction-outcome failed')
+  }
+
   // ── 10. Lead re-scoring nightly (03h UTC = 00h BRT) ─────────────────────
   // Aplica recency decay e captura mudanças que aconteceram sem trigger
   // direto (ex.: lead que ficou parado, atividades manuais no CRM, etc.).

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -911,6 +911,21 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] auction-geocode-bairro failed')
   }
 
+  // ── 9c. Arquivamento de documentos de leilão (edital/matrícula → S3) ─────
+  // Baixa e arquiva os documentos públicos dos leilões que ainda não têm
+  // nenhum documento arquivado. Idempotente (dedup por sha256) e limitado a
+  // 20 leilões por rodada — throttle natural. Também extrai nº de matrícula,
+  // cartório e processo do texto e preenche o leilão se estiverem vazios.
+  try {
+    const { runAuctionArchiveBatch } = await import('./auction-archive.service.js')
+    const r = await runAuctionArchiveBatch(app.prisma, 20)
+    if (r.processed > 0) {
+      app.log.info(`[scheduled] auction-archive: ${r.archived} docs arquivados de ${r.processed} leilões`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] auction-archive failed')
+  }
+
   // ── 10. Lead re-scoring nightly (03h UTC = 00h BRT) ─────────────────────
   // Aplica recency decay e captura mudanças que aconteceram sem trigger
   // direto (ex.: lead que ficou parado, atividades manuais no CRM, etc.).

--- a/apps/api/src/services/scrapers/base-scraper.ts
+++ b/apps/api/src/services/scrapers/base-scraper.ts
@@ -218,6 +218,9 @@ export abstract class BaseScraper {
             opportunityScore: score,
             estimatedROI: discount ? discount * 0.7 : null,
             lastScrapedAt: new Date(),
+            lastSeenAt: new Date(),
+            // Reapareceu na fonte → limpa marca de deslistagem (o leilão voltou).
+            disappearedAt: null,
             scrapedHash: hash,
           }
 
@@ -228,17 +231,35 @@ export abstract class BaseScraper {
                 data: auctionData,
               })
               updated++
+              // Registra a mudança na linha do tempo histórica (best-effort).
+              await this.writeSnapshot(existing.id, item, hash, discount, score).catch(() => {})
+            } else {
+              // Ainda listado, sem mudança de conteúdo: só marca que continua
+              // vivo. Sem isto, lastScrapedAt ficaria congelado no create e o
+              // monitor marcaria como SUSPENDED após 7 dias mesmo sendo visto a
+              // cada scrape (bug de falso-positivo de deslistagem).
+              await this.prisma.auction.update({
+                where: { id: existing.id },
+                data: { lastSeenAt: new Date(), lastScrapedAt: new Date(), disappearedAt: null },
+              }).catch(() => {})
             }
           } else {
-            await this.prisma.auction.create({
-              data: { ...auctionData, slug },
-            }).catch(async () => {
-              // Slug conflict — add random suffix
-              await this.prisma.auction.create({
-                data: { ...auctionData, slug: `${slug}-${Date.now().toString(36)}` },
+            let createdId: string | null = null
+            try {
+              const row = await this.prisma.auction.create({
+                data: { ...auctionData, slug, firstSeenAt: new Date() },
               })
-            })
+              createdId = row.id
+            } catch {
+              // Slug conflict — add random suffix
+              const row = await this.prisma.auction.create({
+                data: { ...auctionData, slug: `${slug}-${Date.now().toString(36)}`, firstSeenAt: new Date() },
+              })
+              createdId = row.id
+            }
             created++
+            // Primeiro snapshot do histórico (best-effort).
+            if (createdId) await this.writeSnapshot(createdId, item, hash, discount, score).catch(() => {})
 
             // Geocode novos leilões na hora da ingestão (bairro → cidade como
             // fallback). Sem lat/lng o leilão não vira pin em /auctions/map,
@@ -306,5 +327,37 @@ export abstract class BaseScraper {
     }
 
     return { created, updated, found: items.length, errors }
+  }
+
+  /**
+   * Grava um snapshot temporal do leilão — histórico imutável de cada mudança
+   * observada (preço, status, desconto). Permite reconstruir a evolução do
+   * leilão (1ª praça → 2ª praça → arrematado) mesmo depois que a fonte remove
+   * o item. Best-effort: uma falha aqui nunca deve interromper a ingestão.
+   */
+  protected async writeSnapshot(
+    auctionId: string,
+    item: ScrapedAuction,
+    hash: string,
+    discount: number | null,
+    score: number,
+  ): Promise<void> {
+    await this.prisma.auctionSnapshot.create({
+      data: {
+        auctionId,
+        scrapedHash: hash,
+        status: item.status || 'UPCOMING',
+        appraisalValue: item.appraisalValue,
+        minimumBid: item.minimumBid,
+        discountPercent: discount,
+        raw: {
+          firstRoundBid: item.firstRoundBid ?? null,
+          secondRoundBid: item.secondRoundBid ?? null,
+          auctionDate: item.auctionDate?.toISOString() ?? null,
+          opportunityScore: score,
+          occupation: item.occupation ?? null,
+        },
+      },
+    })
   }
 }

--- a/apps/api/src/services/scrapers/scheduler.ts
+++ b/apps/api/src/services/scrapers/scheduler.ts
@@ -296,13 +296,15 @@ export class ScraperScheduler {
 
     // For bank auctions, only close if they haven't been scraped in 7+ days
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    // Só quem não foi visto há 7+ dias saiu da fonte → marca deslistagem
+    // (disappearedAt). O registro é preservado como histórico, nunca deletado.
     const bankResult = await this.prisma.auction.updateMany({
       where: {
         lastScrapedAt: { lt: sevenDaysAgo },
         status: { in: ['UPCOMING', 'OPEN', 'FIRST_ROUND', 'SECOND_ROUND'] },
         source: { in: ['CAIXA', 'BANCO_DO_BRASIL', 'BRADESCO', 'SANTANDER', 'ITAU'] },
       },
-      data: { status: 'CLOSED' },
+      data: { status: 'CLOSED', disappearedAt: now },
     })
 
     console.log(`[ScraperScheduler] ${result.count} leilões + ${bankResult.count} bancários marcados como CLOSED`)

--- a/apps/api/test/auction-archive.test.ts
+++ b/apps/api/test/auction-archive.test.ts
@@ -1,0 +1,110 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import {
+  archiveAuctionDocuments,
+  runAuctionArchiveBatch,
+  classifyDocType,
+  extractRegistryInfo,
+  type ArchiveDeps,
+} from '../src/services/auction-archive.service.js'
+
+// ── Puros (sempre rodam, sem banco) ─────────────────────────────────────────
+test('classifyDocType classifica por URL', () => {
+  assert.equal(classifyDocType('https://x/edital-leilao.pdf'), 'EDITAL')
+  assert.equal(classifyDocType('https://x/matricula-90123.pdf'), 'MATRICULA')
+  assert.equal(classifyDocType('https://x/laudo-avaliacao.pdf'), 'LAUDO')
+  assert.equal(classifyDocType('https://x/auto-de-arrematacao.pdf'), 'ATA')
+  assert.equal(classifyDocType('https://x/planta.png'), 'OUTRO')
+})
+
+test('extractRegistryInfo extrai matrícula, cartório e processo', () => {
+  const t = 'Imóvel objeto da Matrícula nº 90.123 do 2º Cartório de Registro de Imóveis de Franca, ' +
+    'oriundo do processo 1234567-89.2024.8.26.0196.'
+  const i = extractRegistryInfo(t)
+  assert.equal(i.registryNumber, '90123')
+  assert.match(i.registryOffice!, /Registro de Im[óo]veis/i)
+  assert.equal(i.processNumber, '1234567-89.2024.8.26.0196')
+})
+
+// ── Integração (requer TEST_DATABASE_URL) ───────────────────────────────────
+const DB = process.env.TEST_DATABASE_URL
+
+test('arquivamento: download → S3 → AuctionDocument + extração', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const EDITAL = 'https://leiloeiro.test/edital.html'
+  const LAUDO = 'https://leiloeiro.test/laudo.pdf'
+  const html = '<html><body>Matrícula nº 90.123 do 2º Cartório de Registro de Imóveis de Franca. ' +
+    'Processo 1234567-89.2024.8.26.0196.</body></html>'
+
+  const uploads: { key: string; size: number }[] = []
+  const s3Ok: ArchiveDeps['s3'] = {
+    isConfigured: () => true,
+    upload: async (key, body) => { uploads.push({ key, size: body.length }); return `https://bucket.s3/${key}` },
+  }
+  const fetchImpl = (async (url: any) => {
+    if (url === EDITAL) return new Response(html, { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } })
+    if (url === LAUDO) return new Response(new Uint8Array([1, 2, 3, 4, 5]), { status: 200, headers: { 'content-type': 'application/pdf' } })
+    return new Response('', { status: 404 })
+  }) as typeof fetch
+
+  const mk = async (externalId: string, data: any = {}) => {
+    await prisma.auction.deleteMany({ where: { externalId, source: 'LEILOEIRO' as any } })
+    return prisma.auction.create({
+      data: { externalId, source: 'LEILOEIRO' as any, title: 'Teste arq', slug: `arq-${externalId}-${Math.round(performance.now())}`, ...data },
+    })
+  }
+
+  try {
+    // 1) Arquivamento completo com S3 configurado
+    const a1 = await mk('IT-ARQ-1', { editalUrl: EDITAL, documentsUrls: [LAUDO] })
+    const r1 = await archiveAuctionDocuments(prisma, a1.id, { fetchImpl, s3: s3Ok })
+    assert.equal(r1.archived, 2, 'arquiva 2 documentos')
+    assert.equal(uploads.length, 2, '2 uploads ao S3')
+
+    const docs = await prisma.auctionDocument.findMany({ where: { auctionId: a1.id }, orderBy: { type: 'asc' } })
+    assert.equal(docs.length, 2)
+    const edital = docs.find(d => d.type === 'EDITAL')!
+    const laudo = docs.find(d => d.type === 'LAUDO')!
+    assert.ok(edital.sha256 && edital.s3Url && edital.status === 'ARCHIVED', 'edital arquivado com sha256+s3Url')
+    assert.match(edital.extractedText || '', /Matrícula/, 'texto extraído do HTML')
+    assert.equal(edital.mimeType, 'text/html')
+    assert.equal(laudo.extractedText, null, 'PDF não vira texto (sem parser)')
+    assert.ok(laudo.s3Key?.endsWith('.pdf'), 's3Key do laudo com extensão .pdf')
+
+    // Extração preencheu o leilão
+    const a1b = (await prisma.auction.findUnique({ where: { id: a1.id } }))!
+    assert.equal(a1b.registryNumber, '90123', 'matrícula preenchida')
+    assert.match(a1b.registryOffice || '', /Registro de Im[óo]veis/i, 'cartório preenchido')
+    assert.equal(a1b.processNumber, '1234567-89.2024.8.26.0196', 'processo preenchido')
+
+    // 2) Idempotência: re-arquivar não duplica nem re-sobe
+    const r2 = await archiveAuctionDocuments(prisma, a1.id, { fetchImpl, s3: s3Ok })
+    assert.equal(r2.archived, 0, 're-run não arquiva nada novo')
+    assert.equal(uploads.length, 2, 'nenhum upload adicional (dedup por sha256)')
+    assert.equal(await prisma.auctionDocument.count({ where: { auctionId: a1.id } }), 2, 'sem linhas duplicadas')
+
+    // 3) Sem S3 configurado → registro fica PENDING (mas texto/hash preservados)
+    const noS3: ArchiveDeps['s3'] = { isConfigured: () => false, upload: async () => { throw new Error('n/a') } }
+    const a2 = await mk('IT-ARQ-2', { editalUrl: EDITAL })
+    await archiveAuctionDocuments(prisma, a2.id, { fetchImpl, s3: noS3 })
+    const d2 = (await prisma.auctionDocument.findFirst({ where: { auctionId: a2.id } }))!
+    assert.equal(d2.status, 'PENDING', 'sem S3 → PENDING')
+    assert.equal(d2.s3Key, null, 'sem S3 → s3Key nulo')
+    assert.ok(d2.extractedText && d2.sha256, 'texto e hash preservados mesmo sem S3')
+
+    // 4) Batch pega leilão pendente e o arquiva
+    const a3 = await mk('IT-ARQ-3', { editalUrl: EDITAL })
+    const rb = await runAuctionArchiveBatch(prisma, 20, { fetchImpl, s3: s3Ok })
+    assert.ok(rb.processed >= 1, 'batch processa ao menos 1 leilão pendente')
+    assert.ok((await prisma.auctionDocument.count({ where: { auctionId: a3.id } })) >= 1, 'a3 arquivado pelo batch')
+
+    // Limpeza
+    for (const id of [a1.id, a2.id, a3.id]) {
+      await prisma.auctionDocument.deleteMany({ where: { auctionId: id } })
+      await prisma.auction.deleteMany({ where: { id } })
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/api/test/auction-archive.test.ts
+++ b/apps/api/test/auction-archive.test.ts
@@ -34,8 +34,29 @@ test('arquivamento: download → S3 → AuctionDocument + extração', { skip: D
   const prisma = new PrismaClient({ datasourceUrl: DB })
   const EDITAL = 'https://leiloeiro.test/edital.html'
   const LAUDO = 'https://leiloeiro.test/laudo.pdf'
+  const PDF_EDITAL = 'https://leiloeiro.test/edital.pdf'
   const html = '<html><body>Matrícula nº 90.123 do 2º Cartório de Registro de Imóveis de Franca. ' +
     'Processo 1234567-89.2024.8.26.0196.</body></html>'
+
+  // Gera um PDF mínimo válido com uma linha de texto (para testar extração real).
+  const makePdf = (line: string): Buffer => {
+    const o = [
+      '<</Type/Catalog/Pages 2 0 R>>',
+      '<</Type/Pages/Kids[3 0 R]/Count 1>>',
+      '<</Type/Page/Parent 2 0 R/MediaBox[0 0 2000 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>',
+    ]
+    const s = `BT /F1 12 Tf 20 120 Td (${line}) Tj ET`
+    o.push(`<</Length ${s.length}>>\nstream\n${s}\nendstream`)
+    o.push('<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>')
+    let p = '%PDF-1.4\n'; const off: number[] = []
+    o.forEach((x, i) => { off.push(p.length); p += `${i + 1} 0 obj\n${x}\nendobj\n` })
+    const xr = p.length
+    p += `xref\n0 ${o.length + 1}\n0000000000 65535 f \n`
+    off.forEach(f => { p += String(f).padStart(10, '0') + ' 00000 n \n' })
+    p += `trailer\n<</Size ${o.length + 1}/Root 1 0 R>>\nstartxref\n${xr}\n%%EOF`
+    return Buffer.from(p, 'latin1')
+  }
+  const pdfEdital = makePdf('Imovel objeto da Matricula no 55.777 do 1o Oficio de Registro de Imoveis. Processo 7654321-01.2023.8.26.0196')
 
   const uploads: { key: string; size: number }[] = []
   const s3Ok: ArchiveDeps['s3'] = {
@@ -45,6 +66,7 @@ test('arquivamento: download → S3 → AuctionDocument + extração', { skip: D
   const fetchImpl = (async (url: any) => {
     if (url === EDITAL) return new Response(html, { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } })
     if (url === LAUDO) return new Response(new Uint8Array([1, 2, 3, 4, 5]), { status: 200, headers: { 'content-type': 'application/pdf' } })
+    if (url === PDF_EDITAL) return new Response(pdfEdital, { status: 200, headers: { 'content-type': 'application/pdf' } })
     return new Response('', { status: 404 })
   }) as typeof fetch
 
@@ -99,8 +121,18 @@ test('arquivamento: download → S3 → AuctionDocument + extração', { skip: D
     assert.ok(rb.processed >= 1, 'batch processa ao menos 1 leilão pendente')
     assert.ok((await prisma.auctionDocument.count({ where: { auctionId: a3.id } })) >= 1, 'a3 arquivado pelo batch')
 
+    // 5) Edital em PDF → extrai matrícula/cartório/processo do texto do PDF
+    const a4 = await mk('IT-ARQ-4', { editalUrl: PDF_EDITAL })
+    await archiveAuctionDocuments(prisma, a4.id, { fetchImpl, s3: s3Ok })
+    const d4 = (await prisma.auctionDocument.findFirst({ where: { auctionId: a4.id } }))!
+    assert.match(d4.extractedText || '', /Matricula/, 'texto extraído do PDF (unpdf)')
+    assert.equal(d4.type, 'EDITAL')
+    const a4b = (await prisma.auction.findUnique({ where: { id: a4.id } }))!
+    assert.equal(a4b.registryNumber, '55777', 'matrícula extraída do PDF')
+    assert.equal(a4b.processNumber, '7654321-01.2023.8.26.0196', 'processo extraído do PDF')
+
     // Limpeza
-    for (const id of [a1.id, a2.id, a3.id]) {
+    for (const id of [a1.id, a2.id, a3.id, a4.id]) {
       await prisma.auctionDocument.deleteMany({ where: { auctionId: id } })
       await prisma.auction.deleteMany({ where: { id } })
     }

--- a/apps/api/test/auction-outcome.test.ts
+++ b/apps/api/test/auction-outcome.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import {
+  parseOutcome,
+  parseBRCurrency,
+  captureAuctionOutcome,
+  runAuctionOutcomeBatch,
+  type OutcomeDeps,
+} from '../src/services/auction-outcome.service.js'
+
+// ── Puros (sempre rodam) ────────────────────────────────────────────────────
+test('parseBRCurrency converte moeda BR', () => {
+  assert.equal(parseBRCurrency('R$ 250.000,00'), 250000)
+  assert.equal(parseBRCurrency('1.250.000,50'), 1250000.5)
+  assert.equal(parseBRCurrency('sem valor'), null)
+})
+
+test('parseOutcome classifica desfechos', () => {
+  assert.deepEqual(parseOutcome('Lote ARREMATADO por R$ 250.000,00'), { status: 'SOLD', soldValue: 250000 })
+  assert.equal(parseOutcome('Situação: DESERTO — não houve lances').status, 'DESERTED')
+  assert.equal(parseOutcome('Leilão REVOGADO por decisão judicial').status, 'CANCELLED')
+  assert.equal(parseOutcome('1ª praça: 01/09/2026 às 14h').status, 'INCONCLUSIVE')
+  // arrematado sem valor explícito ainda é SOLD
+  assert.equal(parseOutcome('Bem vendido em leilão').status, 'SOLD')
+})
+
+// ── Integração (requer TEST_DATABASE_URL) ───────────────────────────────────
+const DB = process.env.TEST_DATABASE_URL
+
+test('captura de desfecho: SOLD + snapshot + lance, idempotente, anti-hammer', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const SOLD_URL = 'https://leiloeiro.test/lote-vendido'
+  const NEUTRAL_URL = 'https://leiloeiro.test/lote-aberto'
+
+  const fetchImpl = (async (url: any) => {
+    if (url === SOLD_URL) return new Response('<h1>Lote ARREMATADO por R$ 250.000,00</h1>', { status: 200 })
+    if (url === NEUTRAL_URL) return new Response('<h1>Lote aberto para lances</h1>', { status: 200 })
+    return new Response('', { status: 404 })
+  }) as typeof fetch
+  const deps: OutcomeDeps = { fetchImpl }
+
+  const past = new Date('2026-06-01T12:00:00Z')
+  const mk = async (externalId: string, data: any) => {
+    await prisma.auction.deleteMany({ where: { externalId, source: 'LEILOEIRO' as any } })
+    return prisma.auction.create({
+      data: { externalId, source: 'LEILOEIRO' as any, title: 'Teste desfecho', slug: `out-${externalId}-${Math.round(performance.now())}`, ...data },
+    })
+  }
+
+  try {
+    // 1) Arremate conclusivo
+    const a1 = await mk('IT-OUT-1', { sourceUrl: SOLD_URL, status: 'CLOSED', disappearedAt: past, appraisalValue: 500000 })
+    const r1 = await captureAuctionOutcome(prisma, a1.id, deps)
+    assert.equal(r1.outcome, 'SOLD')
+    assert.equal(r1.soldValue, 250000)
+    const a1b = (await prisma.auction.findUnique({ where: { id: a1.id } }))!
+    assert.equal(a1b.status, 'SOLD', 'status vira SOLD')
+    assert.equal(Number(a1b.soldValue), 250000, 'soldValue gravado')
+    assert.ok(a1b.soldDate, 'soldDate gravado')
+    assert.ok(a1b.outcomeCapturedAt, 'outcomeCapturedAt gravado')
+    assert.equal(await prisma.auctionSnapshot.count({ where: { auctionId: a1.id } }), 1, 'snapshot do desfecho')
+    const bid = await prisma.auctionBid.findFirst({ where: { auctionId: a1.id, isWinning: true } })
+    assert.ok(bid && Number(bid.bidValue) === 250000, 'lance vencedor criado (só valor)')
+    assert.equal(bid!.bidderCpf, null, 'sem CPF do arrematante (LGPD)')
+
+    // 2) Idempotência: batch não re-seleciona (outcomeCapturedAt setado)
+    const rb = await runAuctionOutcomeBatch(prisma, 20, deps)
+    const stillOne = await prisma.auctionSnapshot.count({ where: { auctionId: a1.id } })
+    assert.equal(stillOne, 1, 'não re-processa leilão já resolvido')
+    assert.ok(!rb.processed || true) // batch pode pegar outros; a1 não deve reabrir
+
+    // 3) Inconclusivo → incrementa outcomeAttempts, status inalterado
+    const a2 = await mk('IT-OUT-2', { sourceUrl: NEUTRAL_URL, status: 'CLOSED', disappearedAt: past })
+    const r2 = await captureAuctionOutcome(prisma, a2.id, deps)
+    assert.equal(r2.outcome, 'INCONCLUSIVE')
+    const a2b = (await prisma.auction.findUnique({ where: { id: a2.id } }))!
+    assert.equal(a2b.status, 'CLOSED', 'status inalterado')
+    assert.equal(a2b.outcomeAttempts, 1, 'attempt incrementado')
+    assert.equal(a2b.outcomeCapturedAt, null, 'sem desfecho conclusivo')
+
+    // Limpeza
+    for (const id of [a1.id, a2.id]) {
+      await prisma.auctionBid.deleteMany({ where: { auctionId: id } })
+      await prisma.auctionSnapshot.deleteMany({ where: { auctionId: id } })
+      await prisma.auction.deleteMany({ where: { id } })
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/api/test/auction-snapshot-lifecycle.test.ts
+++ b/apps/api/test/auction-snapshot-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import { BaseScraper, type ScrapedAuction } from '../src/services/scrapers/base-scraper.js'
+
+// Teste de integração do arquivo histórico de leilões (ciclo de vida + snapshots).
+// Requer um Postgres real com o schema aplicado. Auto-pula sem TEST_DATABASE_URL
+// para não quebrar o `pnpm test` em ambientes sem banco.
+//
+//   createdb agora_test && \
+//   DATABASE_URL=postgres://... pnpm --filter @agoraencontrei/database db:push && \
+//   TEST_DATABASE_URL=postgres://.../agora_test pnpm --filter @agoraencontrei/api test
+const DB = process.env.TEST_DATABASE_URL
+
+test('arquivo histórico: ciclo de vida + snapshots do BaseScraper', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async (t) => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const externalId = 'IT-SNAP-A1'
+  const src = 'LEILOEIRO'
+
+  class TestScraper extends BaseScraper {
+    items: ScrapedAuction[] = []
+    constructor() { super(prisma, src, 'http://test.local') }
+    async scrape(): Promise<ScrapedAuction[]> { return this.items }
+  }
+  // Hermético: sem city/neighborhood (pula geocode), com coverImage (pula street view)
+  const baseItem = (o: Partial<ScrapedAuction> = {}): ScrapedAuction => ({
+    externalId, source: src, title: 'Casa teste snapshot',
+    coverImage: 'http://img.local/x.jpg', appraisalValue: 500000, minimumBid: 300000,
+    status: 'OPEN', auctionDate: new Date('2026-09-01T12:00:00Z'), ...o,
+  })
+  const find = () => prisma.auction.findFirst({ where: { externalId, source: src as any } })
+  const snaps = (auctionId: string) => prisma.auctionSnapshot.count({ where: { auctionId } })
+
+  const cleanup = async () => {
+    const rows = await prisma.auction.findMany({ where: { externalId, source: src as any }, select: { id: true } })
+    for (const r of rows) await prisma.auctionSnapshot.deleteMany({ where: { auctionId: r.id } })
+    await prisma.auction.deleteMany({ where: { externalId, source: src as any } })
+  }
+
+  try {
+    await cleanup()
+    const scraper = new TestScraper()
+
+    // 1) Criação
+    scraper.items = [baseItem()]
+    const r1 = await scraper.run()
+    assert.equal(r1.created, 1, 'run#1 deve criar 1 leilão')
+    const a1 = (await find())!
+    assert.ok(a1.firstSeenAt, 'firstSeenAt setado no create')
+    assert.ok(a1.lastSeenAt, 'lastSeenAt setado no create')
+    assert.equal(a1.disappearedAt, null, 'disappearedAt nulo no create')
+    assert.equal(await snaps(a1.id), 1, '1 snapshot após create')
+    const firstSeen0 = a1.firstSeenAt!.getTime()
+    const lastSeen0 = a1.lastSeenAt!.getTime()
+
+    // 2) Re-scrape idêntico (hash inalterado): bump de lastSeenAt, sem novo snapshot
+    await new Promise((r) => setTimeout(r, 25))
+    scraper.items = [baseItem()]
+    const r2 = await scraper.run()
+    assert.equal(r2.created, 0)
+    assert.equal(r2.updated, 0)
+    const a2 = (await find())!
+    assert.equal(a2.firstSeenAt!.getTime(), firstSeen0, 'firstSeenAt inalterado')
+    assert.ok(a2.lastSeenAt!.getTime() >= lastSeen0, 'lastSeenAt bumpado')
+    assert.equal(await snaps(a2.id), 1, 'sem novo snapshot quando hash não muda')
+
+    // 3) Reaparecimento limpa disappearedAt
+    await prisma.auction.update({ where: { id: a2.id }, data: { disappearedAt: new Date(), status: 'SUSPENDED' } })
+    scraper.items = [baseItem()]
+    await scraper.run()
+    const a3 = (await find())!
+    assert.equal(a3.disappearedAt, null, 'disappearedAt limpo ao reaparecer')
+    assert.equal(await snaps(a3.id), 1, 'ainda 1 snapshot (hash inalterado)')
+
+    // 4) Mudança de conteúdo (novo hash) gera 2º snapshot
+    scraper.items = [baseItem({ minimumBid: 250000 })]
+    const r4 = await scraper.run()
+    assert.equal(r4.updated, 1, 'run#4 deve atualizar')
+    const a4 = (await find())!
+    assert.equal(Number(a4.minimumBid), 250000, 'minimumBid atualizado')
+    assert.equal(a4.firstSeenAt!.getTime(), firstSeen0, 'firstSeenAt inalterado após update')
+    assert.equal(a4.disappearedAt, null, 'disappearedAt segue nulo')
+    assert.equal(await snaps(a4.id), 2, '2 snapshots após mudança de hash')
+    const latest = await prisma.auctionSnapshot.findFirst({ where: { auctionId: a4.id }, orderBy: { capturedAt: 'desc' } })
+    assert.equal(Number(latest!.minimumBid), 250000, 'último snapshot reflete novo minimumBid')
+
+    await cleanup()
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2382,6 +2382,11 @@ model Auction {
   lastSeenAt          DateTime?       // Última vez que a fonte ainda o listava (bump a cada sighting)
   disappearedAt       DateTime?       // Quando saiu da fonte (deslistado) — gatilho da captura de desfecho
 
+  // Desfecho do leilão (arrematado por quanto / deserto)
+  soldDate            DateTime?       // Data do arremate
+  outcomeCapturedAt   DateTime?       // Quando capturamos um desfecho conclusivo
+  outcomeAttempts     Int             @default(0) // Tentativas de captura (limite anti-hammer)
+
   // Analytics
   views               Int             @default(0)
   favorites           Int             @default(0)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2394,6 +2394,7 @@ model Auction {
   alerts              AuctionAlert[]
   analyses            AuctionAnalysis[]
   snapshots           AuctionSnapshot[]
+  documents           AuctionDocument[]
 
   @@index([source])
   @@index([status])
@@ -2428,6 +2429,31 @@ model AuctionSnapshot {
 
   @@index([auctionId, capturedAt])
   @@map("auction_snapshots")
+}
+
+// Documento público de leilão arquivado internamente (edital, matrícula, laudo,
+// ata). Baixamos o arquivo da fonte e guardamos no S3 — os links dos leiloeiros
+// apodrecem depois que o leilão encerra; o binário arquivado sobrevive.
+model AuctionDocument {
+  id            String   @id @default(cuid())
+  auctionId     String
+  auction       Auction  @relation(fields: [auctionId], references: [id], onDelete: Cascade)
+  type          String   @default("OUTRO") // EDITAL | MATRICULA | LAUDO | ATA | OUTRO
+  sourceUrl     String                     // URL original de onde foi baixado
+  s3Key         String?                    // chave no S3 (null se S3 indisponível)
+  s3Url         String?
+  sha256        String                     // hash do conteúdo — dedup/versionamento
+  sizeBytes     Int?
+  mimeType      String?
+  extractedText String?  @db.Text          // texto extraído (HTML/texto), quando disponível
+  status        String   @default("ARCHIVED") // ARCHIVED | PENDING | FAILED
+  capturedAt    DateTime @default(now())
+
+  // Mesmo conteúdo (sha256) não duplica; conteúdo novo vira nova versão.
+  @@unique([auctionId, sha256])
+  @@index([auctionId])
+  @@index([type])
+  @@map("auction_documents")
 }
 
 model AuctionBid {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2377,6 +2377,11 @@ model Auction {
   scrapedHash         String?         // Hash para detectar mudanças
   isVerified          Boolean         @default(false)
 
+  // Ciclo de vida / arquivo histórico (nunca deletar — leilão sumido vira histórico)
+  firstSeenAt         DateTime?       // 1ª vez que a fonte listou este leilão
+  lastSeenAt          DateTime?       // Última vez que a fonte ainda o listava (bump a cada sighting)
+  disappearedAt       DateTime?       // Quando saiu da fonte (deslistado) — gatilho da captura de desfecho
+
   // Analytics
   views               Int             @default(0)
   favorites           Int             @default(0)
@@ -2388,6 +2393,7 @@ model Auction {
   bids                AuctionBid[]
   alerts              AuctionAlert[]
   analyses            AuctionAnalysis[]
+  snapshots           AuctionSnapshot[]
 
   @@index([source])
   @@index([status])
@@ -2399,7 +2405,29 @@ model Auction {
   @@index([opportunityScore])
   @@index([slug])
   @@index([externalId, source])
+  @@index([disappearedAt])
   @@map("auctions")
+}
+
+// Snapshot temporal de um leilão — histórico imutável de cada mudança observada.
+// Preserva a evolução (1ª praça → 2ª praça → arrematado) mesmo depois que a fonte
+// remove o item do site. É a base do arquivo histórico de leilões.
+model AuctionSnapshot {
+  id              String   @id @default(cuid())
+  auctionId       String
+  auction         Auction  @relation(fields: [auctionId], references: [id], onDelete: Cascade)
+  capturedAt      DateTime @default(now())
+  scrapedHash     String?
+  status          String?  // status observado neste snapshot
+  appraisalValue  Decimal? @db.Decimal(14, 2)
+  minimumBid      Decimal? @db.Decimal(14, 2)
+  currentBid      Decimal? @db.Decimal(14, 2)
+  soldValue       Decimal? @db.Decimal(14, 2)
+  discountPercent Float?
+  raw             Json     @default("{}") // campos brutos relevantes no momento da captura
+
+  @@index([auctionId, capturedAt])
+  @@map("auction_snapshots")
 }
 
 model AuctionBid {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       playwright-core:
         specifier: ^1.61.0
         version: 1.61.0
+      unpdf:
+        specifier: ^1.6.2
+        version: 1.6.2
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1314,6 +1317,7 @@ packages:
   '@embedded-postgres/windows-x64@18.4.0-beta.17':
     resolution: {integrity: sha512-AwRerliA4IGWyW5jWBvHt5vidVUSB0QQW9Tt2y7ScnmifnCb/awfxZr4BkBSTv+gNt8Djcddqs+xSF5Z6/CkTg==}
     engines: {node: '>=16'}
+    cpu: [x64]
     os: [win32]
 
   '@emnapi/core@1.9.1':
@@ -1504,7 +1508,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -7411,6 +7415,14 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -16036,6 +16048,8 @@ snapshots:
   universalify@1.0.0: {}
 
   universalify@2.0.1: {}
+
+  unpdf@1.6.2: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Objetivo

Transformar a captação de **leilões ativos** num **arquivo histórico permanente** e **alimentar a inteligência do Tomás/copilot** com ele: armazenar os dados públicos de todo leilão (inclusive já arrematados), preservando **valor de arremate, matrícula, cartório, processo e os PDFs de edital/matrícula**; responder perguntas por localização/tipo/valor; agrupar o mesmo imóvel entre vários leilões no tempo; e expor tudo no site. Roda **24/7** (`ScraperScheduler`, `AuctionMonitorService`, `runScheduledJobs`).

## Fases (backend)

- **F0 — Reconciliação de schema:** 16 colunas via ALTER idempotente.
- **F1 — Ciclo de vida + snapshots:** `firstSeenAt`/`lastSeenAt`/`disappearedAt`, nunca-deletar, **`AuctionSnapshot`** (evolução 1ª→2ª praça→arrematado).
- **F2 — Documentos → S3 + extração:** **`AuctionDocument`** (dedup sha256), download→S3, **extração de PDF (unpdf)** e HTML, matrícula/cartório/processo.
- **F3 — Desfecho:** re-visita `sourceUrl`, `parseOutcome()` (arrematado + valor/deserto), snapshot + lance vencedor (só valor — LGPD).
- **F4 — Identidade do imóvel:** **`AuctionPropertyIdentity`** + timeline ("foi a leilão N vezes desde ANO").
- **F5 — Scraper estruturado do Mega Leilões:** `parseMegaListing` (o site é SSR; o regex genérico registrava 0).

## Inteligência + REST + Frontend

- **Tomás + copilot:** `auction-report.service` + tools **`buscar_leiloes`** e **`relatorio_leiloes`** (policy pública). Cobre widget do site + copilot.
- **REST (`/api/v1/auctions`):** `GET /report`, `/:slug/history`, `/:slug/documents`, `/property/:id/timeline`.
- **Frontend:** `AuctionArchivePanel` (documentos + histórico na página do leilão) e página **`/leiloes/relatorios`** (valores por localização/tipo, com estatísticas). 0 erros de typecheck no web.

## Melhorias

- **1 — Enriquecimento por detalhe do Mega:** busca a página do lote e extrai `editalUrl` + **matrícula em PDF** enquanto o lote está vivo (`detailEnrichedAt` como guard). Cron 9f, antes do arquivamento. Registro de parsers por host, extensível.
- **2 — Mais leiloeiros SSR:** investiguei 8 (Sodré, Sold, Zuk, Vip, Milan, Biasi, Lance, Frazão). **Só o Mega é SSR imóvel-a-imóvel**; os demais são SPA/landing ou event-based (lots via JS) → território de **Apify** (já existente). Deixei o registro de parsers extensível para adds rápidos quando um SSR novo aparecer. Não fabriquei scrapers frágeis.
- **3 — Frontend:** entregue (acima).

## Pipeline 24/7

```
scraper (Caixa/bancos/leiloeiros + Mega SSR) → snapshots + firstSeenAt/lastSeenAt
   → cron 9f enriquece detalhe (descobre editalUrl/matrícula)
   → cron 9c arquiva edital/matrícula no S3 + extrai matrícula (PDF/HTML)
   → cron 9d captura desfecho ("arrematado por R$ X")
   → cron 9e agrupa o mesmo imóvel entre leilões (identidade + timeline)
Tomás/copilot + REST + telas → relatórios/listas/histórico/timeline por local/tipo/valor
```

## Migrações
Produção é `db push` + `runMigrations()` idempotente no boot. Tudo refletido no `schema.prisma` e no `runMigrations`.

## Testes (Postgres 16 real)
- **115/115 testes verdes** (API), 0 falhas. **Web: 0 erros de typecheck.**
- Cobrem: ciclo de vida + snapshots; arquivamento (S3/sha256/dedup, matrícula HTML **e PDF**, batch); desfecho; relatório + tools do Tomás; identidade + timeline; scraper do Mega (fixture real + run()); enriquecimento por detalhe.
- **Boot real** (~4s, `/health` OK) + **smoke dos endpoints**. `verify:boot` → 100 rotas. SQL idempotente. Testes com banco se auto-pulam sem `TEST_DATABASE_URL`.

## Notas honestas
- **Backfill retroativo** de leilões já fora do ar não é possível — a base se constrói a partir de agora.
- Batches (9c–9f) dependem de `REDIS_URL` (via `runScheduledJobs`), que produção já tem.
- `FloatingChatbot.tsx` (site Lemos) é bot de regras/WhatsApp separado, não conectado à IA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)