### PR TITLE
feat(leiloes): central de inteligência — landing por leilão, agente de imagem, Desconto Real AE e dashboard regional

### DIFF
--- a/apps/api/src/plugins/automation.ts
+++ b/apps/api/src/plugins/automation.ts
@@ -7,6 +7,7 @@ import { runAutomation } from '../services/automation.worker.js'
 import { runScheduledJobs } from '../services/scheduled.jobs.js'
 import { runDetailEnrichmentBatch } from '../services/auction-detail-enrichment.service.js'
 import { runAuctionArchiveBatch } from '../services/auction-archive.service.js'
+import { runAuctionImageBatch } from '../services/auction-image.service.js'
 import { processVisualAIJob } from '../workers/visual-ai.worker.js'
 import { processCampaignJob } from '../workers/campaign.worker.js'
 import { processVideoEditorJob } from '../workers/video-editor.worker.js'
@@ -44,6 +45,21 @@ export default fp(async (app: FastifyInstance) => {
         app.log.info(`[auction-backfill] ${discovered}/${checked} documentos oficiais descobertos`)
         const archive = await runAuctionArchiveBatch(app.prisma, 500)
         app.log.info(`[auction-backfill] ${archive.archived} documentos arquivados de ${archive.processed} leilões`)
+
+        // Agente de imagem: dá foto real (leiloeiro/Caixa) ou fachada (Street
+        // View) aos leilões sem capa. Percorre o backlog em lotes até esgotar
+        // ou atingir o teto de segurança (evita loop infinito no boot).
+        let covered = 0
+        let processedImgs = 0
+        for (let page = 0; page < 40; page++) {
+          const imgs = await runAuctionImageBatch(app.prisma, 60)
+          covered += imgs.withCover
+          processedImgs += imgs.processed
+          if (imgs.processed === 0) break
+        }
+        if (processedImgs > 0) {
+          app.log.info(`[auction-backfill] ${covered}/${processedImgs} leilões receberam imagem (foto ou fachada)`)
+        }
       } catch (e) {
         app.log.error({ err: e }, '[auction-backfill] failed')
       }

--- a/apps/api/src/routes/auctions/index.ts
+++ b/apps/api/src/routes/auctions/index.ts
@@ -684,20 +684,37 @@ export default async function auctionsRoutes(app: FastifyInstance) {
   app.get('/:slug', async (req: FastifyRequest<{ Params: { slug: string } }>, reply: FastifyReply) => {
     const { slug } = req.params
 
-    const auction = await app.prisma.auction.findUnique({
-      where: { slug },
-      include: {
-        bids: { orderBy: { bidDate: 'desc' }, take: 10 },
-        analyses: { orderBy: { createdAt: 'desc' }, take: 1 },
-        documents: {
-          orderBy: { capturedAt: 'desc' },
-          select: {
-            id: true, type: true, sourceUrl: true, s3Url: true,
-            mimeType: true, status: true, capturedAt: true,
-          },
+    const includeRelations = {
+      bids: { orderBy: { bidDate: 'desc' as const }, take: 10 },
+      analyses: { orderBy: { createdAt: 'desc' as const }, take: 1 },
+      documents: {
+        orderBy: { capturedAt: 'desc' as const },
+        select: {
+          id: true, type: true, sourceUrl: true, s3Url: true,
+          mimeType: true, status: true, capturedAt: true,
         },
       },
+    }
+
+    let auction = await app.prisma.auction.findUnique({
+      where: { slug },
+      include: includeRelations,
     })
+
+    // Fallback: itens do feed público da Caixa chegam como `public-{id}` (ou o
+    // próprio código do imóvel). Resolvemos para o leilão canônico pelo
+    // externalId — assim TODO leilão listado abre uma landing no AgoraEncontrei
+    // em vez de cair no site do leiloeiro.
+    if (!auction) {
+      const rawId = slug.replace(/^public[-_]/i, '').replace(/^caixa[-_]/i, '')
+      const digits = rawId.replace(/\D/g, '')
+      if (digits) {
+        auction = await app.prisma.auction.findFirst({
+          where: { externalId: { in: [`CAIXA-${digits}`, `CAIXA-${rawId}`, rawId, digits] } },
+          include: includeRelations,
+        })
+      }
+    }
 
     if (!auction) {
       return reply.status(404).send({ error: 'Leilão não encontrado' })

--- a/apps/api/src/routes/auctions/index.ts
+++ b/apps/api/src/routes/auctions/index.ts
@@ -5,6 +5,7 @@ import { env } from '../../utils/env.js'
 import { calculateAcquisitionCosts, getStateCosts, validateDocument } from '../../utils/brazil-costs.js'
 import { CaixaScraper } from '../../services/scrapers/caixa-scraper.js'
 import { GenericLeiloeiroScraper, BANCOS_CONFIG } from '../../services/scrapers/generic-scraper.js'
+import { computeRealDiscount } from '../../services/auction-real-discount.service.js'
 
 // ── Schemas de validação ────────────────────────────────────────────────────
 
@@ -727,7 +728,17 @@ export default async function auctionsRoutes(app: FastifyInstance) {
       }).catch(() => null),
     ])
 
-    return reply.send({ ...auction, relatedAuctions })
+    // Desconto Real AE — vantagem líquida real (mercado − lance − custos).
+    const realDiscount = await computeRealDiscount(app.prisma, {
+      city: auction.city, state: auction.state, propertyType: auction.propertyType,
+      totalArea: auction.totalArea, builtArea: auction.builtArea, landArea: auction.landArea,
+      appraisalValue: auction.appraisalValue ? Number(auction.appraisalValue) : null,
+      minimumBid: auction.minimumBid ? Number(auction.minimumBid) : null,
+      marketPriceEstimate: auction.marketPriceEstimate ? Number(auction.marketPriceEstimate) : null,
+      occupation: auction.occupation, discountPercent: auction.discountPercent,
+    }).catch(() => null)
+
+    return reply.send({ ...auction, relatedAuctions, realDiscount })
   })
 
   // ── POST /auctions/calculate — Calculadora financeira ──────────────────────

--- a/apps/api/src/services/auction-image.service.ts
+++ b/apps/api/src/services/auction-image.service.ts
@@ -1,0 +1,227 @@
+/**
+ * Auction Image Capture Agent — captura automática da imagem do leilão.
+ *
+ * A maior parte dos leilões entra na base sem foto (o CSV/lista da fonte não
+ * traz imagem), e o card/landing acaba mostrando o banner ilustrativo padrão.
+ * Este agente resolve isso em três camadas, na ordem de melhor procedência:
+ *
+ *   1. AUCTIONEER  — foto oficial do imóvel:
+ *        • Caixa: derivada do código oficial do imóvel (padrão de URL conhecido);
+ *        • demais leiloeiros SSR: og:image / primeira foto da galeria do lote.
+ *   2. STREETVIEW  — fachada via Google Street View a partir do endereço/coords
+ *        do leilão (fallback quando não há foto do leiloeiro).
+ *
+ * Grava `coverImage` (se estiver vazia), `streetViewUrl` (sempre que houver
+ * fachada), e a procedência em `imageSource` — a página do leilão usa isso para
+ * sinalizar a confiabilidade da imagem (foto do leiloeiro x fachada aproximada).
+ *
+ * Best-effort e throttled: cada tentativa incrementa `imageCaptureAttempts` e
+ * grava `imageCapturedAt`, evitando martelar fontes que não têm imagem.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { getStreetViewForProperty } from './streetview.service.js'
+
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36'
+
+export interface ImageCaptureDeps {
+  fetchImpl?: typeof fetch
+}
+
+export type ImageSource = 'AUCTIONEER' | 'STREETVIEW' | 'NONE'
+
+/**
+ * Deriva a URL da foto oficial da Caixa a partir do código do imóvel — mesma
+ * lógica usada no frontend (`fotos-imoveis/{id}_1.jpg`). Não depende de HTTP:
+ * a origem recusa datacenters, mas o mesmo arquivo abre para o usuário final.
+ */
+export function deriveCaixaPhotoUrl(
+  externalId: string | null | undefined,
+  sourceUrl: string | null | undefined,
+): string | undefined {
+  let id = ''
+  if (externalId && /^CAIXA[-_:]/i.test(externalId)) {
+    id = externalId.replace(/^CAIXA[-_:]/i, '').replace(/^HTML[-_:]/i, '')
+  }
+  if (!id && sourceUrl && /caixa\.gov\.br/i.test(sourceUrl)) {
+    const m = sourceUrl.match(/[?&](?:hdnimovel|idImo)=([^&#]+)/i)
+    id = m?.[1] || ''
+  }
+  const digits = id.replace(/\D/g, '')
+  if (!digits) return undefined
+  return `https://venda-imoveis.caixa.gov.br/fotos-imoveis/${digits}_1.jpg`
+}
+
+/** Extrai a melhor imagem de uma página de detalhe SSR (og:image + galeria). */
+export function extractImageFromHtml(html: string, baseUrl?: string): string | undefined {
+  const abs = (u: string): string | undefined => {
+    if (!u) return undefined
+    if (/^https?:\/\//i.test(u)) return u
+    if (u.startsWith('//')) return `https:${u}`
+    if (baseUrl && u.startsWith('/')) {
+      try { return new URL(u, baseUrl).toString() } catch { return undefined }
+    }
+    return undefined
+  }
+
+  // 1. og:image / twitter:image — o que o próprio leiloeiro escolheu como capa.
+  const og =
+    html.match(/<meta[^>]+(?:property|name)=["'](?:og:image|twitter:image)(?::url)?["'][^>]*content=["']([^"']+)["']/i) ||
+    html.match(/<meta[^>]+content=["']([^"']+)["'][^>]*(?:property|name)=["'](?:og:image|twitter:image)["']/i)
+  const ogUrl = og && abs(og[1].trim())
+  if (ogUrl && !/logo|placeholder|sprite|icon|banner|selo/i.test(ogUrl)) return ogUrl
+
+  // 2. Primeira foto de imóvel na galeria (jpg/png/webp com cara de foto do lote).
+  const imgs = [...html.matchAll(/<img[^>]+src=["']([^"']+\.(?:jpe?g|png|webp))(?:\?[^"']*)?["']/gi)].map((m) => m[1])
+  for (const src of imgs) {
+    if (/logo|placeholder|sprite|icon|avatar|banner|selo|bandeira|favicon/i.test(src)) continue
+    const u = abs(src)
+    if (u) return u
+  }
+  return ogUrl || undefined
+}
+
+/** Confirma que a URL responde como imagem (best-effort; falha vira "sem imagem"). */
+async function urlLooksLikeImage(url: string, fetchImpl: typeof fetch): Promise<boolean> {
+  try {
+    const res = await fetchImpl(url, { method: 'GET', headers: { 'User-Agent': UA, Range: 'bytes=0-2048' } })
+    if (!res.ok) return false
+    const ct = res.headers.get('content-type') || ''
+    return /image\//i.test(ct)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Captura a imagem de UM leilão. Idempotente: só preenche o que falta. Marca
+ * a tentativa (imageCapturedAt/attempts) mesmo quando não encontra imagem.
+ */
+export async function captureAuctionImage(
+  prisma: PrismaClient,
+  auctionId: string,
+  deps: ImageCaptureDeps = {},
+): Promise<{ updated: boolean; source: ImageSource }> {
+  const fetchImpl = deps.fetchImpl || fetch
+  const auction = await prisma.auction.findUnique({
+    where: { id: auctionId },
+    select: {
+      id: true, externalId: true, source: true, sourceUrl: true,
+      coverImage: true, streetViewUrl: true, imageSource: true,
+      latitude: true, longitude: true, street: true, number: true,
+      city: true, state: true,
+    },
+  })
+  if (!auction) return { updated: false, source: 'NONE' }
+
+  const data: Record<string, unknown> = {
+    imageCapturedAt: new Date(),
+    imageCaptureAttempts: { increment: 1 },
+  }
+  let cover: string | undefined
+  let coverSource: ImageSource = 'NONE'
+  let streetView: string | undefined = auction.streetViewUrl ?? undefined
+
+  const hasRealCover = !!auction.coverImage && auction.imageSource !== 'STREETVIEW'
+
+  // ── Camada 1: foto oficial do leiloeiro ──────────────────────────────────
+  if (!hasRealCover) {
+    // Caixa: URL derivada do código do imóvel (sem HTTP — a origem bloqueia DC).
+    if (/caixa/i.test(auction.source) || /caixa\.gov\.br/i.test(auction.sourceUrl || '')) {
+      const caixa = deriveCaixaPhotoUrl(auction.externalId, auction.sourceUrl)
+      if (caixa) { cover = caixa; coverSource = 'AUCTIONEER' }
+    }
+    // Demais leiloeiros SSR: extrai og:image / galeria da página de detalhe.
+    if (!cover && auction.sourceUrl && /^https?:\/\//i.test(auction.sourceUrl)) {
+      try {
+        const res = await fetchImpl(auction.sourceUrl, { headers: { 'User-Agent': UA } })
+        if (res.ok) {
+          const html = await res.text()
+          const found = extractImageFromHtml(html, auction.sourceUrl)
+          if (found && (await urlLooksLikeImage(found, fetchImpl))) {
+            cover = found
+            coverSource = 'AUCTIONEER'
+          }
+        }
+      } catch { /* rede falhou — tenta Street View / próxima rodada */ }
+    }
+  }
+
+  // ── Camada 2: fachada via Street View ────────────────────────────────────
+  // Sempre buscamos a fachada quando ainda não temos — serve de capa (se não
+  // houver foto do leiloeiro) e como camada extra na landing.
+  if (!streetView && (auction.latitude || auction.street || auction.city)) {
+    try {
+      const sv = await getStreetViewForProperty({
+        latitude: auction.latitude, longitude: auction.longitude,
+        street: auction.street, number: auction.number,
+        city: auction.city, state: auction.state,
+      })
+      if (sv.available && sv.imageUrl) streetView = sv.imageUrl
+    } catch { /* Street View é best-effort */ }
+  }
+  if (!cover && !hasRealCover && streetView) {
+    cover = streetView
+    coverSource = 'STREETVIEW'
+  }
+
+  if (streetView && streetView !== auction.streetViewUrl) data.streetViewUrl = streetView
+  if (cover && !hasRealCover) {
+    data.coverImage = cover
+    data.imageSource = coverSource
+  }
+
+  await prisma.auction.update({ where: { id: auctionId }, data }).catch(() => {})
+  const updated = !!data.coverImage || !!data.streetViewUrl
+  return { updated, source: coverSource }
+}
+
+/**
+ * Passe agendado: captura imagem dos leilões sem foto real (ou nunca tentados),
+ * priorizando ativos. Sequencial + throttled para respeitar Street View e as
+ * páginas dos leiloeiros.
+ */
+export async function runAuctionImageBatch(
+  prisma: PrismaClient,
+  limit = 40,
+  deps: ImageCaptureDeps = {},
+): Promise<{ processed: number; withCover: number; withStreetView: number }> {
+  const activeStatuses = ['OPEN', 'UPCOMING', 'FIRST_ROUND', 'SECOND_ROUND']
+  // Falta capa real (nula ou só Street View) OU nunca passou pelo agente.
+  const needsImage = {
+    OR: [
+      { coverImage: null },
+      { imageSource: 'STREETVIEW', streetViewUrl: null },
+      { imageCapturedAt: null },
+    ],
+    // Anti-hammer: no máximo 5 tentativas por leilão.
+    imageCaptureAttempts: { lt: 5 },
+    status: { notIn: ['CANCELLED'] as any },
+  }
+
+  const activeLimit = Math.ceil(limit / 2)
+  const active = await prisma.auction.findMany({
+    where: { ...needsImage, status: { in: activeStatuses as any } },
+    select: { id: true },
+    orderBy: [{ imageCapturedAt: { sort: 'asc', nulls: 'first' } }, { createdAt: 'desc' }],
+    take: activeLimit,
+  })
+  const historical = await prisma.auction.findMany({
+    where: { ...needsImage, status: { notIn: [...activeStatuses, 'CANCELLED'] as any } },
+    select: { id: true },
+    orderBy: [{ imageCapturedAt: { sort: 'asc', nulls: 'first' } }, { createdAt: 'desc' }],
+    take: limit - activeLimit,
+  })
+  const pending = [...active, ...historical]
+
+  let withCover = 0
+  let withStreetView = 0
+  for (const a of pending) {
+    const r = await captureAuctionImage(prisma, a.id, deps).catch(() => ({ updated: false, source: 'NONE' as ImageSource }))
+    if (r.source === 'AUCTIONEER' || r.source === 'STREETVIEW') withCover++
+    if (r.source === 'STREETVIEW') withStreetView++
+    // Throttle leve entre leilões (respeita Street View e páginas dos leiloeiros).
+    await new Promise((res) => setTimeout(res, 120))
+  }
+  return { processed: pending.length, withCover, withStreetView }
+}

--- a/apps/api/src/services/auction-real-discount.service.ts
+++ b/apps/api/src/services/auction-real-discount.service.ts
@@ -1,0 +1,250 @@
+/**
+ * Desconto Real AE — a métrica proprietária do AgoraEncontrei (plano §8 e §30).
+ *
+ * O desconto que os leiloeiros anunciam usa a AVALIAÇÃO como referência — que
+ * costuma estar acima do mercado. Aqui recalculamos a vantagem LÍQUIDA de
+ * verdade: partimos de um valor de mercado com procedência declarada, subtraímos
+ * o lance e TODOS os custos de arrematação (comissão, ITBI, registro, escritura,
+ * advogado, desocupação, reforma) e uma margem de segurança, e mostramos a
+ * margem líquida real, o % sobre o investimento e o lance máximo recomendado
+ * para um retorno-alvo.
+ *
+ * Princípio do plano: nada de "lucro garantido". Todo número traz a origem e a
+ * confiança do valor de mercado usado.
+ */
+
+import type { PrismaClient, Prisma } from '@prisma/client'
+import { calculateAcquisitionCosts } from '../utils/brazil-costs.js'
+
+const AUCTIONEER_COMMISSION_RATE = 0.05 // comissão do leiloeiro (padrão de mercado)
+const SAFETY_MARGIN_RATE = 0.05         // margem de imprevistos sobre o investimento
+const DEFAULT_TARGET_RETURN = 0.20      // retorno-alvo padrão p/ o lance máximo
+
+export type MarketValueOrigin = 'AI_ESTIMATE' | 'REGIONAL_M2' | 'APPRAISAL_HAIRCUT'
+
+export interface RealDiscountResult {
+  currency: 'BRL'
+  minimumBid: number | null
+  appraisalValue: number | null
+  announcedDiscountPercent: number | null // desconto que a fonte anuncia (sobre a avaliação)
+  marketValue: {
+    conservative: number
+    origin: MarketValueOrigin
+    originLabel: string
+    confidence: number // 0-100
+    pricePerM2?: number | null
+    sampleSize?: number | null
+    note: string
+  } | null
+  costs: {
+    auctioneerCommission: number
+    itbi: number
+    registry: number
+    notary: number
+    lawyer: number
+    eviction: number
+    reform: number
+    safetyMargin: number
+    totalCosts: number
+  } | null
+  totalInvestment: number | null
+  netMargin: number | null        // valor de mercado conservador − investimento total
+  netMarginPercent: number | null // margem líquida sobre o investimento
+  realDiscountPercent: number | null // desconto real: 1 − (investimento / mercado)
+  maxRecommendedBid: number | null   // lance máximo p/ atingir o retorno-alvo
+  targetReturnPercent: number
+  verdict: 'STRONG' | 'MODERATE' | 'WEAK' | 'NEGATIVE' | 'INSUFFICIENT_DATA'
+  assumptions: string[]
+}
+
+function round(n: number): number {
+  return Math.round(n)
+}
+
+/** Mediana de R$/m² de leilões comparáveis na região (sinal de preço regional). */
+async function regionalPricePerM2(
+  prisma: PrismaClient,
+  auction: { city: string | null; state: string | null; propertyType: string | null },
+): Promise<{ median: number; sample: number } | null> {
+  if (!auction.city) return null
+  const baseWhere: Prisma.AuctionWhereInput = {
+    city: { equals: auction.city, mode: 'insensitive' },
+    ...(auction.state ? { state: { equals: auction.state, mode: 'insensitive' } } : {}),
+    totalArea: { gt: 0 },
+    status: { not: 'CANCELLED' },
+  }
+  // Primeiro tenta com o mesmo tipo de imóvel; se a amostra for pobre, abre p/ cidade.
+  for (const where of [
+    { ...baseWhere, propertyType: (auction.propertyType || undefined) as any },
+    baseWhere,
+  ]) {
+    const rows = await prisma.auction.findMany({
+      where,
+      select: { soldValue: true, minimumBid: true, appraisalValue: true, totalArea: true },
+      take: 400,
+    })
+    const perM2: number[] = []
+    for (const r of rows) {
+      const area = Number(r.totalArea)
+      // Preferimos avaliação (proxy de mercado) > arremate > lance mínimo.
+      const val = Number(r.appraisalValue) || Number(r.soldValue) || Number(r.minimumBid)
+      if (area > 0 && val > 0) perM2.push(val / area)
+    }
+    if (perM2.length >= 5) {
+      perM2.sort((a, b) => a - b)
+      const mid = Math.floor(perM2.length / 2)
+      const median = perM2.length % 2 ? perM2[mid] : (perM2[mid - 1] + perM2[mid]) / 2
+      return { median, sample: perM2.length }
+    }
+  }
+  return null
+}
+
+export interface RealDiscountInput {
+  city: string | null
+  state: string | null
+  propertyType: string | null
+  totalArea: number | null
+  builtArea: number | null
+  landArea: number | null
+  appraisalValue: number | null
+  minimumBid: number | null
+  marketPriceEstimate: number | null
+  occupation: string | null
+  discountPercent: number | null
+}
+
+/**
+ * Calcula o Desconto Real AE de um leilão. Escolhe o melhor valor de mercado
+ * disponível (estimativa de IA > R$/m² regional > avaliação com deságio) e
+ * declara a procedência + confiança de forma transparente.
+ */
+export async function computeRealDiscount(
+  prisma: PrismaClient,
+  auction: RealDiscountInput,
+): Promise<RealDiscountResult> {
+  const minimumBid = auction.minimumBid && auction.minimumBid > 0 ? Number(auction.minimumBid) : null
+  const appraisalValue = auction.appraisalValue && auction.appraisalValue > 0 ? Number(auction.appraisalValue) : null
+  const area = Number(auction.builtArea) || Number(auction.totalArea) || Number(auction.landArea) || 0
+  const assumptions: string[] = []
+
+  // ── Valor de mercado conservador (com procedência) ───────────────────────
+  let market: RealDiscountResult['marketValue'] = null
+  const aiEstimate = auction.marketPriceEstimate && auction.marketPriceEstimate > 0 ? Number(auction.marketPriceEstimate) : null
+
+  if (aiEstimate) {
+    market = {
+      conservative: round(aiEstimate * 0.95), // deságio conservador sobre a estimativa
+      origin: 'AI_ESTIMATE',
+      originLabel: 'Estimativa de mercado do AgoraEncontrei',
+      confidence: 70,
+      note: 'Estimativa própria com deságio conservador de 5%.',
+    }
+  } else if (area > 0) {
+    const regional = await regionalPricePerM2(prisma, auction).catch(() => null)
+    if (regional) {
+      // Deságio para chegar a um cenário conservador de venda rápida.
+      const conservative = regional.median * area * 0.9
+      const confidence = Math.min(75, 35 + regional.sample) // mais amostra → mais confiança
+      market = {
+        conservative: round(conservative),
+        origin: 'REGIONAL_M2',
+        originLabel: `R$/m² regional (${auction.city})`,
+        confidence,
+        pricePerM2: round(regional.median),
+        sampleSize: regional.sample,
+        note: `Baseado na mediana de R$ ${round(regional.median).toLocaleString('pt-BR')}/m² de ${regional.sample} imóveis comparáveis na região, com deságio conservador de 10%.`,
+      }
+      assumptions.push(`Valor de mercado estimado por R$/m² regional (${regional.sample} comparáveis).`)
+    }
+  }
+  if (!market && appraisalValue) {
+    // Último recurso: avaliação com deságio forte (avaliação tende a ser otimista).
+    market = {
+      conservative: round(appraisalValue * 0.8),
+      origin: 'APPRAISAL_HAIRCUT',
+      originLabel: 'Avaliação com deságio',
+      confidence: 30,
+      note: 'Sem comparáveis suficientes: usamos a avaliação com deságio de 20%. A avaliação pode estar acima do mercado — confiança baixa.',
+    }
+    assumptions.push('Sem comparáveis regionais suficientes — valor de mercado derivado da avaliação (confiança baixa).')
+  }
+
+  const announcedDiscountPercent = auction.discountPercent ??
+    (appraisalValue && minimumBid ? round(((appraisalValue - minimumBid) / appraisalValue) * 100) : null)
+
+  // ── Sem lance ou sem mercado → não dá para calcular a vantagem líquida ────
+  if (!minimumBid || !market) {
+    return {
+      currency: 'BRL', minimumBid, appraisalValue, announcedDiscountPercent,
+      marketValue: market, costs: null, totalInvestment: null, netMargin: null,
+      netMarginPercent: null, realDiscountPercent: null, maxRecommendedBid: null,
+      targetReturnPercent: DEFAULT_TARGET_RETURN * 100,
+      verdict: 'INSUFFICIENT_DATA',
+      assumptions: [...assumptions, 'Dados insuficientes (lance mínimo ou valor de mercado ausente) para o Desconto Real.'],
+    }
+  }
+
+  // ── Custos de arrematação ─────────────────────────────────────────────────
+  const isOccupied = auction.occupation === 'OCUPADO'
+  const needsReform = true // premissa conservadora: prevê reforma leve (10% do lance)
+  const acq = calculateAcquisitionCosts({
+    bidValue: minimumBid,
+    state: auction.state || 'SP',
+    isOccupied,
+    needsReform,
+  })
+  const auctioneerCommission = minimumBid * AUCTIONEER_COMMISSION_RATE
+  const safetyMargin = (minimumBid + acq.totalCosts + auctioneerCommission) * SAFETY_MARGIN_RATE
+  const totalCosts = acq.totalCosts + auctioneerCommission + safetyMargin
+  const totalInvestment = minimumBid + totalCosts
+
+  const netMargin = market.conservative - totalInvestment
+  const netMarginPercent = totalInvestment > 0 ? (netMargin / totalInvestment) * 100 : 0
+  const realDiscountPercent = market.conservative > 0 ? (1 - totalInvestment / market.conservative) * 100 : 0
+
+  // Lance máximo para o retorno-alvo: investimento(lance) = mercado / (1+alvo).
+  // Aproxima os custos como fração ~ (custos/lance) fixa neste ponto de operação.
+  const costRatio = totalInvestment / minimumBid // multiplicador lance → investimento
+  const maxInvestmentForTarget = market.conservative / (1 + DEFAULT_TARGET_RETURN)
+  const maxRecommendedBid = round(maxInvestmentForTarget / costRatio)
+
+  let verdict: RealDiscountResult['verdict']
+  if (netMarginPercent >= 20) verdict = 'STRONG'
+  else if (netMarginPercent >= 10) verdict = 'MODERATE'
+  else if (netMarginPercent >= 0) verdict = 'WEAK'
+  else verdict = 'NEGATIVE'
+
+  assumptions.push(
+    `Comissão do leiloeiro ${(AUCTIONEER_COMMISSION_RATE * 100).toFixed(0)}%, margem de segurança ${(SAFETY_MARGIN_RATE * 100).toFixed(0)}%.`,
+    isOccupied ? 'Imóvel ocupado — inclui custo estimado de desocupação.' : 'Imóvel considerado desocupado.',
+    'Inclui reforma leve estimada em 10% do lance (premissa conservadora).',
+  )
+
+  return {
+    currency: 'BRL',
+    minimumBid,
+    appraisalValue,
+    announcedDiscountPercent,
+    marketValue: market,
+    costs: {
+      auctioneerCommission: round(auctioneerCommission),
+      itbi: round(acq.itbi),
+      registry: round(acq.registry),
+      notary: round(acq.notary),
+      lawyer: round(acq.lawyer),
+      eviction: round(acq.eviction),
+      reform: round(acq.reform),
+      safetyMargin: round(safetyMargin),
+      totalCosts: round(totalCosts),
+    },
+    totalInvestment: round(totalInvestment),
+    netMargin: round(netMargin),
+    netMarginPercent: Math.round(netMarginPercent * 10) / 10,
+    realDiscountPercent: Math.round(realDiscountPercent * 10) / 10,
+    maxRecommendedBid,
+    targetReturnPercent: DEFAULT_TARGET_RETURN * 100,
+    verdict,
+    assumptions,
+  }
+}

--- a/apps/api/src/services/auction-report.service.ts
+++ b/apps/api/src/services/auction-report.service.ts
@@ -135,10 +135,27 @@ export async function buildAuctionReport(prisma: PrismaClient, f: AuctionReportF
 
   // pricePerM2 (usa arremate se houver, senão lance mínimo)
   const perM2: number[] = []
+  // Split leilão x mercado (plano §3): R$/m² do lance/arremate vs R$/m² da
+  // avaliação (proxy do valor de mercado). A diferença mostra o quanto o leilão
+  // está abaixo do mercado por metro quadrado.
+  const perM2Auction: number[] = []
+  const perM2Market: number[] = []
+  // Desconto "real" aproximado: desconto sobre a avaliação líquido de um custo
+  // padrão de arrematação (~18% do lance). Mostra que o desconto anunciado
+  // encolhe depois dos custos — sem prometer "lucro garantido".
+  const COST_LOAD = 0.18
+  const netDiscount: number[] = []
   for (const r of rows) {
     const val = toNum(r.soldValue) ?? toNum(r.minimumBid)
     const area = toNum(r.totalArea)
     if (val && area && area > 0) perM2.push(val / area)
+    const bid = toNum(r.minimumBid)
+    const appraisal = toNum(r.appraisalValue)
+    if (bid && area && area > 0) perM2Auction.push(bid / area)
+    if (appraisal && area && area > 0) perM2Market.push(appraisal / area)
+    if (bid && appraisal && appraisal > 0) {
+      netDiscount.push((1 - (bid * (1 + COST_LOAD)) / appraisal) * 100)
+    }
   }
 
   // recorte por bairro (top) e por tipo/status
@@ -210,6 +227,24 @@ export async function buildAuctionReport(prisma: PrismaClient, f: AuctionReportF
       discountPercent: numStats(rows.map((r) => r.discountPercent)),
       opportunityScore: numStats(rows.map((r) => r.opportunityScore)),
     },
+    // Painel regional (plano §3): indicadores estilo plataforma financeira.
+    regional: (() => {
+      const auctionM2 = numStats(perM2Auction)
+      const marketM2 = numStats(perM2Market)
+      const net = numStats(netDiscount)
+      const spreadM2 = auctionM2 && marketM2 && marketM2.median > 0
+        ? Math.round((1 - auctionM2.median / marketM2.median) * 100)
+        : null
+      return {
+        pricePerM2Auction: auctionM2,   // R$/m² pelo lance mínimo
+        pricePerM2Market: marketM2,     // R$/m² pela avaliação (proxy de mercado)
+        m2SpreadPercent: spreadM2,      // quanto o leilão está abaixo do mercado por m²
+        announcedDiscountMedian: rows.length ? numStats(rows.map((r) => r.discountPercent))?.median ?? null : null,
+        netDiscountMedian: net?.median ?? null, // desconto após custos (estimado)
+        liquidityPercent: total > 0 ? Math.round((soldCount / total) * 100) : 0,
+        occupiedPercent: total > 0 ? Math.round((occupiedCount / total) * 100) : 0,
+      }
+    })(),
     topNeighborhoods: neighborhoods,
     dataQuality,
     opportunities,

--- a/apps/api/src/services/scheduled.jobs.ts
+++ b/apps/api/src/services/scheduled.jobs.ts
@@ -829,20 +829,24 @@ export async function runScheduledJobs(app: FastifyInstance) {
     app.log.error({ err }, '[scheduled] follow-ups failed')
   }
 
-  // ── 9. Street View batch: capture facades for auctions/properties missing images ──
+  // ── 9. Agente de imagem dos leilões: foto do leiloeiro/Caixa ou fachada ────
+  // Roda a cada passe (não só 13h): a maioria dos leilões entra sem foto e o
+  // card/landing acabaria no banner padrão. O agente tenta a foto oficial e,
+  // como fallback, a fachada via Street View. Lote pequeno por rodada.
+  try {
+    const { runAuctionImageBatch } = await import('./auction-image.service.js')
+    const imgResult = await runAuctionImageBatch(app.prisma, 40)
+    if (imgResult.withCover > 0) {
+      app.log.info(`[scheduled] auction-image: ${imgResult.withCover}/${imgResult.processed} leilões com imagem (${imgResult.withStreetView} via Street View)`)
+    }
+  } catch (err) {
+    app.log.error({ err }, '[scheduled] auction-image failed')
+  }
+
+  // Street View para IMÓVEIS (carteira própria) segue no passe diário das 13h.
   if (hour === 13 && minute < 30) {
     try {
       const { batchGenerateStreetView } = await import('./streetview.service.js')
-
-      // Process auctions first (most likely to be missing images)
-      const auctionResult = await batchGenerateStreetView(app.prisma, {
-        type: 'auction', limit: 30, onlyWithCoords: false,
-      })
-      if (auctionResult.updated > 0) {
-        app.log.info(`[scheduled] streetview-batch: Updated ${auctionResult.updated}/${auctionResult.processed} auctions`)
-      }
-
-      // Then properties
       const propResult = await batchGenerateStreetView(app.prisma, {
         type: 'property', limit: 20, onlyWithCoords: true,
       })

--- a/apps/api/test/auction-image.test.ts
+++ b/apps/api/test/auction-image.test.ts
@@ -1,0 +1,59 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  deriveCaixaPhotoUrl,
+  extractImageFromHtml,
+} from '../src/services/auction-image.service.js'
+
+// ── Puros (sempre rodam, sem banco) ─────────────────────────────────────────
+
+test('deriveCaixaPhotoUrl deriva a foto oficial pelo externalId', () => {
+  assert.equal(
+    deriveCaixaPhotoUrl('CAIXA-8444401234567', null),
+    'https://venda-imoveis.caixa.gov.br/fotos-imoveis/8444401234567_1.jpg',
+  )
+})
+
+test('deriveCaixaPhotoUrl extrai o id da sourceUrl da Caixa', () => {
+  assert.equal(
+    deriveCaixaPhotoUrl(null, 'https://venda-imoveis.caixa.gov.br/sistema/detalhe-imovel.asp?hdnimovel=1444402'),
+    'https://venda-imoveis.caixa.gov.br/fotos-imoveis/1444402_1.jpg',
+  )
+})
+
+test('deriveCaixaPhotoUrl retorna undefined sem código', () => {
+  assert.equal(deriveCaixaPhotoUrl(null, null), undefined)
+  assert.equal(deriveCaixaPhotoUrl('LEILOEIRO-abc', 'https://exemplo.com/lote/1'), undefined)
+})
+
+test('extractImageFromHtml prioriza og:image e ignora logos', () => {
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.leiloeiro.com/lote/foto-123.jpg" />
+    </head><body>
+      <img src="/assets/logo.png" />
+      <img src="https://cdn.leiloeiro.com/lote/galeria-1.jpg" />
+    </body></html>`
+  assert.equal(extractImageFromHtml(html, 'https://leiloeiro.com/lote/1'), 'https://cdn.leiloeiro.com/lote/foto-123.jpg')
+})
+
+test('extractImageFromHtml cai na galeria quando og:image é institucional', () => {
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.leiloeiro.com/logo-institucional.png" />
+    </head><body>
+      <img src="/assets/sprite.png" />
+      <img src="https://cdn.leiloeiro.com/lote/galeria-1.jpg" />
+    </body></html>`
+  assert.equal(extractImageFromHtml(html, 'https://leiloeiro.com/lote/1'), 'https://cdn.leiloeiro.com/lote/galeria-1.jpg')
+})
+
+test('extractImageFromHtml resolve caminho relativo com o baseUrl', () => {
+  const html = `<img src="/media/lote/foto.jpg" />`
+  assert.equal(extractImageFromHtml(html, 'https://leiloeiro.com/lote/1'), 'https://leiloeiro.com/media/lote/foto.jpg')
+})
+
+test('extractImageFromHtml retorna undefined sem imagem útil', () => {
+  const html = `<img src="/assets/logo.png" /><img src="/icons/favicon.ico" />`
+  assert.equal(extractImageFromHtml(html), undefined)
+})

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -1112,15 +1112,6 @@ export default function LeiloesClient() {
                     data-testid="auction-card"
                     prefetch={false}
                     className="block"
-                    onClick={(e) => {
-                      // Itens do feed público da Caixa (ao vivo) não têm landing
-                      // própria — para esses, mantém o fluxo de captação. Todos os
-                      // demais abrem a página do leilão no AgoraEncontrei.
-                      if (auction.slug.startsWith('public-')) {
-                        e.preventDefault()
-                        openLeadModal(auction)
-                      }
-                    }}
                   >
                   {/* Image — Real photo > banner padrão de leilão (imagem ilustrativa) */}
                   <div className="relative h-48 bg-gray-200 overflow-hidden">
@@ -1238,6 +1229,20 @@ export default function LeiloesClient() {
                       {auction.auctioneerName && (
                         <span className="text-[10px] px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{auction.auctioneerName}</span>
                       )}
+                    </div>
+
+                    {/* CTAs: ver análise (landing) + captar interesse sem sair do card */}
+                    <div className="mt-3 flex items-center gap-2">
+                      <span className="flex-1 inline-flex items-center justify-center gap-1 rounded-lg bg-[#143A1F] px-3 py-2 text-xs font-bold text-white group-hover:bg-[#1c4d2a] transition">
+                        Ver análise <ArrowRight className="w-3.5 h-3.5" />
+                      </span>
+                      <button
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); openLeadModal(auction) }}
+                        className="inline-flex items-center justify-center gap-1 rounded-lg border border-[#C9A84C] px-3 py-2 text-xs font-bold text-[#8a6d1f] hover:bg-[#C9A84C]/10 transition"
+                        title="Tenho interesse neste imóvel"
+                      >
+                        Tenho interesse
+                      </button>
                     </div>
                   </div>
                   </Link>{/* close card link */}

--- a/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/LeiloesClient.tsx
@@ -1107,7 +1107,21 @@ export default function LeiloesClient() {
                   >
                     {compareIds.has(auction.id) ? '✓' : '⇔'}
                   </button>
-                  <div data-testid="auction-card" onClick={() => openLeadModal(auction)}>
+                  <Link
+                    href={`/leiloes/${auction.slug}`}
+                    data-testid="auction-card"
+                    prefetch={false}
+                    className="block"
+                    onClick={(e) => {
+                      // Itens do feed público da Caixa (ao vivo) não têm landing
+                      // própria — para esses, mantém o fluxo de captação. Todos os
+                      // demais abrem a página do leilão no AgoraEncontrei.
+                      if (auction.slug.startsWith('public-')) {
+                        e.preventDefault()
+                        openLeadModal(auction)
+                      }
+                    }}
+                  >
                   {/* Image — Real photo > banner padrão de leilão (imagem ilustrativa) */}
                   <div className="relative h-48 bg-gray-200 overflow-hidden">
                     <img
@@ -1226,7 +1240,7 @@ export default function LeiloesClient() {
                       )}
                     </div>
                   </div>
-                  </div>{/* close onClick wrapper */}
+                  </Link>{/* close card link */}
                 </div>
               ))}
             </div>

--- a/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
@@ -133,6 +133,17 @@ export default function LeilaoDetailClient({ auction, initialAnalysis = null }: 
                     -{discount}% de desconto
                   </div>
                 )}
+                {/* Procedência da imagem — transparência: foto do leiloeiro x
+                    fachada aproximada via Street View x banner ilustrativo. */}
+                {auction.imageSource && (
+                  <div className="absolute bottom-4 left-4 px-2.5 py-1 rounded-lg text-[11px] font-semibold bg-black/60 text-white backdrop-blur">
+                    {auction.imageSource === 'AUCTIONEER'
+                      ? '📷 Foto do leiloeiro'
+                      : auction.imageSource === 'STREETVIEW'
+                        ? '🗺️ Fachada (Street View) — aproximada'
+                        : 'Imagem ilustrativa'}
+                  </div>
+                )}
               </div>
 
               {/* Extra images */}
@@ -141,6 +152,21 @@ export default function LeilaoDetailClient({ auction, initialAnalysis = null }: 
                   {auction.images.slice(0, 6).map((img: string, i: number) => (
                     <img key={img} src={img} alt={`Foto ${i + 1}`} className="h-20 w-28 object-cover rounded cursor-pointer hover:opacity-80" />
                   ))}
+                </div>
+              )}
+
+              {/* Fachada via Street View — mostra quando temos a fachada e ela
+                  não é a própria capa (ex.: capa é foto do leiloeiro). Dá ao
+                  usuário a vista de rua do endereço informado no leilão. */}
+              {auction.streetViewUrl && auction.streetViewUrl !== auction.coverImage && (
+                <div className="p-2 border-t border-gray-100">
+                  <p className="px-1 pb-1 text-xs font-semibold text-gray-500">Fachada aproximada (Google Street View)</p>
+                  <img
+                    src={auction.streetViewUrl}
+                    alt={`Fachada aproximada de ${auction.title}`}
+                    loading="lazy"
+                    className="h-40 w-full object-cover rounded-lg"
+                  />
                 </div>
               )}
             </div>

--- a/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/[slug]/LeilaoDetailClient.tsx
@@ -44,6 +44,113 @@ function modalityLabel(modality: string): string {
   return labels[modality] || modality
 }
 
+const VERDICT_UI: Record<string, { label: string; cls: string; bar: string }> = {
+  STRONG: { label: 'Oportunidade forte', cls: 'bg-green-50 text-green-800 border-green-200', bar: 'bg-green-500' },
+  MODERATE: { label: 'Oportunidade moderada', cls: 'bg-yellow-50 text-yellow-800 border-yellow-200', bar: 'bg-yellow-500' },
+  WEAK: { label: 'Margem apertada', cls: 'bg-orange-50 text-orange-800 border-orange-200', bar: 'bg-orange-500' },
+  NEGATIVE: { label: 'Sem margem no lance atual', cls: 'bg-red-50 text-red-800 border-red-200', bar: 'bg-red-500' },
+  INSUFFICIENT_DATA: { label: 'Dados insuficientes', cls: 'bg-gray-50 text-gray-700 border-gray-200', bar: 'bg-gray-400' },
+}
+
+function RealDiscountPanel({ rd }: { rd: any }) {
+  const v = VERDICT_UI[rd.verdict] || VERDICT_UI.INSUFFICIENT_DATA
+  const fmt = (n: number | null | undefined) => formatCurrency(n)
+  const insufficient = rd.verdict === 'INSUFFICIENT_DATA' || !rd.marketValue
+
+  return (
+    <div className="bg-white rounded-xl p-6 shadow-sm border-l-4 border-[#C9A84C]">
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="w-5 h-5 text-[#C9A84C]" />
+          <h2 className="text-lg font-bold text-gray-800">Desconto Real AE — vale a pena?</h2>
+        </div>
+        <span className={`text-xs font-bold px-3 py-1 rounded-full border ${v.cls}`}>{v.label}</span>
+      </div>
+
+      {insufficient ? (
+        <p className="text-sm text-gray-500">
+          Ainda não há dados suficientes (lance mínimo ou referência de mercado) para calcular a vantagem líquida real deste imóvel.
+        </p>
+      ) : (
+        <>
+          {/* Números-chave */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+            <div className="rounded-lg bg-gray-50 p-3">
+              <p className="text-[11px] text-gray-500">Lance mínimo</p>
+              <p className="text-base font-bold text-gray-800">{fmt(rd.minimumBid)}</p>
+            </div>
+            <div className="rounded-lg bg-gray-50 p-3">
+              <p className="text-[11px] text-gray-500">Investimento total</p>
+              <p className="text-base font-bold text-gray-800">{fmt(rd.totalInvestment)}</p>
+            </div>
+            <div className="rounded-lg bg-gray-50 p-3">
+              <p className="text-[11px] text-gray-500">Valor de mercado (conservador)</p>
+              <p className="text-base font-bold text-gray-800">{fmt(rd.marketValue?.conservative)}</p>
+            </div>
+            <div className="rounded-lg bg-[#143A1F]/5 p-3">
+              <p className="text-[11px] text-gray-500">Margem líquida</p>
+              <p className={`text-base font-bold ${rd.netMargin >= 0 ? 'text-green-700' : 'text-red-600'}`}>
+                {fmt(rd.netMargin)} {rd.netMarginPercent != null && <span className="text-xs">({rd.netMarginPercent}%)</span>}
+              </p>
+            </div>
+          </div>
+
+          {/* Desconto anunciado x real */}
+          <div className="flex flex-wrap gap-4 mb-4 text-sm">
+            {rd.announcedDiscountPercent != null && (
+              <span className="text-gray-500">Desconto anunciado: <b className="text-gray-700">{rd.announcedDiscountPercent}%</b></span>
+            )}
+            {rd.realDiscountPercent != null && (
+              <span className="text-gray-500">Desconto real AE: <b className="text-[#143A1F]">{rd.realDiscountPercent}%</b></span>
+            )}
+            {rd.maxRecommendedBid != null && (
+              <span className="text-gray-500">Lance máx. p/ {rd.targetReturnPercent}%: <b className="text-[#143A1F]">{fmt(rd.maxRecommendedBid)}</b></span>
+            )}
+          </div>
+
+          {/* Procedência do valor de mercado (transparência) */}
+          {rd.marketValue && (
+            <div className="rounded-lg border border-gray-100 bg-gray-50 p-3 mb-4">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <p className="text-xs font-semibold text-gray-600">Origem do valor de mercado: {rd.marketValue.originLabel}</p>
+                <span className="text-[11px] text-gray-500">confiança {rd.marketValue.confidence}%</span>
+              </div>
+              <div className="h-1.5 w-full rounded-full bg-gray-200 overflow-hidden mb-2">
+                <div className={`h-full ${v.bar}`} style={{ width: `${rd.marketValue.confidence}%` }} />
+              </div>
+              <p className="text-[11px] leading-4 text-gray-500">{rd.marketValue.note}</p>
+            </div>
+          )}
+
+          {/* Custos considerados */}
+          {rd.costs && (
+            <details className="text-sm">
+              <summary className="cursor-pointer text-xs font-semibold text-gray-600 mb-2">Ver custos de arrematação considerados</summary>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2 text-xs text-gray-600">
+                <span>Comissão leiloeiro: <b>{fmt(rd.costs.auctioneerCommission)}</b></span>
+                <span>ITBI: <b>{fmt(rd.costs.itbi)}</b></span>
+                <span>Registro: <b>{fmt(rd.costs.registry)}</b></span>
+                <span>Escritura: <b>{fmt(rd.costs.notary)}</b></span>
+                <span>Advogado: <b>{fmt(rd.costs.lawyer)}</b></span>
+                {rd.costs.eviction > 0 && <span>Desocupação: <b>{fmt(rd.costs.eviction)}</b></span>}
+                <span>Reforma: <b>{fmt(rd.costs.reform)}</b></span>
+                <span>Margem segurança: <b>{fmt(rd.costs.safetyMargin)}</b></span>
+              </div>
+            </details>
+          )}
+
+          {/* Premissas — evita "lucro garantido" */}
+          {rd.assumptions?.length > 0 && (
+            <p className="mt-3 text-[11px] leading-4 text-gray-400">
+              Estimativa com premissas conservadoras: {rd.assumptions.join(' ')} Não substitui a análise do edital, da matrícula e uma visita técnica.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
 export default function LeilaoDetailClient({ auction, initialAnalysis = null }: { auction: any; initialAnalysis?: any }) {
   const [analysis, setAnalysis] = useState<any>(initialAnalysis)
 
@@ -170,6 +277,9 @@ export default function LeilaoDetailClient({ auction, initialAnalysis = null }: 
                 </div>
               )}
             </div>
+
+            {/* Desconto Real AE — vale a pena? (vantagem líquida real) */}
+            {auction.realDiscount && <RealDiscountPanel rd={auction.realDiscount} />}
 
             {/* Title & Location */}
             <div className="bg-white rounded-xl p-6 shadow-sm">

--- a/apps/web/src/app/(public)/leiloes/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/leiloes/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { ArrowRight, Building2, Calculator, MapPin, ShieldCheck, TrendingUp } from 'lucide-react'
 import LeilaoDetailClient from './LeilaoDetailClient'
 
@@ -336,6 +337,12 @@ export default async function LeilaoPage(props: Props) {
     getAuction(params.slug),
     getAuctionAnalysis(params.slug),
   ])
+
+  // Item do feed público (public-{id}) resolvido para o leilão canônico:
+  // redireciona para o slug real para não duplicar conteúdo / canonical errado.
+  if (auction?.slug && auction.slug !== params.slug) {
+    redirect(`/leiloes/${auction.slug}`)
+  }
 
   if (!auction) {
     return (

--- a/apps/web/src/app/(public)/leiloes/relatorios/RelatoriosClient.tsx
+++ b/apps/web/src/app/(public)/leiloes/relatorios/RelatoriosClient.tsx
@@ -23,6 +23,15 @@ interface Report {
     appraisalValue: NumStats | null; minimumBid: NumStats | null; soldValue: NumStats | null
     pricePerM2: NumStats | null; discountPercent: NumStats | null; opportunityScore: NumStats | null
   }
+  regional?: {
+    pricePerM2Auction: NumStats | null
+    pricePerM2Market: NumStats | null
+    m2SpreadPercent: number | null
+    announcedDiscountMedian: number | null
+    netDiscountMedian: number | null
+    liquidityPercent: number
+    occupiedPercent: number
+  }
   topNeighborhoods?: { neighborhood: string; count: number; avgValue: number | null }[]
   dataQuality?: { withAppraisal: number; withMinimumBid: number; withSoldValue: number; withArea: number; withRegistry: number; withDocuments: number; withOccupation: number }
   opportunities?: { slug: string; title: string; city?: string; state?: string; neighborhood?: string; status: string; source: string; coverImage?: string; appraisalValue?: number; minimumBid?: number; discountPercent?: number; opportunityScore?: number; occupation?: string; auctionDate?: string }[]
@@ -221,6 +230,47 @@ export default function RelatoriosClient() {
               <div className="flex gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-950">
                 <AlertTriangle className="h-5 w-5 shrink-0 text-blue-600" />
                 <div><b>Nenhum valor de arremate foi confirmado nesta amostra.</b><br />Os valores abaixo representam avaliação e lance mínimo anunciados; não devem ser interpretados como preço efetivo de venda.</div>
+              </div>
+            )}
+
+            {/* Painel regional (plano §3): leilão x mercado, liquidez, desconto real */}
+            {report.regional && (
+              <div className="bg-white rounded-xl p-6 shadow-sm">
+                <h3 className="mb-1 flex items-center gap-2 text-lg font-bold text-gray-800"><TrendingDown className="h-5 w-5 text-[#C9A84C]" /> Leilão x mercado na região</h3>
+                <p className="mb-4 text-sm text-gray-500">O desconto anunciado usa a avaliação como base. Aqui comparamos o preço por m² do leilão com o de mercado e mostramos o desconto que sobra depois dos custos.</p>
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                  <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+                    <div className="text-xs text-gray-500">R$/m² em leilão</div>
+                    <div className="text-xl font-bold text-[#143A1F]">{report.regional.pricePerM2Auction ? fmt(report.regional.pricePerM2Auction.median) : '—'}</div>
+                    <div className="text-[11px] text-gray-400">mediana pelo lance mínimo</div>
+                  </div>
+                  <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+                    <div className="text-xs text-gray-500">R$/m² de mercado</div>
+                    <div className="text-xl font-bold text-gray-700">{report.regional.pricePerM2Market ? fmt(report.regional.pricePerM2Market.median) : '—'}</div>
+                    <div className="text-[11px] text-gray-400">mediana pela avaliação</div>
+                  </div>
+                  <div className="rounded-lg border border-green-100 bg-green-50 p-4">
+                    <div className="text-xs text-gray-500">Abaixo do mercado por m²</div>
+                    <div className="text-xl font-bold text-green-700">{report.regional.m2SpreadPercent != null ? `${report.regional.m2SpreadPercent}%` : '—'}</div>
+                    <div className="text-[11px] text-gray-400">leilão vs mercado</div>
+                  </div>
+                  <div className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+                    <div className="text-xs text-gray-500">Desconto após custos</div>
+                    <div className="text-xl font-bold text-amber-700">{report.regional.netDiscountMedian != null ? `${Math.round(report.regional.netDiscountMedian)}%` : '—'}</div>
+                    <div className="text-[11px] text-gray-400">anunciado: {report.regional.announcedDiscountMedian != null ? `${Math.round(report.regional.announcedDiscountMedian)}%` : '—'}</div>
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  <div className="rounded-lg border border-gray-100 p-3">
+                    <div className="mb-1 flex justify-between text-sm"><span className="text-gray-600">Liquidez (arrematados)</span><b>{report.regional.liquidityPercent}%</b></div>
+                    <div className="h-2 overflow-hidden rounded-full bg-gray-100"><div className="h-full rounded-full bg-teal-500" style={{ width: `${report.regional.liquidityPercent}%` }} /></div>
+                  </div>
+                  <div className="rounded-lg border border-gray-100 p-3">
+                    <div className="mb-1 flex justify-between text-sm"><span className="text-gray-600">Imóveis ocupados</span><b>{report.regional.occupiedPercent}%</b></div>
+                    <div className="h-2 overflow-hidden rounded-full bg-gray-100"><div className="h-full rounded-full bg-red-400" style={{ width: `${report.regional.occupiedPercent}%` }} /></div>
+                  </div>
+                </div>
+                <p className="mt-3 text-[11px] leading-4 text-gray-400">Estimativas: o R$/m² de mercado usa a avaliação como proxy (pode estar acima do praticado) e o desconto após custos aplica uma carga padrão de ~18% sobre o lance. Não substitui a análise de comparáveis reais e do edital.</p>
               </div>
             )}
 

--- a/packages/database/prisma/migrations/20260715140000_auction_image_capture/migration.sql
+++ b/packages/database/prisma/migrations/20260715140000_auction_image_capture/migration.sql
@@ -1,0 +1,7 @@
+-- Agente de captura de imagem dos leilões: guarda a fachada via Street View e a
+-- procedência da coverImage (leiloeiro x Street View x banner padrão), para a
+-- página do leilão exibir a foto real e sinalizar a confiabilidade da imagem.
+ALTER TABLE "auctions" ADD COLUMN IF NOT EXISTS "streetViewUrl" TEXT;
+ALTER TABLE "auctions" ADD COLUMN IF NOT EXISTS "imageSource" TEXT;
+ALTER TABLE "auctions" ADD COLUMN IF NOT EXISTS "imageCapturedAt" TIMESTAMP(3);
+ALTER TABLE "auctions" ADD COLUMN IF NOT EXISTS "imageCaptureAttempts" INTEGER NOT NULL DEFAULT 0;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2369,6 +2369,10 @@ model Auction {
   coverImage          String?
   images              String[]
   documentsUrls       String[]        // Links para editais, laudos
+  streetViewUrl       String?         // Fachada via Google Street View (fallback quando não há foto do leiloeiro)
+  imageSource         String?         // Origem da coverImage: AUCTIONEER | STREETVIEW | DEFAULT (transparência/confiabilidade)
+  imageCapturedAt     DateTime?       // Última tentativa do agente de captura de imagem
+  imageCaptureAttempts Int            @default(0) // Tentativas (limite anti-hammer)
 
   // Score de oportunidade (calculado pela IA)
   opportunityScore    Int?            // 0-100


### PR DESCRIPTION
## Resumo

Dá sequência ao plano de inteligência de leilões (sobre o trabalho do Codex já em `main`), resolve o clique que redirecionava ao leiloeiro e adiciona o agente de captura de imagem.

## Mudanças

### 1. Fim do redirect ao leiloeiro no clique
- O card em `/leiloes` deixa de abrir o modal que levava ao site do leiloeiro — agora o card inteiro é um link para a landing `/leiloes/[slug]`.
- Itens do feed público da Caixa (`public-{id}`) são resolvidos para o leilão canônico pelo `externalId` no `GET /auctions/:slug`; a landing redireciona (308) para o slug real, preservando o canonical.
- A captação de lead ("Tenho interesse") passa a ser um botão explícito no card — o fluxo de assessoria é mantido sem sequestrar o clique.

### 2. Agente automático de captura de imagem (`auction-image.service.ts`)
- Foto oficial do leiloeiro: Caixa via código do imóvel; demais leiloeiros SSR via `og:image`/galeria da página de detalhe.
- Fallback de fachada via Google Street View a partir do endereço/coords.
- Grava `coverImage`, `streetViewUrl` e a procedência (`imageSource`); roda no backfill de boot e a cada passe agendado.
- A página do leilão exibe o selo de procedência e a fachada Street View como camada extra.

### 3. Desconto Real AE (`auction-real-discount.service.ts`)
- Vantagem líquida real: valor de mercado conservador (com origem + confiança declaradas) − lance − custos completos (comissão, ITBI, registro, escritura, advogado, desocupação, reforma) − margem de segurança.
- Margem líquida, desconto real e lance máximo recomendado para o retorno-alvo.
- Exposto em `GET /auctions/:slug` (`realDiscount`) e renderizado como painel "vale a pena?" na landing.

### 4. Dashboard regional na `/leiloes/relatorios`
- R$/m² em leilão x R$/m² de mercado e o spread; desconto anunciado x desconto após custos; liquidez e % de imóveis ocupados.
- `buildAuctionReport` devolve o bloco `regional` (retrocompatível, também consumido pelo Tomás).

## Banco de dados
- `Auction`: novos campos `streetViewUrl`, `imageSource`, `imageCapturedAt`, `imageCaptureAttempts` + migration idempotente (`ADD COLUMN IF NOT EXISTS`).

## Validação
- Typecheck API e web: 0 erros.
- Testes da API: 122/122 passam + 7 novos testes das funções puras do agente de imagem.

## Observações
- Todos os números da landing/relatório trazem premissas e procedência declaradas — sem promessa de "lucro garantido".
- Próximas fases sugeridas: comparador de mercado real (§6/§7), Nota AE 0–100 (§11), análise documental por IA (§12), páginas regionais SEO (§14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJURiwDaXT2PDQvVpDTAvV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJURiwDaXT2PDQvVpDTAvV)_