### PR TITLE
fix(ci): build desktop (.exe) verde + inteligência do Tomás, Fase 4/5, enriquecimento e frontend de leilões

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -61,6 +61,13 @@ jobs:
         continue-on-error: true
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+          # O runner é windows-latest; o next.config desliga o output standalone
+          # no Windows (process.platform === 'win32') para o dev local não exigir
+          # Developer Mode/admin p/ symlinks. Mas o app offline PRECISA do
+          # standalone (o bundle-server.mjs copia apps/web/.next/standalone).
+          # Sem esta flag o build gera .next sem standalone → o bundle pula o web
+          # e o "Verify API packed" falha em "✗ web .next".
+          FORCE_NEXT_STANDALONE: '1'
           # CRÍTICO: o client Next inlina NEXT_PUBLIC_* no BUILD. O app offline
           # sobe a API local em 127.0.0.1:31764 (AGORA_API_PORT em main.js); sem
           # isto o bundle chamaria o fallback localhost:3100 e NADA funcionaria.

--- a/apps/api/src/routes/auctions-archive/index.ts
+++ b/apps/api/src/routes/auctions-archive/index.ts
@@ -1,0 +1,83 @@
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { buildAuctionReport, type AuctionReportFilters } from '../../services/auction-report.service.js'
+import { getPropertyTimeline } from '../../services/auction-identity.service.js'
+
+/**
+ * Endpoints públicos do arquivo histórico de leilões. Registrados no mesmo
+ * prefixo /api/v1/auctions (paths estáticos vencem os paramétricos no Fastify).
+ * Expõem o mesmo relatório que o Tomás usa, o histórico de snapshots, os
+ * documentos arquivados e a linha do tempo do imóvel.
+ */
+
+const reportQuerySchema = z.object({
+  city: z.string().optional(),
+  neighborhood: z.string().optional(),
+  state: z.string().optional(),
+  propertyType: z.string().optional(),
+  category: z.string().optional(),
+  status: z.string().optional(),
+  source: z.string().optional(),
+  soldOnly: z.coerce.boolean().optional(),
+  minDiscount: z.coerce.number().optional(),
+  maxPrice: z.coerce.number().optional(),
+  sinceMonths: z.coerce.number().optional(),
+})
+
+export default async function auctionsArchiveRoutes(app: FastifyInstance) {
+  // Relatório estatístico agregado (o mesmo que alimenta o Tomás).
+  app.get('/report', async (req, reply) => {
+    const parsed = reportQuerySchema.safeParse(req.query)
+    if (!parsed.success) return reply.status(400).send({ error: 'invalid_query', issues: parsed.error.issues })
+    const report = await buildAuctionReport(app.prisma, parsed.data as AuctionReportFilters)
+    return reply.send(report)
+  })
+
+  // Histórico temporal (snapshots) de um leilão.
+  app.get('/:slug/history', async (req, reply) => {
+    const { slug } = req.params as { slug: string }
+    const auction = await app.prisma.auction.findUnique({ where: { slug }, select: { id: true, title: true } })
+    if (!auction) return reply.status(404).send({ error: 'not_found' })
+    const snapshots = await app.prisma.auctionSnapshot.findMany({
+      where: { auctionId: auction.id },
+      orderBy: { capturedAt: 'asc' },
+      select: {
+        capturedAt: true, status: true, appraisalValue: true, minimumBid: true,
+        currentBid: true, soldValue: true, discountPercent: true,
+      },
+    })
+    const num = (v: unknown) => (v == null ? null : Number(v))
+    return reply.send({
+      slug, title: auction.title, count: snapshots.length,
+      history: snapshots.map((s) => ({
+        capturedAt: s.capturedAt, status: s.status,
+        appraisalValue: num(s.appraisalValue), minimumBid: num(s.minimumBid),
+        currentBid: num(s.currentBid), soldValue: num(s.soldValue), discountPercent: s.discountPercent,
+      })),
+    })
+  })
+
+  // Documentos públicos arquivados (edital, matrícula, laudo, ata).
+  app.get('/:slug/documents', async (req, reply) => {
+    const { slug } = req.params as { slug: string }
+    const auction = await app.prisma.auction.findUnique({ where: { slug }, select: { id: true } })
+    if (!auction) return reply.status(404).send({ error: 'not_found' })
+    const docs = await app.prisma.auctionDocument.findMany({
+      where: { auctionId: auction.id },
+      orderBy: { capturedAt: 'desc' },
+      select: {
+        type: true, sourceUrl: true, s3Url: true, mimeType: true,
+        sizeBytes: true, status: true, capturedAt: true,
+      },
+    })
+    return reply.send({ slug, count: docs.length, documents: docs })
+  })
+
+  // Linha do tempo do imóvel (todas as vezes que foi a leilão).
+  app.get('/property/:identityId/timeline', async (req, reply) => {
+    const { identityId } = req.params as { identityId: string }
+    const timeline = await getPropertyTimeline(app.prisma, identityId)
+    if (!timeline) return reply.status(404).send({ error: 'not_found' })
+    return reply.send(timeline)
+  })
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -309,6 +309,7 @@ async function runMigrations(prisma: any) {
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "soldDate" TIMESTAMPTZ`,
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "outcomeCapturedAt" TIMESTAMPTZ`,
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "outcomeAttempts" INTEGER NOT NULL DEFAULT 0`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "detailEnrichedAt" TIMESTAMPTZ`,
     // ── Snapshots temporais (histórico imutável de cada mudança observada) ────
     `CREATE TABLE IF NOT EXISTS auction_snapshots (
       id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -58,6 +58,7 @@ import legalRoutes from './routes/legal/index.js'
 import financeAutomationRoutes from './routes/finance/automation.js'
 import alertsRoutes from './routes/alerts/index.js'
 import auctionsRoutes from './routes/auctions/index.js'
+import auctionsArchiveRoutes from './routes/auctions-archive/index.js'
 import specialistsRoutes from './routes/specialists/index.js'
 import { specialistPaymentRoutes } from './routes/specialists/payments.js'
 import { ScraperScheduler } from './services/scrapers/scheduler.js'
@@ -340,6 +341,21 @@ async function runMigrations(prisma: any) {
     `CREATE UNIQUE INDEX IF NOT EXISTS auction_documents_auction_sha_key ON auction_documents("auctionId", sha256)`,
     `CREATE INDEX IF NOT EXISTS auction_documents_auction_idx ON auction_documents("auctionId")`,
     `CREATE INDEX IF NOT EXISTS auction_documents_type_idx ON auction_documents(type)`,
+    // ── Identidade canônica do imóvel (agrupa leilões do mesmo imóvel no tempo) ─
+    `CREATE TABLE IF NOT EXISTS auction_property_identities (
+      id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+      "registryKey" TEXT UNIQUE,
+      "addressKey" TEXT UNIQUE,
+      city TEXT, state TEXT, neighborhood TEXT,
+      "auctionCount" INTEGER NOT NULL DEFAULT 0,
+      "firstAuctionAt" TIMESTAMPTZ,
+      "lastAuctionAt" TIMESTAMPTZ,
+      "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`,
+    `CREATE INDEX IF NOT EXISTS auction_identities_city_idx ON auction_property_identities(city, state)`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "identityId" TEXT`,
+    `CREATE INDEX IF NOT EXISTS auctions_identity_idx ON auctions("identityId")`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_source_idx ON scraper_runs(source)`,
     `CREATE INDEX IF NOT EXISTS scraper_runs_started_idx ON scraper_runs("startedAt")`,
   ]
@@ -1561,6 +1577,7 @@ async function bootstrap() {
   await app.register(financeAutomationRoutes, { prefix: '/api/v1/finance/automation' })
   await app.register(alertsRoutes,            { prefix: '/api/v1/public/alerts' })
   await app.register(auctionsRoutes,          { prefix: '/api/v1/auctions' })
+  await app.register(auctionsArchiveRoutes,   { prefix: '/api/v1/auctions' })
   // auctionsRoute desativada (FST_ERR_DUPLICATED_ROUTE com publicRoutes)
   // Leilões disponíveis em /api/v1/auctions (Claude) e /api/v1/public/auctions via publicRoutes
   await app.register(freeListingRoutes,        { prefix: '/api/v1/public' })

--- a/apps/api/src/services/auction-detail-enrichment.service.ts
+++ b/apps/api/src/services/auction-detail-enrichment.service.ts
@@ -1,0 +1,112 @@
+/**
+ * Auction Detail Enrichment — descobre editalUrl/documentos na página de detalhe
+ * do lote enquanto ele ainda está no ar.
+ *
+ * A listagem não traz o link do edital; a página de detalhe sim. Aqui buscamos
+ * o sourceUrl (detalhe) e extraímos os PDFs públicos (edital, matrícula, laudo),
+ * preenchendo editalUrl/documentsUrls. Isso alimenta a Fase 2 (arquivar no S3 +
+ * extrair matrícula) sem esperar o leilão fechar.
+ *
+ * Best-effort e por-host: cada leiloeiro tem seu parser de detalhe.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+export interface EnrichmentDeps {
+  fetchImpl?: typeof fetch
+}
+
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36'
+
+/** Parser de detalhe do Mega Leilões — extrai os PDFs públicos do lote. */
+export function parseMegaDetail(html: string): { editalUrl?: string; documentsUrls: string[] } {
+  const pdfs = [...html.matchAll(/https:\/\/cdn\d*\.megaleiloes\.com\.br\/[^\s"'<>]+\.pdf/gi)].map((m) => m[0])
+  const uniq = [...new Set(pdfs)]
+  // Só documentos do lote (edital, matrícula, laudo/avaliação); exclui institucionais.
+  const docs = uniq.filter((u) => /(edital|matricula|laudo|avalia)/i.test(u) && !/politica|privacidade/i.test(u))
+  const editalUrl = docs.find((u) => /edital/i.test(u))
+  return { editalUrl, documentsUrls: docs }
+}
+
+interface DetailParser {
+  match: RegExp
+  parse: (html: string) => { editalUrl?: string; documentsUrls: string[] }
+}
+
+// Registro de parsers por host. Extensível para outros leiloeiros SSR.
+const DETAIL_PARSERS: DetailParser[] = [
+  { match: /megaleiloes\.com\.br/i, parse: parseMegaDetail },
+]
+
+/** Filtro Prisma dos leilões que têm parser de detalhe conhecido. */
+export const ENRICHABLE_HOSTS = ['megaleiloes']
+
+/**
+ * Enriquece um leilão a partir da página de detalhe: descobre editalUrl e
+ * documentos. Marca detailEnrichedAt quando a página carrega (evita re-tentar
+ * à toa); em falha de rede, deixa para a próxima rodada.
+ */
+export async function enrichAuctionDetail(
+  prisma: PrismaClient,
+  auctionId: string,
+  deps: EnrichmentDeps = {},
+): Promise<{ enriched: boolean }> {
+  const fetchImpl = deps.fetchImpl || fetch
+  const auction = await prisma.auction.findUnique({
+    where: { id: auctionId },
+    select: { id: true, sourceUrl: true, editalUrl: true, documentsUrls: true },
+  })
+  if (!auction?.sourceUrl) return { enriched: false }
+
+  const parser = DETAIL_PARSERS.find((p) => p.match.test(auction.sourceUrl!))
+  if (!parser) {
+    await prisma.auction.update({ where: { id: auctionId }, data: { detailEnrichedAt: new Date() } }).catch(() => {})
+    return { enriched: false }
+  }
+
+  let html = ''
+  try {
+    const res = await fetchImpl(auction.sourceUrl, { headers: { 'User-Agent': UA } })
+    if (!res.ok) return { enriched: false } // rede falhou → tenta de novo depois
+    html = await res.text()
+  } catch {
+    return { enriched: false }
+  }
+
+  const { editalUrl, documentsUrls } = parser.parse(html)
+  const mergedDocs = [...new Set([...(auction.documentsUrls || []), ...documentsUrls])]
+  const data: Record<string, unknown> = { detailEnrichedAt: new Date() }
+  if (!auction.editalUrl && editalUrl) data.editalUrl = editalUrl
+  if (mergedDocs.length !== (auction.documentsUrls || []).length) data.documentsUrls = mergedDocs
+
+  await prisma.auction.update({ where: { id: auctionId }, data }).catch(() => {})
+  return { enriched: !!(data.editalUrl || data.documentsUrls) }
+}
+
+/**
+ * Passe agendado: enriquece leilões de leiloeiros com parser de detalhe que
+ * ainda não foram enriquecidos. Limitado + sequencial.
+ */
+export async function runDetailEnrichmentBatch(
+  prisma: PrismaClient,
+  limit = 30,
+  deps: EnrichmentDeps = {},
+): Promise<{ processed: number; enriched: number }> {
+  const pending = await prisma.auction.findMany({
+    where: {
+      detailEnrichedAt: null,
+      sourceUrl: { not: null },
+      OR: ENRICHABLE_HOSTS.map((h) => ({ sourceUrl: { contains: h } })),
+    },
+    select: { id: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let enriched = 0
+  for (const a of pending) {
+    const r = await enrichAuctionDetail(prisma, a.id, deps)
+    if (r.enriched) enriched++
+  }
+  return { processed: pending.length, enriched }
+}

--- a/apps/api/src/services/auction-identity.service.ts
+++ b/apps/api/src/services/auction-identity.service.ts
@@ -1,0 +1,155 @@
+/**
+ * Auction Identity Service — identidade canônica do imóvel.
+ *
+ * Um mesmo imóvel pode ir a leilão várias vezes (praças diferentes, anos
+ * diferentes, fontes diferentes). Aqui agrupamos todas as ocorrências sob uma
+ * identidade única, chaveada por matrícula+cartório (chave forte, extraída do
+ * edital na Fase 2) ou, na falta, pelo endereço completo. Assim conseguimos a
+ * linha do tempo "este imóvel já foi a leilão 3x desde 2023".
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+function norm(s?: string | null): string {
+  return (s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+interface AuctionKeyFields {
+  registryNumber?: string | null
+  registryOffice?: string | null
+  city?: string | null
+  state?: string | null
+  street?: string | null
+  number?: string | null
+}
+
+/** Chave forte por matrícula+cartório, ou fallback por endereço completo. Null se insuficiente. */
+export function computeIdentityKey(a: AuctionKeyFields): { registryKey?: string; addressKey?: string } | null {
+  const regNum = (a.registryNumber || '').replace(/\D/g, '')
+  const regOff = norm(a.registryOffice)
+  if (regNum.length >= 3 && regOff.length >= 3) {
+    return { registryKey: `${regOff}#${regNum}` }
+  }
+  // Fallback: endereço completo (cidade + rua + número) — alta precisão para
+  // evitar fundir imóveis diferentes do mesmo bairro.
+  const city = norm(a.city), street = norm(a.street), number = norm(a.number)
+  if (city && street && number) {
+    return { addressKey: `${norm(a.state)}|${city}|${street}|${number}` }
+  }
+  return null
+}
+
+/**
+ * Resolve (ou cria) a identidade canônica de um leilão e o vincula.
+ * Idempotente: mesma chave → mesma identidade. Recalcula os agregados.
+ */
+export async function resolveAuctionIdentity(
+  prisma: PrismaClient,
+  auctionId: string,
+): Promise<string | null> {
+  const auction = await prisma.auction.findUnique({
+    where: { id: auctionId },
+    select: {
+      id: true, registryNumber: true, registryOffice: true,
+      city: true, state: true, street: true, number: true, neighborhood: true,
+    },
+  })
+  if (!auction) return null
+
+  const key = computeIdentityKey(auction)
+  if (!key) return null
+
+  const where = key.registryKey ? { registryKey: key.registryKey } : { addressKey: key.addressKey! }
+  const base = {
+    city: auction.city, state: auction.state, neighborhood: auction.neighborhood,
+    ...key,
+  }
+
+  const identity = await prisma.auctionPropertyIdentity.upsert({
+    where: where as any,
+    create: base,
+    update: {},
+  })
+
+  await prisma.auction.update({ where: { id: auctionId }, data: { identityId: identity.id } }).catch(() => {})
+  await recomputeIdentityAggregates(prisma, identity.id)
+  return identity.id
+}
+
+/** Recalcula contagem e datas de primeiro/último leilão da identidade. */
+async function recomputeIdentityAggregates(prisma: PrismaClient, identityId: string): Promise<void> {
+  const auctions = await prisma.auction.findMany({
+    where: { identityId },
+    select: { auctionDate: true, createdAt: true },
+  })
+  if (!auctions.length) return
+  const dates = auctions.map((a) => a.auctionDate || a.createdAt).filter(Boolean) as Date[]
+  const first = dates.length ? new Date(Math.min(...dates.map((d) => d.getTime()))) : null
+  const last = dates.length ? new Date(Math.max(...dates.map((d) => d.getTime()))) : null
+  await prisma.auctionPropertyIdentity.update({
+    where: { id: identityId },
+    data: { auctionCount: auctions.length, firstAuctionAt: first, lastAuctionAt: last },
+  }).catch(() => {})
+}
+
+/** Linha do tempo do imóvel: todas as vezes que foi a leilão, em ordem. */
+export async function getPropertyTimeline(prisma: PrismaClient, identityId: string) {
+  const identity = await prisma.auctionPropertyIdentity.findUnique({
+    where: { id: identityId },
+    include: {
+      auctions: {
+        orderBy: [{ auctionDate: 'asc' }, { createdAt: 'asc' }],
+        select: {
+          slug: true, title: true, source: true, status: true,
+          appraisalValue: true, minimumBid: true, soldValue: true,
+          discountPercent: true, auctionDate: true, soldDate: true, createdAt: true,
+        },
+      },
+    },
+  })
+  if (!identity) return null
+  const num = (v: unknown) => (v == null ? null : Number(v))
+  return {
+    id: identity.id,
+    city: identity.city, state: identity.state, neighborhood: identity.neighborhood,
+    auctionCount: identity.auctionCount,
+    firstAuctionAt: identity.firstAuctionAt,
+    lastAuctionAt: identity.lastAuctionAt,
+    timeline: identity.auctions.map((a) => ({
+      slug: a.slug, title: a.title, source: a.source, status: a.status,
+      appraisalValue: num(a.appraisalValue), minimumBid: num(a.minimumBid), soldValue: num(a.soldValue),
+      discountPercent: a.discountPercent, auctionDate: a.auctionDate, soldDate: a.soldDate,
+      url: `https://agoraencontrei.com.br/leiloes/${a.slug}`,
+    })),
+  }
+}
+
+/** Passe agendado: vincula leilões que ainda não têm identidade e podem ser chaveados. */
+export async function runAuctionIdentityBatch(
+  prisma: PrismaClient,
+  limit = 100,
+): Promise<{ processed: number; linked: number }> {
+  const pending = await prisma.auction.findMany({
+    where: {
+      identityId: null,
+      OR: [
+        { AND: [{ registryNumber: { not: null } }, { registryOffice: { not: null } }] },
+        { AND: [{ street: { not: null } }, { number: { not: null } }, { city: { not: null } }] },
+      ],
+    },
+    select: { id: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let linked = 0
+  for (const a of pending) {
+    const id = await resolveAuctionIdentity(prisma, a.id)
+    if (id) linked++
+  }
+  return { processed: pending.length, linked }
+}

--- a/apps/api/src/services/auction-report.service.ts
+++ b/apps/api/src/services/auction-report.service.ts
@@ -1,0 +1,184 @@
+/**
+ * Auction Report Service — inteligência agregada sobre o arquivo histórico de
+ * leilões, para o Tomás/copilot responderem perguntas por localização, tipo e
+ * valor. Ex.: "quais foram os valores dos imóveis residenciais no centro de
+ * Franca-SP", "qual o desconto médio dos apartamentos", "quantos foram
+ * arrematados".
+ *
+ * Cobre leilões ATIVOS e HISTÓRICOS (já arrematados) — todos os dados públicos
+ * capturados: avaliação, lance mínimo, valor de arremate, desconto, ocupação.
+ */
+
+import type { PrismaClient, Prisma } from '@prisma/client'
+
+export interface AuctionReportFilters {
+  city?: string
+  neighborhood?: string
+  state?: string
+  propertyType?: string // HOUSE | APARTMENT | LAND | COMMERCIAL | ...
+  category?: string      // RESIDENTIAL | COMMERCIAL | ...
+  status?: string        // SOLD | OPEN | DESERTED | ...
+  source?: string        // CAIXA | SANTANDER | JUDICIAL | ...
+  soldOnly?: boolean      // só arrematados (com valor de arremate)
+  minDiscount?: number
+  maxPrice?: number       // teto sobre o lance mínimo
+  sinceMonths?: number    // janela temporal (createdAt)
+}
+
+const CAP = 5000
+
+function toNum(v: unknown): number | null {
+  if (v == null) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+interface NumStats { count: number; min: number; avg: number; median: number; max: number }
+
+function numStats(values: (number | null | undefined)[]): NumStats | null {
+  const v = values.map(toNum).filter((x): x is number => x != null && x > 0).sort((a, b) => a - b)
+  if (!v.length) return null
+  const sum = v.reduce((a, b) => a + b, 0)
+  const mid = Math.floor(v.length / 2)
+  const median = v.length % 2 ? v[mid] : (v[mid - 1] + v[mid]) / 2
+  const round = (n: number) => Math.round(n)
+  return { count: v.length, min: round(v[0]), avg: round(sum / v.length), median: round(median), max: round(v[v.length - 1]) }
+}
+
+/** Monta o where do Prisma a partir dos filtros. */
+export function buildAuctionWhere(f: AuctionReportFilters): Prisma.AuctionWhereInput {
+  const where: Prisma.AuctionWhereInput = {}
+  if (f.city) where.city = { contains: f.city, mode: 'insensitive' }
+  if (f.neighborhood) where.neighborhood = { contains: f.neighborhood, mode: 'insensitive' }
+  if (f.state) where.state = { equals: f.state, mode: 'insensitive' }
+  if (f.propertyType) where.propertyType = f.propertyType.toUpperCase() as any
+  if (f.category) where.category = f.category.toUpperCase() as any
+  if (f.source) where.source = f.source.toUpperCase() as any
+  if (f.minDiscount != null) where.discountPercent = { gte: f.minDiscount }
+  if (f.maxPrice != null) where.minimumBid = { lte: f.maxPrice }
+  if (f.soldOnly) {
+    where.status = 'SOLD'
+    where.soldValue = { not: null }
+  } else if (f.status) {
+    where.status = f.status.toUpperCase() as any
+  } else {
+    // Por padrão, exclui cancelados (ruído) — mantém ativos + históricos.
+    where.status = { not: 'CANCELLED' }
+  }
+  if (f.sinceMonths != null && f.sinceMonths > 0) {
+    const since = new Date(Date.now() - f.sinceMonths * 30 * 24 * 60 * 60 * 1000)
+    where.createdAt = { gte: since }
+  }
+  return where
+}
+
+/** Lista leilões que batem com os filtros (para o tool buscar_leiloes). */
+export async function queryAuctions(prisma: PrismaClient, f: AuctionReportFilters, limit = 12) {
+  const rows = await prisma.auction.findMany({
+    where: buildAuctionWhere(f),
+    select: {
+      slug: true, title: true, city: true, neighborhood: true, state: true,
+      propertyType: true, category: true, status: true, source: true,
+      appraisalValue: true, minimumBid: true, soldValue: true, discountPercent: true,
+      totalArea: true, occupation: true, auctionDate: true, soldDate: true, registryNumber: true,
+    },
+    orderBy: [{ soldDate: 'desc' }, { discountPercent: 'desc' }],
+    take: Math.max(1, Math.min(limit, 30)),
+  })
+  return rows.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    city: r.city,
+    neighborhood: r.neighborhood,
+    state: r.state,
+    propertyType: r.propertyType,
+    category: r.category,
+    status: r.status,
+    source: r.source,
+    appraisalValue: toNum(r.appraisalValue),
+    minimumBid: toNum(r.minimumBid),
+    soldValue: toNum(r.soldValue),
+    discountPercent: r.discountPercent ?? null,
+    totalArea: r.totalArea ?? null,
+    occupation: r.occupation ?? null,
+    auctionDate: r.auctionDate ?? null,
+    soldDate: r.soldDate ?? null,
+    registryNumber: r.registryNumber ?? null,
+    url: `https://agoraencontrei.com.br/leiloes/${r.slug}`,
+  }))
+}
+
+/**
+ * Relatório estatístico agregado (para o tool relatorio_leiloes).
+ * Responde "valores dos imóveis residenciais no centro de Franca-SP" etc.
+ */
+export async function buildAuctionReport(prisma: PrismaClient, f: AuctionReportFilters) {
+  const where = buildAuctionWhere(f)
+
+  const rows = await prisma.auction.findMany({
+    where,
+    select: {
+      appraisalValue: true, minimumBid: true, soldValue: true, discountPercent: true,
+      opportunityScore: true, totalArea: true, propertyType: true, category: true,
+      neighborhood: true, city: true, status: true, occupation: true,
+    },
+    take: CAP,
+  })
+
+  const total = rows.length
+  if (!total) {
+    return { filters: f, total: 0, message: 'Nenhum leilão encontrado com esses filtros no arquivo.' }
+  }
+
+  // pricePerM2 (usa arremate se houver, senão lance mínimo)
+  const perM2: number[] = []
+  for (const r of rows) {
+    const val = toNum(r.soldValue) ?? toNum(r.minimumBid)
+    const area = toNum(r.totalArea)
+    if (val && area && area > 0) perM2.push(val / area)
+  }
+
+  // recorte por bairro (top) e por tipo/status
+  const byNeighborhood = new Map<string, { count: number; sum: number; n: number }>()
+  const byType = new Map<string, number>()
+  const byStatus = new Map<string, number>()
+  let soldCount = 0, occupiedCount = 0
+  for (const r of rows) {
+    const nb = (r.neighborhood || 'Não informado').trim()
+    const agg = byNeighborhood.get(nb) || { count: 0, sum: 0, n: 0 }
+    agg.count++
+    const v = toNum(r.soldValue) ?? toNum(r.minimumBid)
+    if (v) { agg.sum += v; agg.n++ }
+    byNeighborhood.set(nb, agg)
+    byType.set(r.propertyType || '?', (byType.get(r.propertyType || '?') || 0) + 1)
+    byStatus.set(r.status || '?', (byStatus.get(r.status || '?') || 0) + 1)
+    if (r.status === 'SOLD') soldCount++
+    if (r.occupation === 'OCUPADO') occupiedCount++
+  }
+
+  const neighborhoods = [...byNeighborhood.entries()]
+    .map(([name, a]) => ({ neighborhood: name, count: a.count, avgValue: a.n ? Math.round(a.sum / a.n) : null }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 15)
+
+  return {
+    filters: f,
+    total,
+    truncated: total >= CAP,
+    counts: {
+      sold: soldCount,
+      occupied: occupiedCount,
+      byStatus: Object.fromEntries([...byStatus.entries()].sort((a, b) => b[1] - a[1])),
+      byPropertyType: Object.fromEntries([...byType.entries()].sort((a, b) => b[1] - a[1])),
+    },
+    values: {
+      appraisalValue: numStats(rows.map((r) => toNum(r.appraisalValue))),
+      minimumBid: numStats(rows.map((r) => toNum(r.minimumBid))),
+      soldValue: numStats(rows.map((r) => toNum(r.soldValue))),
+      pricePerM2: numStats(perM2),
+      discountPercent: numStats(rows.map((r) => r.discountPercent)),
+      opportunityScore: numStats(rows.map((r) => r.opportunityScore)),
+    },
+    topNeighborhoods: neighborhoods,
+  }
+}

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -941,6 +941,20 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] auction-outcome failed')
   }
 
+  // ── 9e. Identidade canônica do imóvel (agrupa leilões do mesmo imóvel) ───
+  // Vincula leilões chaveáveis (matrícula+cartório, ou endereço completo) a uma
+  // identidade única, habilitando a linha do tempo "foi a leilão N vezes".
+  // 100/rodada, idempotente.
+  try {
+    const { runAuctionIdentityBatch } = await import('./auction-identity.service.js')
+    const r = await runAuctionIdentityBatch(app.prisma, 100)
+    if (r.linked > 0) {
+      app.log.info(`[scheduled] auction-identity: ${r.linked}/${r.processed} leilões vinculados a identidades`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] auction-identity failed')
+  }
+
   // ── 10. Lead re-scoring nightly (03h UTC = 00h BRT) ─────────────────────
   // Aplica recency decay e captura mudanças que aconteceram sem trigger
   // direto (ex.: lead que ficou parado, atividades manuais no CRM, etc.).

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -911,6 +911,20 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] auction-geocode-bairro failed')
   }
 
+  // ── 9f. Enriquecimento por detalhe (descobre editalUrl/documentos) ───────
+  // Busca a página de detalhe dos lotes de leiloeiros SSR (ex.: Mega) e extrai
+  // os PDFs (edital/matrícula), preenchendo editalUrl enquanto o lote está no
+  // ar. Roda antes do arquivamento para o edital já estar disponível.
+  try {
+    const { runDetailEnrichmentBatch } = await import('./auction-detail-enrichment.service.js')
+    const r = await runDetailEnrichmentBatch(app.prisma, 30)
+    if (r.enriched > 0) {
+      app.log.info(`[scheduled] auction-detail-enrich: ${r.enriched}/${r.processed} leilões enriquecidos`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] auction-detail-enrich failed')
+  }
+
   // ── 9c. Arquivamento de documentos de leilão (edital/matrícula → S3) ─────
   // Baixa e arquiva os documentos públicos dos leilões que ainda não têm
   // nenhum documento arquivado. Idempotente (dedup por sha256) e limitado a

--- a/apps/api/src/services/scrapers/mega-scraper.ts
+++ b/apps/api/src/services/scrapers/mega-scraper.ts
@@ -1,0 +1,163 @@
+/**
+ * Mega Leilões — scraper estruturado (Fase 5).
+ *
+ * O megaleiloes.com.br serve HTML renderizado no servidor com cards de lote
+ * consistentes (o GenericLeiloeiroScraper por regex genérico registra 0 nele).
+ * Aqui parseamos os cards de verdade e alimentamos o BaseScraper — cada lote
+ * entra com sourceUrl = página de detalhe, onde o desfecho ("arrematado por
+ * R$ X"), a matrícula e o link do edital ficam disponíveis. Assim o lote flui
+ * por todo o arquivo: snapshots (Fase 1), edital→S3 + matrícula (Fase 2),
+ * captura de desfecho (Fase 3) e identidade do imóvel (Fase 4).
+ */
+
+import { BaseScraper, type ScrapedAuction } from './base-scraper.js'
+
+const BASE = 'https://www.megaleiloes.com.br'
+const LIST = `${BASE}/imoveis`
+
+const TYPE_MAP: Record<string, string> = {
+  casas: 'HOUSE', apartamentos: 'APARTMENT', terrenos: 'LAND', 'terrenos-e-lotes': 'LAND',
+  comerciais: 'COMMERCIAL', 'salas-e-conjuntos': 'COMMERCIAL', galpoes: 'COMMERCIAL',
+  predios: 'COMMERCIAL', lojas: 'COMMERCIAL', rurais: 'FARM', fazendas: 'FARM',
+  'flats-e-lofts': 'APARTMENT', sobrados: 'HOUSE', chacaras: 'FARM',
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .trim()
+}
+
+function parseBR(s: string): number | undefined {
+  const m = s.match(/([\d.]+,\d{2})/)
+  if (!m) return undefined
+  const n = Number(m[1].replace(/\./g, '').replace(',', '.'))
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+// O leiloeiro é o Mega (auctioneerName); a `source` é a CATEGORIA jurídica,
+// que o card informa ("Extrajudicial"/"Judicial"). Usa valores válidos do enum.
+function mapSource(modalidade?: string): string {
+  const t = (modalidade || '').toLowerCase()
+  if (t.includes('extra')) return 'EXTRAJUDICIAL'
+  if (t.includes('judicial')) return 'JUDICIAL'
+  return 'LEILOEIRO'
+}
+
+function mapStatus(s: string): string {
+  const t = s.toLowerCase()
+  if (/arrematad|vendid/.test(t)) return 'SOLD'
+  if (/deserto|negativo/.test(t)) return 'DESERTED'
+  if (/encerrad/.test(t)) return 'CLOSED'
+  if (/aberto|andamento|recebendo/.test(t)) return 'OPEN'
+  return 'UPCOMING'
+}
+
+/**
+ * Parser puro dos cards da listagem do Mega Leilões. Testável offline contra
+ * o HTML real. Um card por `<a class="card-title">`.
+ */
+export function parseMegaListing(html: string): ScrapedAuction[] {
+  const out: ScrapedAuction[] = []
+  const cardRe = /<a class="card-title" href="([^"]+)"[^>]*>([^<]+)<\/a>/g
+  const matches = [...html.matchAll(cardRe)]
+
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i]
+    const start = m.index ?? 0
+    const end = i + 1 < matches.length ? (matches[i + 1].index ?? html.length) : html.length
+    const block = html.slice(start, end)
+
+    const detailUrl = m[1].split('?')[0]
+    const title = decodeEntities(m[2])
+    if (!title) continue
+
+    const idm = detailUrl.match(/-x(\d+)/i) || block.match(/card-number[^>]*>\s*X?(\d+)/i)
+    if (!idm) continue
+    const externalId = `mega-${idm[1]}`
+
+    const loc = block.match(/card-locality"[^>]*title="([^",]+),\s*([^"]+)"/i)
+    const city = loc ? decodeEntities(loc[1]) : undefined
+    const state = loc ? decodeEntities(loc[2]).slice(0, 2).toUpperCase() : undefined
+
+    const st = block.match(/card-status[^>]*>\s*([^<]+)/i)
+    const status = st ? mapStatus(st[1]) : 'OPEN'
+
+    const pr = block.match(/card-price[^>]*>\s*R\$\s*([\d.]+,\d{2})/i)
+    const minimumBid = pr ? parseBR(pr[1]) : undefined
+
+    const mod = block.match(/card-instance-title"><a[^>]*>\s*([^<]+)/i)
+    const modalidade = mod ? decodeEntities(mod[1]) : undefined
+
+    const dt = block.match(/card-first-instance-date"><b>Data:<\/b>\s*(\d{2})\/(\d{2})\/(\d{4})/i)
+    const auctionDate = dt ? new Date(`${dt[3]}-${dt[2]}-${dt[1]}T12:00:00Z`) : undefined
+
+    const seg = detailUrl.match(/\/imoveis\/([a-z0-9-]+)\//i)
+    const propertyType = seg ? (TYPE_MAP[seg[1].toLowerCase()] || 'HOUSE') : 'HOUSE'
+
+    out.push({
+      externalId,
+      source: mapSource(modalidade),
+      sourceUrl: detailUrl,
+      auctioneerName: 'Mega Leilões',
+      auctioneerUrl: BASE,
+      title,
+      city,
+      state,
+      status,
+      modality: 'ONLINE',
+      propertyType,
+      minimumBid,
+      auctionDate,
+      metadata: modalidade ? { modalidade } : {},
+    })
+  }
+
+  return out
+}
+
+export class MegaLeiloesScraper extends BaseScraper {
+  private maxPages: number
+  private fetchImpl: typeof fetch
+
+  constructor(prisma: any, maxPages = 3, fetchImpl: typeof fetch = fetch) {
+    super(prisma, 'MEGA_LEILOES', LIST)
+    this.maxPages = maxPages
+    this.fetchImpl = fetchImpl
+  }
+
+  async scrape(): Promise<ScrapedAuction[]> {
+    const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36'
+    const seen = new Set<string>()
+    const all: ScrapedAuction[] = []
+
+    for (let page = 1; page <= this.maxPages; page++) {
+      const url = page === 1 ? LIST : `${LIST}?pagina=${page}`
+      let html = ''
+      try {
+        const res = await this.fetchImpl(url, { headers: { 'User-Agent': UA } })
+        if (!res.ok) break
+        html = await res.text()
+      } catch {
+        break
+      }
+
+      const items = parseMegaListing(html)
+      if (!items.length) break
+
+      let novos = 0
+      for (const it of items) {
+        if (seen.has(it.externalId)) continue
+        seen.add(it.externalId)
+        all.push(it)
+        novos++
+      }
+      // Página sem itens novos (paginação ignorada/repetida) → para.
+      if (novos === 0) break
+    }
+
+    return all
+  }
+}

--- a/apps/api/src/services/scrapers/scheduler.ts
+++ b/apps/api/src/services/scrapers/scheduler.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { CaixaScraper } from './caixa-scraper.js'
 import { GenericLeiloeiroScraper, LEILOEIROS_CONFIG, BANCOS_CONFIG } from './generic-scraper.js'
+import { MegaLeiloesScraper } from './mega-scraper.js'
 import { AiNewsroomService } from '../ai-newsroom.service.js'
 import { env } from '../../utils/env.js'
 import { fetchSantanderApifyLastRun, persistApifySantanderItems } from '../apify-santander.service.js'
@@ -272,6 +273,21 @@ export class ScraperScheduler {
       } catch (err: any) {
         console.error(`[ScraperScheduler] ${config.name} falhou:`, err.message)
         results.push({ source: config.source, found: 0, created: 0, updated: 0, errors: [err.message], duration: Date.now() - start })
+      }
+    }
+
+    // Mega Leilões — scraper estruturado (o site é HTML renderizado; o parser
+    // genérico por regex registrava 0). Alimenta o pipeline completo do arquivo.
+    {
+      const start = Date.now()
+      try {
+        const scraper = new MegaLeiloesScraper(this.prisma)
+        const result = await scraper.run()
+        console.log(`[ScraperScheduler] Mega Leilões: ${result.found} encontrados (${Date.now() - start}ms)`)
+        results.push({ source: 'MEGA_LEILOES', ...result, duration: Date.now() - start })
+      } catch (err: any) {
+        console.error('[ScraperScheduler] Mega Leilões falhou:', err.message)
+        results.push({ source: 'MEGA_LEILOES', found: 0, created: 0, updated: 0, errors: [err.message], duration: Date.now() - start })
       }
     }
 

--- a/apps/api/src/services/tomas-policy.ts
+++ b/apps/api/src/services/tomas-policy.ts
@@ -88,6 +88,17 @@ export const TOOL_POLICIES: Record<string, ToolPolicy> = {
     requiresConfirmation: true, minRoleRank: R.BROKER, audit: true,
     description: 'Altera dados/preço de um imóvel do parceiro. Escrita — exige confirmação.',
   },
+  // ── Leilões (dados públicos globais — ativos e históricos/arrematados) ─────
+  buscar_leiloes: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: false,
+    description: 'Busca leilões de imóveis (Caixa, bancos, judiciais, leiloeiros) por localização/tipo/valor. Dados públicos, ativos e históricos.',
+  },
+  relatorio_leiloes: {
+    brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'read',
+    requiresConfirmation: false, minRoleRank: R.anonymous, audit: false,
+    description: 'Relatório estatístico agregado de leilões (contagem, valores mín/médio/mediana/máx, desconto) por localização/tipo. Dados públicos.',
+  },
   // ── Leads / Contatos / Visitas / Propostas ─────────────────────────────────
   registrar_lead: {
     brains: ['marketplace', 'partner'], requiresCompanyId: false, access: 'write',

--- a/apps/api/src/services/tomas.service.ts
+++ b/apps/api/src/services/tomas.service.ts
@@ -20,6 +20,7 @@ import {
 } from '@agoraencontrei/tomas-knowledge'
 import { evaluateToolPolicy, roleRank, type TomasBrain } from './tomas-policy.js'
 import { hasValidConsent } from './lead-transfer-consent.service.js'
+import { queryAuctions, buildAuctionReport, type AuctionReportFilters } from './auction-report.service.js'
 import { env } from '../utils/env.js'
 import { notify } from './notification.service.js'
 import { checkAIQuota } from './plan-gating.service.js'
@@ -341,6 +342,45 @@ const TOMAS_TOOLS: Anthropic.Tool[] = [
       properties: {
         propertyId: { type: 'string', description: 'ID do imóvel' },
         reference: { type: 'string', description: 'Código de referência (ex: LEM-0087)' },
+      },
+    },
+  },
+  {
+    name: 'buscar_leiloes',
+    description: 'Busca leilões de imóveis (Caixa, bancos, judiciais, leiloeiros) no arquivo do AgoraEncontrei — ativos e históricos (já arrematados). Use quando o cliente perguntar sobre leilões específicos por localização, tipo ou faixa de valor. Retorna lance mínimo, valor de arremate, desconto, status e link.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        city: { type: 'string', description: 'Cidade (ex.: Franca)' },
+        neighborhood: { type: 'string', description: 'Bairro (ex.: Centro)' },
+        state: { type: 'string', description: 'UF (ex.: SP)' },
+        propertyType: { type: 'string', description: 'Tipo: HOUSE, APARTMENT, LAND, COMMERCIAL, etc.' },
+        category: { type: 'string', description: 'Categoria: RESIDENTIAL ou COMMERCIAL' },
+        status: { type: 'string', description: 'Status: OPEN, SOLD, DESERTED, etc.' },
+        soldOnly: { type: 'boolean', description: 'true para trazer só arrematados (com valor de arremate)' },
+        maxPrice: { type: 'number', description: 'Teto sobre o lance mínimo' },
+        minDiscount: { type: 'number', description: 'Desconto mínimo (%)' },
+        limit: { type: 'number', description: 'Quantidade máxima, de 1 a 30' },
+      },
+    },
+  },
+  {
+    name: 'relatorio_leiloes',
+    description: 'Gera um RELATÓRIO ESTATÍSTICO agregado dos leilões (ativos e históricos) por localização/tipo/valor. Use para perguntas sobre VALORES, MÉDIAS ou QUANTIDADES — ex.: "quais foram os valores dos imóveis residenciais no centro de Franca-SP", "qual o desconto médio dos apartamentos", "quantos foram arrematados". Retorna contagem, valores (mín/médio/mediana/máx) de avaliação, lance mínimo e arremate, preço por m², desconto médio, e recortes por bairro e por tipo.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        city: { type: 'string', description: 'Cidade (ex.: Franca)' },
+        neighborhood: { type: 'string', description: 'Bairro (ex.: Centro)' },
+        state: { type: 'string', description: 'UF (ex.: SP)' },
+        propertyType: { type: 'string', description: 'Tipo: HOUSE, APARTMENT, LAND, COMMERCIAL, etc.' },
+        category: { type: 'string', description: 'Categoria: RESIDENTIAL ou COMMERCIAL' },
+        status: { type: 'string', description: 'Status específico (ex.: SOLD)' },
+        source: { type: 'string', description: 'Fonte: CAIXA, SANTANDER, JUDICIAL, etc.' },
+        soldOnly: { type: 'boolean', description: 'true para estatísticas só de arrematados' },
+        minDiscount: { type: 'number', description: 'Desconto mínimo (%)' },
+        maxPrice: { type: 'number', description: 'Teto sobre o lance mínimo' },
+        sinceMonths: { type: 'number', description: 'Janela temporal em meses (ex.: 12 = último ano)' },
       },
     },
   },
@@ -684,6 +724,44 @@ export async function executeTool(
         condoFee: property.condoFee ? Number(property.condoFee) : null,
         iptu: property.iptu ? Number(property.iptu) : null,
       })
+    }
+
+    case 'buscar_leiloes': {
+      const f: AuctionReportFilters = {
+        city: toolInput.city as string | undefined,
+        neighborhood: toolInput.neighborhood as string | undefined,
+        state: toolInput.state as string | undefined,
+        propertyType: toolInput.propertyType as string | undefined,
+        category: toolInput.category as string | undefined,
+        status: toolInput.status as string | undefined,
+        soldOnly: toolInput.soldOnly === true,
+        maxPrice: toolInput.maxPrice as number | undefined,
+        minDiscount: toolInput.minDiscount as number | undefined,
+      }
+      const limit = Math.max(1, Math.min(Number(toolInput.limit) || 12, 30))
+      const auctions = await queryAuctions(prisma, f, limit)
+      if (!auctions.length) {
+        return JSON.stringify({ found: 0, message: 'Nenhum leilão encontrado com esses filtros no arquivo.' })
+      }
+      return JSON.stringify({ found: auctions.length, auctions })
+    }
+
+    case 'relatorio_leiloes': {
+      const f: AuctionReportFilters = {
+        city: toolInput.city as string | undefined,
+        neighborhood: toolInput.neighborhood as string | undefined,
+        state: toolInput.state as string | undefined,
+        propertyType: toolInput.propertyType as string | undefined,
+        category: toolInput.category as string | undefined,
+        status: toolInput.status as string | undefined,
+        source: toolInput.source as string | undefined,
+        soldOnly: toolInput.soldOnly === true,
+        minDiscount: toolInput.minDiscount as number | undefined,
+        maxPrice: toolInput.maxPrice as number | undefined,
+        sinceMonths: toolInput.sinceMonths as number | undefined,
+      }
+      const report = await buildAuctionReport(prisma, f)
+      return JSON.stringify(report)
     }
 
     case 'registrar_lead': {

--- a/apps/api/test/auction-detail-enrichment.test.ts
+++ b/apps/api/test/auction-detail-enrichment.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import {
+  parseMegaDetail,
+  enrichAuctionDetail,
+  runDetailEnrichmentBatch,
+  type EnrichmentDeps,
+} from '../src/services/auction-detail-enrichment.service.js'
+
+// Fixture com os 3 PDFs reais do detalhe do Mega (edital, matrícula, política).
+const DETAIL_HTML = `<html><body>
+<a href="https://cdn1.megaleiloes.com.br/auctions/34160/megaleiloes_edital__260703-171110.pdf">Edital</a>
+<a href="https://cdn1.megaleiloes.com.br/batches/126419/megaleiloes_matricula_X126419.pdf">Matrícula</a>
+<a href="https://cdn1.megaleiloes.com.br/Politica_de_Privacidade_Mega_Leiloes_Rev_Janeiro_2023.pdf">Política</a>
+</body></html>`
+
+// ── Puro ────────────────────────────────────────────────────────────────────
+test('parseMegaDetail extrai edital + matrícula e ignora institucional', () => {
+  const r = parseMegaDetail(DETAIL_HTML)
+  assert.match(r.editalUrl || '', /megaleiloes_edital__/, 'editalUrl é o PDF de edital')
+  assert.equal(r.documentsUrls.length, 2, 'edital + matrícula (política excluída)')
+  assert.ok(r.documentsUrls.some((u) => /matricula/i.test(u)), 'inclui a matrícula em PDF')
+  assert.ok(!r.documentsUrls.some((u) => /privacidade/i.test(u)), 'exclui a política de privacidade')
+})
+
+// ── Integração ──────────────────────────────────────────────────────────────
+const DB = process.env.TEST_DATABASE_URL
+
+test('enriquecimento por detalhe preenche editalUrl/documentos + guard', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const eid = `ENR-${Math.round(performance.now())}`
+  const sourceUrl = 'https://www.megaleiloes.com.br/imoveis/casas/pr/x/casa-x126419'
+
+  let fetches = 0
+  const deps: EnrichmentDeps = {
+    fetchImpl: (async (url: any) => { fetches++; return new Response(DETAIL_HTML, { status: 200 }) }) as typeof fetch,
+  }
+
+  try {
+    await prisma.auction.deleteMany({ where: { externalId: eid } })
+    const a = await prisma.auction.create({
+      data: {
+        externalId: eid, source: 'EXTRAJUDICIAL' as any, status: 'OPEN' as any,
+        title: 'Casa enrich', slug: `enr-${eid}`, sourceUrl,
+      },
+    })
+    assert.equal(a.editalUrl, null, 'começa sem edital')
+
+    const r = await enrichAuctionDetail(prisma, a.id, deps)
+    assert.equal(r.enriched, true)
+    const a2 = (await prisma.auction.findUnique({ where: { id: a.id } }))!
+    assert.match(a2.editalUrl || '', /megaleiloes_edital__/, 'editalUrl preenchido (alimenta Fase 2)')
+    assert.equal(a2.documentsUrls.length, 2, 'documentos (edital + matrícula) salvos')
+    assert.ok(a2.detailEnrichedAt, 'detailEnrichedAt marcado (guard)')
+
+    // Batch não re-processa (detailEnrichedAt setado)
+    const before = fetches
+    await runDetailEnrichmentBatch(prisma, 30, deps)
+    // pode processar outros leilões mega no banco, mas não o nosso (já enriquecido)
+    const a3 = (await prisma.auction.findUnique({ where: { id: a.id } }))!
+    assert.equal(a3.editalUrl, a2.editalUrl, 'não altera o já enriquecido')
+    assert.ok(fetches >= before, 'batch rodou')
+
+    await prisma.auction.deleteMany({ where: { externalId: eid } })
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/api/test/auction-identity.test.ts
+++ b/apps/api/test/auction-identity.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import {
+  computeIdentityKey,
+  resolveAuctionIdentity,
+  getPropertyTimeline,
+  runAuctionIdentityBatch,
+} from '../src/services/auction-identity.service.js'
+
+// ── Puros ───────────────────────────────────────────────────────────────────
+test('computeIdentityKey: matrícula+cartório forte; fallback endereço; null se insuficiente', () => {
+  assert.deepEqual(
+    computeIdentityKey({ registryNumber: '90.123', registryOffice: '2º Cartório de Registro de Imóveis' }),
+    { registryKey: '2cartorioderegistrodeimoveis#90123' },
+  )
+  const addr = computeIdentityKey({ city: 'Franca', state: 'SP', street: 'Rua A', number: '100' })
+  assert.ok(addr?.addressKey?.includes('franca'))
+  assert.equal(computeIdentityKey({ city: 'Franca' }), null, 'só cidade é insuficiente')
+})
+
+// ── Integração ──────────────────────────────────────────────────────────────
+const DB = process.env.TEST_DATABASE_URL
+
+test('identidade canônica agrupa o mesmo imóvel entre leilões + timeline', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const tag = `IDN-${Math.round(performance.now())}`
+  const mk = (o: any) => prisma.auction.create({
+    data: {
+      source: 'JUDICIAL' as any, status: (o.status || 'CLOSED') as any,
+      title: o.title, slug: `${tag}-${o.title}`.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      externalId: `${tag}-${o.title}`,
+      city: 'Franca', state: 'SP', neighborhood: 'Centro',
+      registryNumber: o.registryNumber, registryOffice: o.registryOffice,
+      street: o.street, number: o.number,
+      minimumBid: o.minimumBid, soldValue: o.soldValue, auctionDate: o.auctionDate,
+    },
+  })
+
+  try {
+    // Mesmo imóvel (matrícula 90123 / mesmo cartório), duas idas a leilão
+    const a2023 = await mk({ title: 'leilao 2023', registryNumber: '90.123', registryOffice: '2º CRI Franca', minimumBid: 200000, auctionDate: new Date('2023-05-01') })
+    const a2024 = await mk({ title: 'leilao 2024', registryNumber: '90123', registryOffice: '2 CRI Franca', minimumBid: 180000, soldValue: 210000, status: 'SOLD', auctionDate: new Date('2024-08-01') })
+    // Imóvel diferente
+    const other = await mk({ title: 'outro imovel', registryNumber: '55777', registryOffice: '1º CRI Franca', minimumBid: 300000, auctionDate: new Date('2024-01-01') })
+
+    const id1 = await resolveAuctionIdentity(prisma, a2023.id)
+    const id2 = await resolveAuctionIdentity(prisma, a2024.id)
+    const id3 = await resolveAuctionIdentity(prisma, other.id)
+
+    assert.ok(id1 && id2 && id3)
+    assert.equal(id1, id2, 'mesmo imóvel (matrícula+cartório) → mesma identidade')
+    assert.notEqual(id1, id3, 'imóvel diferente → identidade diferente')
+
+    const identity = (await prisma.auctionPropertyIdentity.findUnique({ where: { id: id1! } }))!
+    assert.equal(identity.auctionCount, 2, 'identidade agrupa 2 leilões')
+    assert.equal(identity.firstAuctionAt?.getFullYear(), 2023)
+    assert.equal(identity.lastAuctionAt?.getFullYear(), 2024)
+
+    // Timeline em ordem cronológica
+    const tl: any = await getPropertyTimeline(prisma, id1!)
+    assert.equal(tl.timeline.length, 2)
+    assert.match(tl.timeline[0].title, /2023/, 'primeiro é o de 2023')
+    assert.match(tl.timeline[1].title, /2024/, 'depois o de 2024')
+    assert.equal(tl.timeline[1].soldValue, 210000, 'arremate do 2º leilão')
+    assert.ok(tl.timeline[0].url.includes('/leiloes/'))
+
+    // Fallback por endereço (sem matrícula), dois leilões do mesmo endereço
+    const b1 = await mk({ title: 'end 2022', street: 'Rua das Flores', number: '250', minimumBid: 100000, auctionDate: new Date('2022-03-01') })
+    const b2 = await mk({ title: 'end 2025', street: 'Rua das Flores', number: '250', minimumBid: 90000, auctionDate: new Date('2025-02-01') })
+    const bid1 = await resolveAuctionIdentity(prisma, b1.id)
+    const bid2 = await resolveAuctionIdentity(prisma, b2.id)
+    assert.equal(bid1, bid2, 'mesmo endereço completo → mesma identidade (fallback)')
+
+    // Batch vincula pendentes (idempotente — os já vinculados não repetem)
+    const rb = await runAuctionIdentityBatch(prisma, 100)
+    assert.ok(rb.processed >= 0)
+
+    // Limpeza
+    const ids = [id1, id3, bid1].filter(Boolean) as string[]
+    await prisma.auction.deleteMany({ where: { externalId: { startsWith: tag } } })
+    await prisma.auctionPropertyIdentity.deleteMany({ where: { id: { in: ids } } })
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/api/test/auction-report.test.ts
+++ b/apps/api/test/auction-report.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import { buildAuctionReport, queryAuctions } from '../src/services/auction-report.service.js'
+import { executeTool } from '../src/services/tomas.service.js'
+
+const DB = process.env.TEST_DATABASE_URL
+
+test('relatório de leilões por localização/tipo/valor + tool do Tomás', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const tag = `RPT-${Math.round(performance.now())}`
+
+  const mk = (o: any) => prisma.auction.create({
+    data: {
+      source: (o.source || 'LEILOEIRO') as any, status: (o.status || 'OPEN') as any,
+      title: o.title, slug: `${tag}-${o.title}`.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      externalId: `${tag}-${o.title}`,
+      city: o.city, neighborhood: o.neighborhood, state: o.state,
+      propertyType: (o.propertyType || 'HOUSE') as any, category: (o.category || 'RESIDENTIAL') as any,
+      appraisalValue: o.appraisalValue, minimumBid: o.minimumBid, soldValue: o.soldValue,
+      discountPercent: o.discountPercent, totalArea: o.totalArea,
+    },
+  })
+
+  try {
+    // Franca/Centro — 2 residenciais arrematados + 1 comercial aberto
+    await mk({ title: 'casa centro', city: 'Franca', neighborhood: 'Centro', state: 'SP', propertyType: 'HOUSE', category: 'RESIDENTIAL', status: 'SOLD', appraisalValue: 400000, minimumBid: 200000, soldValue: 250000, discountPercent: 50, totalArea: 100 })
+    await mk({ title: 'apto centro', city: 'Franca', neighborhood: 'Centro', state: 'SP', propertyType: 'APARTMENT', category: 'RESIDENTIAL', status: 'SOLD', appraisalValue: 300000, minimumBid: 150000, soldValue: 180000, discountPercent: 50, totalArea: 60 })
+    await mk({ title: 'loja centro', city: 'Franca', neighborhood: 'Centro', state: 'SP', propertyType: 'STORE', category: 'COMMERCIAL', status: 'OPEN', appraisalValue: 900000, minimumBid: 500000 })
+    // ruído que deve ser excluído: cancelado no Centro + imóvel em outra cidade
+    await mk({ title: 'cancelado centro', city: 'Franca', neighborhood: 'Centro', state: 'SP', category: 'RESIDENTIAL', status: 'CANCELLED', minimumBid: 999 })
+    await mk({ title: 'casa sp', city: 'São Paulo', neighborhood: 'Centro', state: 'SP', category: 'RESIDENTIAL', status: 'SOLD', soldValue: 999999 })
+
+    // Relatório: residenciais no Centro de Franca
+    const rep: any = await buildAuctionReport(prisma, { city: 'Franca', neighborhood: 'Centro', category: 'RESIDENTIAL' })
+    assert.equal(rep.total, 2, 'só as 2 residenciais do Centro/Franca (comercial, cancelado e outra cidade fora)')
+    assert.equal(rep.values.soldValue.count, 2)
+    assert.equal(rep.values.soldValue.min, 180000)
+    assert.equal(rep.values.soldValue.max, 250000)
+    assert.equal(rep.values.soldValue.median, 215000, 'mediana dos arremates')
+    assert.equal(rep.values.soldValue.avg, 215000)
+    assert.equal(rep.counts.byPropertyType.HOUSE, 1)
+    assert.equal(rep.counts.byPropertyType.APARTMENT, 1)
+    assert.equal(rep.counts.sold, 2)
+    assert.equal(rep.topNeighborhoods[0].neighborhood, 'Centro')
+    assert.ok(rep.values.pricePerM2 && rep.values.pricePerM2.count === 2, 'preço/m² calculado')
+
+    // soldOnly + fonte + janela
+    const repSold: any = await buildAuctionReport(prisma, { city: 'Franca', soldOnly: true })
+    assert.equal(repSold.total, 2, 'soldOnly traz só arrematados')
+
+    // Listagem
+    const list = await queryAuctions(prisma, { city: 'Franca', neighborhood: 'Centro', soldOnly: true }, 10)
+    assert.equal(list.length, 2)
+    assert.ok(list[0].url.includes('/leiloes/'), 'inclui link público')
+    assert.ok(list.every(a => a.soldValue != null), 'arrematados têm valor')
+
+    // Tool do Tomás end-to-end (cérebro marketplace, anônimo → policy libera)
+    const raw = await executeTool(prisma, 'relatorio_leiloes',
+      { city: 'Franca', neighborhood: 'Centro', category: 'RESIDENTIAL' },
+      undefined, 'site', { brain: 'marketplace', roleRank: 0 })
+    const parsed = JSON.parse(raw)
+    assert.equal(parsed.total, 2, 'tool retorna o relatório')
+    assert.ok(!parsed.error, 'policy não bloqueou (dado público, anônimo)')
+
+    const rawList = await executeTool(prisma, 'buscar_leiloes',
+      { city: 'Franca', soldOnly: true }, undefined, 'site', { brain: 'marketplace', roleRank: 0 })
+    assert.equal(JSON.parse(rawList).found, 2, 'buscar_leiloes retorna listagem')
+
+    // Limpeza
+    await prisma.auction.deleteMany({ where: { externalId: { startsWith: tag } } })
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/api/test/mega-scraper.test.ts
+++ b/apps/api/test/mega-scraper.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { PrismaClient } from '@prisma/client'
+import { parseMegaListing, MegaLeiloesScraper } from '../src/services/scrapers/mega-scraper.js'
+
+// Fixture espelhando o markup REAL do megaleiloes.com.br (2 cards).
+const CARD = (o: {
+  url: string; title: string; id: string; city: string; uf: string;
+  modalidade: string; status: string; date: string; price: string;
+}) => `
+<div class="card"><div class="wrap">
+  <a class="card-title" href="${o.url}?utm_source=megaleiloes&utm_medium=link" data-pjax="0">${o.title}</a>
+  <div class="card-number pull-left">X${o.id}</div>
+  <a class="card-locality" href="#" title="${o.city}, ${o.uf}" data-pjax="0">${o.city}, ${o.uf}</a>
+</div>
+<div class="card-instance"><div class="card-instance-title"><a href="#" data-pjax="0">${o.modalidade}</a>
+  <div class="card-batch-number">Lote 1</div></div>
+  <div class="card-instance-info"><div class="card-status">${o.status}</div>
+  <span class="card-first-instance-date"><b>Data:</b> ${o.date} às 10:00</span></div>
+</div>
+<div class="card-price">R$ ${o.price}</div></div>`
+
+const FIXTURE = `<html><body>
+${CARD({ url: 'https://www.megaleiloes.com.br/imoveis/casas/pr/nova-prata-do-iguacu/casa-136-m2-x126419', title: 'Casa 136 m² - Nova Prata do Iguaçu - PR', id: '126419', city: 'Nova Prata Do Iguaçu', uf: 'PR', modalidade: 'Extrajudicial', status: 'Aberto para lances', date: '14/07/2026', price: '256.000,00' })}
+${CARD({ url: 'https://www.megaleiloes.com.br/imoveis/apartamentos/ba/salvador/apartamento-74-m2-x126441', title: 'Apartamento 74 m² - Salvador - BA', id: '126441', city: 'Salvador', uf: 'BA', modalidade: 'Judicial', status: 'Arrematado', date: '01/03/2026', price: '180.000,00' })}
+</body></html>`
+
+// ── Puro ────────────────────────────────────────────────────────────────────
+test('parseMegaListing extrai os cards do HTML real', () => {
+  const items = parseMegaListing(FIXTURE)
+  assert.equal(items.length, 2)
+
+  const casa = items[0]
+  assert.equal(casa.externalId, 'mega-126419')
+  assert.equal(casa.source, 'EXTRAJUDICIAL', 'Extrajudicial → source EXTRAJUDICIAL')
+  assert.equal(casa.auctioneerName, 'Mega Leilões')
+  assert.equal(casa.propertyType, 'HOUSE')
+  assert.equal(casa.city, 'Nova Prata Do Iguaçu')
+  assert.equal(casa.state, 'PR')
+  assert.equal(casa.status, 'OPEN')
+  assert.equal(casa.minimumBid, 256000)
+  assert.equal(casa.sourceUrl, 'https://www.megaleiloes.com.br/imoveis/casas/pr/nova-prata-do-iguacu/casa-136-m2-x126419', 'sourceUrl sem utm')
+  assert.equal(casa.auctionDate?.toISOString().slice(0, 10), '2026-07-14')
+
+  const apto = items[1]
+  assert.equal(apto.externalId, 'mega-126441')
+  assert.equal(apto.source, 'JUDICIAL', 'Judicial → source JUDICIAL')
+  assert.equal(apto.propertyType, 'APARTMENT')
+  assert.equal(apto.state, 'BA')
+  assert.equal(apto.status, 'SOLD', 'Arrematado → SOLD')
+  assert.equal(apto.minimumBid, 180000)
+})
+
+test('parseMegaListing tolera HTML vazio', () => {
+  assert.deepEqual(parseMegaListing('<html></html>'), [])
+})
+
+// ── Integração: run() completo via BaseScraper (fetch mockado) ──────────────
+const DB = process.env.TEST_DATABASE_URL
+
+test('MegaLeiloesScraper.run() ingere os lotes e gera snapshots', { skip: DB ? false : 'defina TEST_DATABASE_URL' }, async () => {
+  const prisma = new PrismaClient({ datasourceUrl: DB })
+  const mockFetch = (async (url: any) => {
+    if (String(url).includes('pagina=')) return new Response('<html></html>', { status: 200 })
+    return new Response(FIXTURE, { status: 200 })
+  }) as typeof fetch
+
+  try {
+    await prisma.auction.deleteMany({ where: { externalId: { in: ['mega-126419', 'mega-126441'] } } })
+    const scraper = new MegaLeiloesScraper(prisma, 2, mockFetch)
+    const r = await scraper.run()
+    assert.equal(r.created, 2, 'ingere 2 lotes')
+
+    const casa = await prisma.auction.findFirst({ where: { externalId: 'mega-126419' } })
+    assert.ok(casa, 'lote persistido')
+    assert.equal(casa!.source, 'EXTRAJUDICIAL')
+    assert.equal(Number(casa!.minimumBid), 256000)
+    assert.ok(casa!.sourceUrl?.includes('megaleiloes'), 'sourceUrl = página de detalhe (Fase 3 usa para desfecho)')
+    assert.ok(casa!.firstSeenAt && casa!.lastSeenAt, 'ciclo de vida preenchido')
+    const snaps = await prisma.auctionSnapshot.count({ where: { auctionId: casa!.id } })
+    assert.equal(snaps, 1, 'snapshot inicial gravado (Fase 1)')
+
+    // Limpeza
+    for (const eid of ['mega-126419', 'mega-126441']) {
+      const a = await prisma.auction.findFirst({ where: { externalId: eid }, select: { id: true } })
+      if (a) { await prisma.auctionSnapshot.deleteMany({ where: { auctionId: a.id } }); await prisma.auction.delete({ where: { id: a.id } }) }
+    }
+  } finally {
+    await prisma.$disconnect()
+  }
+})

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -836,6 +836,13 @@ export default function LeiloesClient() {
             >
               <Calculator className="w-4 h-4" /> Calculadora
             </button>
+            <a
+              href="/leiloes/relatorios"
+              className="inline-flex shrink-0 whitespace-nowrap items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-bold transition border"
+              style={{ borderColor: '#143A1F', color: '#143A1F' }}
+            >
+              <BarChart3 className="w-4 h-4" /> Relatórios
+            </a>
             <button
               onClick={() => setShowAlert(!showAlert)}
               className="inline-flex shrink-0 whitespace-nowrap items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-bold transition"

--- a/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { MapPin, Clock, Star, Calculator, Bell, ArrowLeft, ExternalLink, FileText, DollarSign, Home, Building, AlertTriangle, CheckCircle, ChevronRight, Share2, TrendingUp, Shield, BarChart3 } from 'lucide-react'
+import AuctionArchivePanel from '@/components/public/AuctionArchivePanel'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ''
 
@@ -219,6 +220,9 @@ export default function LeilaoDetailClient({ auction }: { auction: any }) {
                 </a>
               )}
             </div>
+
+            {/* Arquivo histórico: documentos + histórico de preço/status */}
+            <AuctionArchivePanel slug={auction.slug} />
 
             {/* Market Comparison */}
             {analysis?.marketComparison?.similarProperties?.length > 0 && (

--- a/apps/web/src/app/(public)/leiloes/relatorios/RelatoriosClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/relatorios/RelatoriosClient.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, BarChart3, Search, MapPin, TrendingDown, Home } from 'lucide-react'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ''
+
+function fmt(v: number | null | undefined): string {
+  if (v == null) return '—'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(Number(v))
+}
+
+interface NumStats { count: number; min: number; avg: number; median: number; max: number }
+interface Report {
+  total: number
+  message?: string
+  counts?: { sold: number; occupied: number; byStatus: Record<string, number>; byPropertyType: Record<string, number> }
+  values?: {
+    appraisalValue: NumStats | null; minimumBid: NumStats | null; soldValue: NumStats | null
+    pricePerM2: NumStats | null; discountPercent: NumStats | null; opportunityScore: NumStats | null
+  }
+  topNeighborhoods?: { neighborhood: string; count: number; avgValue: number | null }[]
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  HOUSE: 'Casas', APARTMENT: 'Apartamentos', LAND: 'Terrenos', COMMERCIAL: 'Comerciais', FARM: 'Rurais',
+}
+
+function StatRow({ label, stats, suffix }: { label: string; stats: NumStats | null; suffix?: string }) {
+  if (!stats) return null
+  const val = (n: number) => (suffix ? `${n}${suffix}` : fmt(n))
+  return (
+    <div className="grid grid-cols-5 gap-2 py-2 border-b text-sm items-center">
+      <div className="col-span-1 text-gray-600">{label}</div>
+      <div className="text-center"><div className="text-xs text-gray-400">mín</div><div className="font-medium">{val(stats.min)}</div></div>
+      <div className="text-center"><div className="text-xs text-gray-400">médio</div><div className="font-medium">{val(stats.avg)}</div></div>
+      <div className="text-center"><div className="text-xs text-gray-400">mediana</div><div className="font-bold text-gray-800">{val(stats.median)}</div></div>
+      <div className="text-center"><div className="text-xs text-gray-400">máx</div><div className="font-medium">{val(stats.max)}</div></div>
+    </div>
+  )
+}
+
+export default function RelatoriosClient() {
+  const [city, setCity] = useState('')
+  const [neighborhood, setNeighborhood] = useState('')
+  const [category, setCategory] = useState('')
+  const [propertyType, setPropertyType] = useState('')
+  const [soldOnly, setSoldOnly] = useState(false)
+  const [report, setReport] = useState<Report | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const run = async () => {
+    setLoading(true)
+    setReport(null)
+    const p = new URLSearchParams()
+    if (city) p.set('city', city)
+    if (neighborhood) p.set('neighborhood', neighborhood)
+    if (category) p.set('category', category)
+    if (propertyType) p.set('propertyType', propertyType)
+    if (soldOnly) p.set('soldOnly', 'true')
+    try {
+      const r = await fetch(`${API_URL}/api/v1/auctions/report?${p.toString()}`)
+      if (r.ok) setReport(await r.json())
+    } catch { /* best-effort */ }
+    setLoading(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f8f6f1]">
+      <div className="bg-white border-b">
+        <div className="max-w-5xl mx-auto px-4 py-3">
+          <Link href="/leiloes" className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-800">
+            <ArrowLeft className="w-4 h-4" /> Voltar aos Leilões
+          </Link>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-800 flex items-center gap-2 mb-1">
+          <BarChart3 className="w-6 h-6" style={{ color: '#C9A84C' }} /> Relatórios de Leilões
+        </h1>
+        <p className="text-gray-500 mb-6">Valores por localização e tipo — quanto arrematou, lance mínimo, avaliação, desconto e preço/m².</p>
+
+        {/* Filtros */}
+        <div className="bg-white rounded-xl p-5 shadow-sm mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            <input value={city} onChange={(e) => setCity(e.target.value)} placeholder="Cidade (ex.: Franca)"
+              className="px-3 py-2 border rounded-lg text-base" />
+            <input value={neighborhood} onChange={(e) => setNeighborhood(e.target.value)} placeholder="Bairro (ex.: Centro)"
+              className="px-3 py-2 border rounded-lg text-base" />
+            <select value={category} onChange={(e) => setCategory(e.target.value)} className="px-3 py-2 border rounded-lg text-base bg-white">
+              <option value="">Categoria (todas)</option>
+              <option value="RESIDENTIAL">Residencial</option>
+              <option value="COMMERCIAL">Comercial</option>
+            </select>
+            <select value={propertyType} onChange={(e) => setPropertyType(e.target.value)} className="px-3 py-2 border rounded-lg text-base bg-white">
+              <option value="">Tipo (todos)</option>
+              <option value="HOUSE">Casa</option>
+              <option value="APARTMENT">Apartamento</option>
+              <option value="LAND">Terreno</option>
+              <option value="COMMERCIAL">Comercial</option>
+            </select>
+          </div>
+          <div className="flex items-center justify-between mt-3">
+            <label className="flex items-center gap-2 text-sm text-gray-600">
+              <input type="checkbox" checked={soldOnly} onChange={(e) => setSoldOnly(e.target.checked)} /> Só arrematados
+            </label>
+            <button onClick={run} disabled={loading}
+              className="flex items-center gap-2 px-5 py-2 rounded-lg text-white font-medium disabled:opacity-60"
+              style={{ background: '#1B2B5B' }}>
+              <Search className="w-4 h-4" /> {loading ? 'Consultando…' : 'Gerar relatório'}
+            </button>
+          </div>
+        </div>
+
+        {report && report.total === 0 && (
+          <div className="bg-white rounded-xl p-6 shadow-sm text-center text-gray-500">
+            {report.message || 'Nenhum leilão encontrado com esses filtros.'}
+          </div>
+        )}
+
+        {report && report.total > 0 && (
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <div className="bg-white rounded-xl p-4 shadow-sm text-center">
+                <div className="text-2xl font-bold text-gray-800">{report.total}</div>
+                <div className="text-xs text-gray-500">leilões</div>
+              </div>
+              <div className="bg-white rounded-xl p-4 shadow-sm text-center">
+                <div className="text-2xl font-bold text-green-600">{report.counts?.sold ?? 0}</div>
+                <div className="text-xs text-gray-500">arrematados</div>
+              </div>
+              <div className="bg-white rounded-xl p-4 shadow-sm text-center">
+                <div className="text-2xl font-bold text-gray-800">{report.values?.discountPercent?.median ?? '—'}%</div>
+                <div className="text-xs text-gray-500">desconto (mediana)</div>
+              </div>
+              <div className="bg-white rounded-xl p-4 shadow-sm text-center">
+                <div className="text-2xl font-bold text-gray-800">{report.values?.pricePerM2 ? fmt(report.values.pricePerM2.median) : '—'}</div>
+                <div className="text-xs text-gray-500">preço/m² (mediana)</div>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-xl p-6 shadow-sm">
+              <h3 className="text-lg font-bold text-gray-800 mb-3 flex items-center gap-2">
+                <TrendingDown className="w-5 h-5" style={{ color: '#C9A84C' }} /> Valores
+              </h3>
+              <StatRow label="Arremate" stats={report.values?.soldValue ?? null} />
+              <StatRow label="Lance mínimo" stats={report.values?.minimumBid ?? null} />
+              <StatRow label="Avaliação" stats={report.values?.appraisalValue ?? null} />
+              <StatRow label="Desconto" stats={report.values?.discountPercent ?? null} suffix="%" />
+            </div>
+
+            {report.counts?.byPropertyType && Object.keys(report.counts.byPropertyType).length > 0 && (
+              <div className="bg-white rounded-xl p-6 shadow-sm">
+                <h3 className="text-lg font-bold text-gray-800 mb-3 flex items-center gap-2">
+                  <Home className="w-5 h-5" style={{ color: '#C9A84C' }} /> Por tipo
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(report.counts.byPropertyType).map(([t, n]) => (
+                    <span key={t} className="px-3 py-1.5 bg-gray-50 rounded-lg text-sm">
+                      {TYPE_LABEL[t] || t}: <b>{n}</b>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {report.topNeighborhoods && report.topNeighborhoods.length > 0 && (
+              <div className="bg-white rounded-xl p-6 shadow-sm">
+                <h3 className="text-lg font-bold text-gray-800 mb-3 flex items-center gap-2">
+                  <MapPin className="w-5 h-5" style={{ color: '#C9A84C' }} /> Por bairro
+                </h3>
+                <div className="space-y-2">
+                  {report.topNeighborhoods.map((n, i) => (
+                    <div key={i} className="flex items-center justify-between text-sm border-b last:border-0 py-1.5">
+                      <span className="text-gray-700">{n.neighborhood}</span>
+                      <span className="text-gray-500">{n.count} · valor médio <b className="text-gray-800">{fmt(n.avgValue)}</b></span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(public)/leiloes/relatorios/page.tsx
+++ b/apps/web/src/app/(public)/leiloes/relatorios/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+import RelatoriosClient from './RelatoriosClient'
+
+export const metadata: Metadata = {
+  title: 'Relatórios de Leilões | AgoraEncontrei — Valores por Cidade, Bairro e Tipo',
+  description: 'Consulte os valores dos imóveis em leilão por localização e tipo: quanto foi arrematado, lance mínimo, avaliação, desconto médio e preço por m². Dados do arquivo histórico de leilões.',
+  keywords: [
+    'valores leilão imóveis', 'quanto arrematou leilão', 'preço médio leilão',
+    'relatório leilão imóveis', 'desconto médio leilão', 'leilão por bairro',
+  ],
+  alternates: { canonical: 'https://www.agoraencontrei.com.br/leiloes/relatorios' },
+}
+
+export default function RelatoriosPage() {
+  return <RelatoriosClient />
+}

--- a/apps/web/src/components/public/AuctionArchivePanel.tsx
+++ b/apps/web/src/components/public/AuctionArchivePanel.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { FileText, History, Download, Landmark } from 'lucide-react'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ''
+
+function fmtCurrency(v: number | null | undefined): string {
+  if (!v) return '—'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }).format(Number(v))
+}
+function fmtDateTime(d: string | null | undefined): string {
+  if (!d) return '—'
+  return new Date(d).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+const STATUS_LABEL: Record<string, string> = {
+  UPCOMING: 'Em breve', OPEN: 'Aberto', FIRST_ROUND: '1ª Praça', SECOND_ROUND: '2ª Praça',
+  SOLD: 'Arrematado', DESERTED: 'Deserto', SUSPENDED: 'Suspenso', CANCELLED: 'Cancelado', CLOSED: 'Encerrado',
+}
+const DOC_LABEL: Record<string, string> = {
+  EDITAL: 'Edital', MATRICULA: 'Matrícula', LAUDO: 'Laudo de Avaliação', ATA: 'Ata do Leilão', OUTRO: 'Documento',
+}
+
+interface Snapshot {
+  capturedAt: string; status: string | null
+  appraisalValue: number | null; minimumBid: number | null
+  currentBid: number | null; soldValue: number | null; discountPercent: number | null
+}
+interface Doc {
+  type: string; sourceUrl: string; s3Url: string | null; mimeType: string | null; capturedAt: string
+}
+
+/**
+ * Painel do arquivo histórico de um leilão: documentos públicos arquivados
+ * (edital/matrícula/laudo) e a linha do tempo de preço/status (snapshots).
+ * Consome GET /api/v1/auctions/:slug/documents e /history.
+ */
+export default function AuctionArchivePanel({ slug }: { slug: string }) {
+  const [history, setHistory] = useState<Snapshot[]>([])
+  const [documents, setDocuments] = useState<Doc[]>([])
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        const r = await fetch(`${API_URL}/api/v1/auctions/${slug}/documents`)
+        if (r.ok && alive) setDocuments((await r.json()).documents || [])
+      } catch { /* best-effort */ }
+      try {
+        const r = await fetch(`${API_URL}/api/v1/auctions/${slug}/history`)
+        if (r.ok && alive) setHistory((await r.json()).history || [])
+      } catch { /* best-effort */ }
+    })()
+    return () => { alive = false }
+  }, [slug])
+
+  if (!documents.length && history.length < 2) return null
+
+  return (
+    <>
+      {documents.length > 0 && (
+        <div className="bg-white rounded-xl p-6 shadow-sm">
+          <h3 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
+            <FileText className="w-5 h-5" style={{ color: '#C9A84C' }} /> Documentos do Leilão
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {documents.map((d, i) => (
+              <a key={i} href={d.s3Url || d.sourceUrl} target="_blank" rel="noopener noreferrer"
+                className="flex items-center justify-between gap-2 px-4 py-3 bg-gray-50 rounded-lg text-sm hover:bg-gray-100 transition">
+                <span className="flex items-center gap-2 font-medium text-gray-700">
+                  {d.type === 'MATRICULA' ? <Landmark className="w-4 h-4" /> : <FileText className="w-4 h-4" />}
+                  {DOC_LABEL[d.type] || d.type}
+                </span>
+                <Download className="w-4 h-4 text-gray-400" />
+              </a>
+            ))}
+          </div>
+          <p className="text-xs text-gray-400 mt-3">Documentos públicos arquivados pelo AgoraEncontrei.</p>
+        </div>
+      )}
+
+      {history.length >= 2 && (
+        <div className="bg-white rounded-xl p-6 shadow-sm">
+          <h3 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
+            <History className="w-5 h-5" style={{ color: '#C9A84C' }} /> Histórico do Leilão
+          </h3>
+          <div className="space-y-3">
+            {history.slice().reverse().map((s, i) => {
+              const value = s.soldValue || s.currentBid || s.minimumBid
+              return (
+                <div key={i} className="flex items-center justify-between gap-3 pb-3 border-b last:border-0 text-sm">
+                  <div className="flex items-center gap-3">
+                    <div className={`w-2 h-2 rounded-full ${s.status === 'SOLD' ? 'bg-green-500' : s.status === 'DESERTED' ? 'bg-red-400' : 'bg-[#C9A84C]'}`} />
+                    <div>
+                      <div className="font-medium text-gray-700">{STATUS_LABEL[s.status || ''] || s.status || '—'}</div>
+                      <div className="text-xs text-gray-400">{fmtDateTime(s.capturedAt)}</div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-bold text-gray-800">{fmtCurrency(value)}</div>
+                    {s.discountPercent != null && <div className="text-xs text-green-600">{s.discountPercent}% off</div>}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <p className="text-xs text-gray-400 mt-3">Evolução de preço e status capturada automaticamente.</p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2387,6 +2387,10 @@ model Auction {
   outcomeCapturedAt   DateTime?       // Quando capturamos um desfecho conclusivo
   outcomeAttempts     Int             @default(0) // Tentativas de captura (limite anti-hammer)
 
+  // Identidade canônica do imóvel (liga o mesmo imóvel entre vários leilões no tempo)
+  identityId          String?
+  identity            AuctionPropertyIdentity? @relation(fields: [identityId], references: [id])
+
   // Analytics
   views               Int             @default(0)
   favorites           Int             @default(0)
@@ -2412,7 +2416,30 @@ model Auction {
   @@index([slug])
   @@index([externalId, source])
   @@index([disappearedAt])
+  @@index([identityId])
   @@map("auctions")
+}
+
+// Identidade canônica de um imóvel — agrupa todas as vezes que o MESMO imóvel
+// foi a leilão ao longo do tempo (chave = matrícula+cartório; fallback endereço
+// completo). Permite a linha do tempo "este imóvel já foi a leilão 3x desde 2023".
+model AuctionPropertyIdentity {
+  id             String    @id @default(cuid())
+  registryKey    String?   @unique // cartório+matrícula normalizado (chave forte)
+  addressKey     String?   @unique // endereço normalizado (fallback)
+  city           String?
+  state          String?
+  neighborhood   String?
+  auctionCount   Int       @default(0)
+  firstAuctionAt DateTime?
+  lastAuctionAt  DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  auctions       Auction[]
+
+  @@index([city, state])
+  @@map("auction_property_identities")
 }
 
 // Snapshot temporal de um leilão — histórico imutável de cada mudança observada.

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2391,6 +2391,9 @@ model Auction {
   identityId          String?
   identity            AuctionPropertyIdentity? @relation(fields: [identityId], references: [id])
 
+  // Enriquecimento por página de detalhe (descoberta de editalUrl/documentos)
+  detailEnrichedAt    DateTime?
+
   // Analytics
   views               Int             @default(0)
   favorites           Int             @default(0)


### PR DESCRIPTION
## Contexto

O PR #308 foi mergeado em `main` **até o commit de extração de PDF** — antes de estas partes serem concluídas. Além disso, o merge disparou o workflow **Build Desktop (.exe) #42**, que **falhou** (`✗ web .next`). Este PR corrige o build **e** traz o restante do trabalho.

## Correção do Build Desktop (.exe) — a falha do #42

**Causa raiz (não relacionada às mudanças de leilão):** o job `build-windows` roda em `windows-latest`. O `next.config.mjs` desliga o `output: 'standalone'` no Windows (`process.platform === 'win32'`) para o dev local não exigir Developer Mode/admin nos symlinks do trace. Mas o instalador offline **precisa** do standalone — o `bundle-server.mjs` copia `apps/web/.next/standalone`. Sem ele, o build gera `.next` sem standalone → o bundle pula o web (`web (Next standalone): pulado`) → o passo "Verify API packed" falha em `✗ web .next`.

Esse guard de Windows foi adicionado depois do último build verde (07/07); o merge do #308 (tocando `packages/database/prisma/**`) foi o primeiro trigger do workflow desde então e apenas expôs o bug pré-existente.

**Fix (1 linha):** `FORCE_NEXT_STANDALONE: '1'` no env do passo "Build Web", que reativa o standalone no Windows. Verificado localmente: com standalone ligado, o build gera `apps/web/.next/standalone/apps/web/server.js` — exatamente o que o bundle copia e o verify checa.

## Restante do trabalho (não incluído no merge do #308)

- **Inteligência do Tomás + copilot:** `auction-report.service` + tools `buscar_leiloes` e `relatorio_leiloes` (policy pública). Responde valores por localização/tipo/valor no widget do site e no copilot.
- **Fase 4 — Identidade do imóvel:** `AuctionPropertyIdentity` + timeline ("foi a leilão N vezes desde ANO").
- **Fase 5 — Scraper estruturado do Mega Leilões** (SSR; o regex genérico registrava 0).
- **Endpoints REST** (`/api/v1/auctions`): `/report`, `/:slug/history`, `/:slug/documents`, `/property/:id/timeline`.
- **Enriquecimento por detalhe do Mega:** descobre `editalUrl` + **matrícula em PDF** enquanto o lote está vivo (cron 9f).
- **Frontend:** `AuctionArchivePanel` (documentos + histórico na página do leilão) e página `/leiloes/relatorios`.

## Testes

- **API: 115/115 testes verdes** (Postgres 16 real). **Web: 0 erros de typecheck.**
- `next build` reproduzido localmente: **compila e gera standalone** (as 217 páginas + minhas rotas). `verify:boot` → 100 rotas. Boot real do servidor OK.
- Testes com banco se auto-pulam sem `TEST_DATABASE_URL` (CI verde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JG1LJ7JvTabaeKJNHvQCoH)_