### PR TITLE
hotfix(api): corrige HTTP 500 em todas as páginas de leilão (coluna imageSource ausente)

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -281,6 +281,12 @@ async function runMigrations(prisma: any) {
     `CREATE INDEX IF NOT EXISTS auctions_discount_idx ON auctions("discountPercent")`,
     `CREATE INDEX IF NOT EXISTS auctions_created_idx ON auctions("createdAt" DESC)`,
     `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "streetViewUrl" TEXT`,
+    // ── Agente de captura de imagem (origin: 20260715140000_auction_image_capture)
+    //    Sem estes ALTERs o findUnique do Prisma seleciona colunas inexistentes e
+    //    TODA página de leilão responde 500 (P2022). Idempotente.
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "imageSource" TEXT`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "imageCapturedAt" TIMESTAMPTZ`,
+    `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS "imageCaptureAttempts" INTEGER NOT NULL DEFAULT 0`,
     // ── Reconciliação: colunas presentes no schema Prisma mas ausentes do
     //    CREATE TABLE acima. O scraper já escreve algumas destas (registryNumber,
     //    registryOffice, debtorName, documentsUrls, features) — sem estes ALTERs


### PR DESCRIPTION
## 🚨 Hotfix de produção

Após o merge do #310, **todas as páginas de leilão (`/leiloes/[slug]`) passaram a responder HTTP 500**:

```
Invalid `prisma.auction.findUnique()` invocation:
The column `auctions.imageSource` does not exist in the current database.  (P2022)
```

### Causa
A produção mantém o schema por um **`runMigrations()` idempotente em runtime** (`ADD COLUMN IF NOT EXISTS ...`), e **não** por `prisma migrate deploy` (ver Dockerfile). As novas colunas do agente de imagem (`imageSource`, `imageCapturedAt`, `imageCaptureAttempts`) foram adicionadas ao schema Prisma e ao arquivo de migration, mas **não** ao `runMigrations()`. Com o client novo, o `findUnique` (que sem `select` traz todas as colunas escalares) passou a selecionar `imageSource`, que não existe no banco → 500 em toda página de leilão.

### Correção
Adiciona os `ALTER TABLE auctions ADD COLUMN IF NOT EXISTS` no bloco de `auctions` do `runMigrations()` (o `streetViewUrl` já estava lá). São idempotentes e ficam no topo do array, aplicando cedo dentro da janela de 20s do boot. No próximo deploy as colunas são criadas e as páginas voltam a responder 200.

### Diff
O único conteúdo novo em relação à `main` é o commit do hotfix em `apps/api/src/server.ts` — o restante do diff é o do #310, já mesclado (o git reconhece como conteúdo idêntico).

### Observação de processo
Toda mudança de schema neste projeto precisa de uma entrada correspondente no `runMigrations()` — a migration Prisma sozinha não é aplicada em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJURiwDaXT2PDQvVpDTAvV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJURiwDaXT2PDQvVpDTAvV)_