### PR TITLE
Site da Lemos: fallback de imagem quebrada nos cards de imóvel

### DIFF
--- a/apps/web/src/app/parceiro/[slug]/imoveis/[propertySlug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/imoveis/[propertySlug]/page.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link'
 import { resolveTheme } from '@/lib/site-factory/theme-registry'
 import TomasWidget from '@/components/tomas/TomasWidget'
 import { PartnerChatWidget } from '@/components/partner/PartnerChatWidget'
+import PropertyImage from '@/components/partner/PropertyImage'
 
 // Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
 export const dynamic = 'force-dynamic'
@@ -198,13 +199,22 @@ export default async function TenantPropertyPage({
             <div className={`${theme.card} border rounded-2xl overflow-hidden`}>
               {gallery.length > 0 ? (
                 <>
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={gallery[0]} alt={property.title} className="w-full h-[280px] sm:h-[420px] object-cover" />
+                  <PropertyImage
+                    src={gallery[0]}
+                    alt={property.title}
+                    className="w-full h-[280px] sm:h-[420px] object-cover"
+                    fallbackStyle={{ background: `linear-gradient(135deg, ${accentColor}22, ${accentColor}0a)` }}
+                  />
                   {gallery.length > 1 && (
                     <div className="grid grid-cols-4 gap-1 p-1">
                       {gallery.slice(1, 9).map((img, i) => (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img key={i} src={img} alt={`${property.title} ${i + 2}`} className="w-full h-20 sm:h-24 object-cover rounded" />
+                        <PropertyImage
+                          key={i}
+                          src={img}
+                          alt={`${property.title} ${i + 2}`}
+                          className="w-full h-20 sm:h-24 object-cover rounded"
+                          fallbackStyle={{ background: `linear-gradient(135deg, ${accentColor}22, ${accentColor}0a)` }}
+                        />
                       ))}
                     </div>
                   )}

--- a/apps/web/src/app/parceiro/[slug]/imoveis/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/imoveis/page.tsx
@@ -10,6 +10,7 @@ import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { resolveTheme } from '@/lib/site-factory/theme-registry'
 import { MapSearch } from '@/app/(public)/imoveis/MapSearch'
+import PropertyImage from '@/components/partner/PropertyImage'
 
 // Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
 export const dynamic = 'force-dynamic'
@@ -219,14 +220,12 @@ export default async function TenantCatalogPage({
                   className={`${theme.card} ${theme.cardHover} border rounded-xl overflow-hidden transition-all duration-300 block`}
                 >
                   <div className="h-48 relative overflow-hidden">
-                    {property.coverImage || property.images?.[0] ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={property.coverImage || property.images[0]} alt={property.title} className="w-full h-full object-cover" />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center" style={{ background: `linear-gradient(135deg, ${accentColor}33, ${accentColor}11)` }}>
-                        <span className="text-4xl opacity-20">🏠</span>
-                      </div>
-                    )}
+                    <PropertyImage
+                      src={property.coverImage || property.images?.[0]}
+                      alt={property.title}
+                      className="w-full h-full object-cover"
+                      fallbackStyle={{ background: `linear-gradient(135deg, ${accentColor}33, ${accentColor}11)` }}
+                    />
                     {property.isPremium && <span className="absolute top-2 left-2 rounded-full px-2 py-0.5 text-[10px] font-bold text-white" style={{ backgroundColor: '#e11d48' }}>🌟 Super Destaque</span>}
                     {property.isFeatured && !property.isPremium && <span className="absolute top-2 left-2 rounded-full px-2 py-0.5 text-[10px] font-bold text-white" style={{ backgroundColor: accentColor }}>⭐ Destaque</span>}
                     <span className="absolute top-2 right-2 rounded-full px-2 py-0.5 text-[10px] font-semibold" style={{ backgroundColor: `${accentColor}22`, color: accentColor, backdropFilter: 'blur(4px)' }}>

--- a/apps/web/src/app/parceiro/[slug]/page.tsx
+++ b/apps/web/src/app/parceiro/[slug]/page.tsx
@@ -11,6 +11,7 @@ import type { Metadata } from 'next'
 import { resolveTheme, type ThemeConfig } from '@/lib/site-factory/theme-registry'
 import TomasWidget from '@/components/tomas/TomasWidget'
 import { PartnerChatWidget } from '@/components/partner/PartnerChatWidget'
+import PropertyImage from '@/components/partner/PropertyImage'
 
 // Render ao vivo: evita 404 preso no cache ISR/CDN quando a API tem um blip.
 export const dynamic = 'force-dynamic'
@@ -509,20 +510,12 @@ export default async function TenantPage({
                 >
                   {/* Imagem */}
                   <div className="h-48 relative overflow-hidden">
-                    {property.coverImage || (property.images && property.images.length > 0) ? (
-                      <img
-                        src={property.coverImage || property.images[0]}
-                        alt={property.title}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <div
-                        className="w-full h-full flex items-center justify-center"
-                        style={{ background: `linear-gradient(135deg, ${accentColor}33, ${accentColor}11)` }}
-                      >
-                        <span className="text-4xl opacity-20">🏠</span>
-                      </div>
-                    )}
+                    <PropertyImage
+                      src={property.coverImage || property.images?.[0]}
+                      alt={property.title}
+                      className="w-full h-full object-cover"
+                      fallbackStyle={{ background: `linear-gradient(135deg, ${accentColor}33, ${accentColor}11)` }}
+                    />
                     {/* Badge de destaque */}
                     <PropertyBadge property={property} theme={theme} accentColor={accentColor} />
                     {/* Badge de tipo */}

--- a/apps/web/src/components/partner/PropertyImage.tsx
+++ b/apps/web/src/components/partner/PropertyImage.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+interface PropertyImageProps {
+  src?: string | null
+  alt: string
+  /** Classes aplicadas tanto na <img> quanto no fallback (ex.: "w-full h-full object-cover"). */
+  className?: string
+  /** Gradiente/estilo do fallback. Default: cinza neutro. */
+  fallbackStyle?: React.CSSProperties
+}
+
+/**
+ * Imagem de imóvel resiliente: se a URL de capa estiver quebrada (404, host morto,
+ * import legado com link inválido), troca por um placeholder premium em vez de
+ * mostrar o ícone de imagem quebrada / texto alternativo. Client component só por
+ * causa do onError — o resto do card continua sendo server-rendered.
+ */
+export default function PropertyImage({ src, alt, className = '', fallbackStyle }: PropertyImageProps) {
+  const [failed, setFailed] = useState(false)
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  // A <img> renderizada no servidor pode ter falhado (404) ANTES da hidratação —
+  // nesse caso o evento nativo `error` já disparou e o onError do React nunca roda.
+  // No mount, detectamos a imagem já quebrada (complete + naturalWidth 0) e trocamos.
+  useEffect(() => {
+    const img = imgRef.current
+    if (img && img.complete && img.naturalWidth === 0) setFailed(true)
+  }, [src])
+
+  if (!src || failed) {
+    return (
+      <div
+        className={`${className} flex items-center justify-center`}
+        style={fallbackStyle ?? { background: 'linear-gradient(135deg, #f3f4f6, #e5e7eb)' }}
+        aria-label={alt}
+        role="img"
+      >
+        <span className="text-4xl opacity-25 select-none">🏡</span>
+      </div>
+    )
+  }
+
+  return (
+    <img
+      ref={imgRef}
+      src={src}
+      alt={alt}
+      className={className}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  )
+}


### PR DESCRIPTION
Na conferência do catálogo, vários cards mostravam **texto no lugar da foto** — imóveis importados do sistema legado (Univen) têm URL de capa inválida (404), e o `<img>` quebrado deixava o texto alternativo vazar por cima do conteúdo.

## O que muda
- **Novo componente client `PropertyImage`** (`components/partner/`): quando a imagem falha, troca por um **placeholder premium** (🏡 sobre o gradiente do tema) em vez do ícone de imagem quebrada.
- **Detecta falha de dois jeitos**: `onError` **e** no mount via `img.complete && img.naturalWidth === 0`. Esse segundo caminho é essencial — imagens que dão 404 **antes da hidratação** já dispararam o evento nativo `error`, então o `onError` do React nunca rodaria (foi o que peguei na 1ª tentativa, o fallback não aparecia).
- Aplicado nos **cards da home** do parceiro, no **grid do catálogo** e na **galeria da página de detalhe**.

## Verificação
`pnpm --filter web build` ✅ · com **todas** as imagens forçadas a falhar (route abort no Playwright), os cards renderizam o placeholder limpo em vez do texto alternativo (screenshot antes/depois).

Coordenação mantida: mexe só no site do parceiro (`parceiro/[slug]/**` + 1 componente novo), nada da malha SEO/ranking da Fase 4/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzNPP9ZFTixDkZ71DVXzBZ)_