### PR TITLE
fix(ci): gera Prisma Client no seo-tests (corrige 7 testes de leilão que quebravam no import)

### DIFF
--- a/.github/workflows/seo-tests.yml
+++ b/.github/workflows/seo-tests.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      # Os testes de integração da API importam { PrismaClient } de '@prisma/client'.
+      # Sem `prisma generate`, o pacote não exporta PrismaClient e o import ESM
+      # falha na carga do módulo (SyntaxError), quebrando os testes ANTES do skip.
+      # (Os testes de banco pulam sem TEST_DATABASE_URL; só precisam do client gerado.)
+      - name: Prisma generate
+        run: pnpm db:generate
+
       # Os testes da API importam @agoraencontrei/tomas-knowledge pelo dist/
       # (gitignored), então o pacote precisa ser BUILDADO antes — senão os testes
       # do Tomás quebram com ERR_MODULE_NOT_FOUND.


### PR DESCRIPTION
## Problema

Após o merge, o workflow **SEO Pipeline Tests** ficou vermelho na `main`: **7 testes falhando** — exatamente os 7 arquivos de teste de integração de leilão:

```
not ok - test/auction-archive.test.ts
not ok - test/auction-detail-enrichment.test.ts
not ok - test/auction-identity.test.ts
not ok - test/auction-outcome.test.ts
not ok - test/auction-report.test.ts
not ok - test/auction-snapshot-lifecycle.test.ts
not ok - test/mega-scraper.test.ts
```

**Causa raiz:**
```
SyntaxError: The requested module '@prisma/client' does not provide an export named 'PrismaClient'
  import { PrismaClient } from '@prisma/client'
```

O `seo-tests.yml` roda a suíte da API (`pnpm --filter api test`) mas **não** roda `prisma generate` (diferente do `build-desktop.yml`, que roda). Sem gerar o client, `@prisma/client` não exporta `PrismaClient`, e o **import ESM estático** (no topo dos testes de integração e na cadeia `base-scraper`) falha na **carga do módulo** — antes do `skip` poder agir. Os outros ~119 testes passam porque são unitários puros que não importam `PrismaClient`; os testes de leilão são os primeiros a importá-lo.

Os testes de banco já pulam sozinhos sem `TEST_DATABASE_URL` (o seo-tests não sobe Postgres) — eles só precisam que o client esteja **gerado** para o import resolver.

## Fix

Um passo **"Prisma generate"** (`pnpm db:generate`) após o install, espelhando o `build-desktop.yml` e o padrão de "preparar deps" que o próprio workflow já usa (build do tomas-knowledge).

## Verificação

Suíte da API em **modo-CI** (client gerado, tomas-knowledge buildado, **sem** `TEST_DATABASE_URL`), contra o estado atual da `main`:

```
# tests 136
# pass 129
# fail 0
# skipped 7   ← os 7 testes de banco de leilão pulam corretamente
```

Só toca `.github/workflows/seo-tests.yml` (1 passo). Não altera código de produção nem os testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JG1LJ7JvTabaeKJNHvQCoH)_